### PR TITLE
Remove timezone delta affecting calendar dates

### DIFF
--- a/src/components/Ui/Calendar.vue
+++ b/src/components/Ui/Calendar.vue
@@ -90,7 +90,9 @@ export default {
   },
   methods: {
     formatDate(year, month, day) {
-      return new Date(year, month, day + 1).toISOString().split('T')[0];
+      const formattedDate = new Date(year, month, day);
+      formattedDate.setUTCHours(0,0,0,0);
+      return formattedDate.toISOString().split('T')[0];
     },
     toggleDay(year, month, day) {
       this.input = this.formatDate(year, month, day);


### PR DESCRIPTION
Fixes #120.

Changes proposed in this pull request:
- Fixes +1 day addition to selecting dates in the Calendar widget, which was being caused due by handling the initial local timezone as ISO 
