### PR TITLE
Add xDai network support for Gnosis Impact plugin

### DIFF
--- a/src/components/Plugin/Gnosis/Config.vue
+++ b/src/components/Plugin/Gnosis/Config.vue
@@ -7,6 +7,17 @@
       </UiButton>
       <div v-else-if="!preview">
         <UiButton class="width-full mb-2">
+          <select
+            v-model="input.network"
+            class="input width-full text-center"
+            placeholder="Select network"
+            required
+          >
+            <option value="1" selected="selected">Mainnet</option>
+            <option value="100">xDai</option>
+          </select>
+        </UiButton>
+        <UiButton class="width-full mb-2">
           <input
             v-model="input.conditionId"
             class="input width-full text-center"
@@ -39,7 +50,6 @@
       <PluginGnosisCustomBlock
         :proposalConfig="input"
         :choices="getChoices()"
-        :network="network"
       />
     </div>
     <UiButton

--- a/src/components/Plugin/Gnosis/Config.vue
+++ b/src/components/Plugin/Gnosis/Config.vue
@@ -13,7 +13,7 @@
             placeholder="Select network"
             required
           >
-            <option value="1" selected="selected">Mainnet</option>
+            <option value="1" selected>Mainnet</option>
             <option value="100">xDai</option>
           </select>
         </UiButton>
@@ -103,6 +103,7 @@ export default {
     addAction() {
       if (!this.input) this.input = {};
       this.input = {
+        network: '1',
         conditionId: '',
         baseTokenAddress: '',
         quoteCurrencyAddress: ''

--- a/src/components/Plugin/Gnosis/CustomBlock.vue
+++ b/src/components/Plugin/Gnosis/CustomBlock.vue
@@ -96,13 +96,14 @@ export default {
   },
   async created() {
     this.loading = true;
+    const provider = getProvider(this.proposalConfig.network);
     this.baseToken = await this.plugin.getTokenInfo(
-      getProvider(this.proposalConfig.network),
+      provider,
       this.proposalConfig.baseTokenAddress
     );
     this.baseTokenUrl = this.getLogoUrl(this.baseToken.checksumAddress);
     this.quoteToken = await this.plugin.getTokenInfo(
-      getProvider(this.proposalConfig.network),
+      provider,
       this.proposalConfig.quoteCurrencyAddress
     );
     const conditionQuery = await this.plugin.getOmenCondition(

--- a/src/components/Plugin/Gnosis/CustomBlock.vue
+++ b/src/components/Plugin/Gnosis/CustomBlock.vue
@@ -78,7 +78,7 @@ import Plugin from '@snapshot-labs/snapshot.js/src/plugins/gnosis';
 import getProvider from '@snapshot-labs/snapshot.js/src/utils/provider';
 
 export default {
-  props: ['proposalConfig', 'choices', 'network'],
+  props: ['proposalConfig', 'choices'],
   data() {
     return {
       loading: false,
@@ -97,16 +97,16 @@ export default {
   async created() {
     this.loading = true;
     this.baseToken = await this.plugin.getTokenInfo(
-      getProvider(this.network),
+      getProvider(this.proposalConfig.network),
       this.proposalConfig.baseTokenAddress
     );
     this.baseTokenUrl = this.getLogoUrl(this.baseToken.checksumAddress);
     this.quoteToken = await this.plugin.getTokenInfo(
-      getProvider(this.network),
+      getProvider(this.proposalConfig.network),
       this.proposalConfig.quoteCurrencyAddress
     );
     const conditionQuery = await this.plugin.getOmenCondition(
-      this.network,
+      this.proposalConfig.network,
       this.proposalConfig.conditionId
     );
     this.baseProductMarketMaker = conditionQuery.condition.fixedProductMarketMakers.find(
@@ -117,7 +117,7 @@ export default {
     );
 
     const tokenPairQuery = await this.plugin.getUniswapPair(
-      this.network,
+      this.proposalConfig.network,
       this.proposalConfig.quoteCurrencyAddress,
       this.proposalConfig.baseTokenAddress
     );
@@ -140,6 +140,9 @@ export default {
       return `https://gnosis-safe-token-logos.s3.amazonaws.com/${checksumAddress}.png`;
     },
     getMarketUrl(marketIndex) {
+      if (this.proposalConfig.network === "100") {
+        return `https://xdai.omen.eth.link/#/${marketIndex.id}`;
+      }
       return `https://omen.eth.link/#/${marketIndex.id}`;
     },
     getTokenPrice(outcomeIndex) {

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -171,7 +171,6 @@
         v-if="payload.metadata.plugins?.gnosis?.baseTokenAddress"
         :proposalConfig="payload.metadata.plugins.gnosis"
         :choices="payload.choices"
-        :network="space.network"
       />
     </template>
   </Layout>


### PR DESCRIPTION
Add network on the Gnosis Impact plugin form to select from which markets would you like to base your proposal. In case you select the network xDai, the Omen markets will come from the xDai network.

- Add default value to `input.network` as Mainnet.
