### PR TITLE
Fix adding 1 day when picking dates

### DIFF
--- a/src/components/Ui/Calendar.vue
+++ b/src/components/Ui/Calendar.vue
@@ -90,7 +90,7 @@ export default {
   },
   methods: {
     formatDate(year, month, day) {
-      return new Date(year, month, day + 1).toISOString().split('T')[0];
+      return new Date(year, month, day).toISOString().split('T')[0];
     },
     toggleDay(year, month, day) {
       this.input = this.formatDate(year, month, day);


### PR DESCRIPTION
Fixes #120  .

Changes proposed in this pull request:

remove + 1 from here:

```
 formatDate(year, month, day) {
      return new Date(year, month, day + 1).toISOString().split('T')[0];
    },
```