### PR TITLE
Move filter state outside setup to make it persistent 

### DIFF
--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -79,7 +79,7 @@ import { scrollEndMonitor } from '@/helpers/utils';
 import { useInfiniteLoader } from '@/composables/useInfiniteLoader';
 import { subgraphRequest } from '@snapshot-labs/snapshot.js/src/utils';
 
-// Persistant filter state
+// Persistent filter state
 const filterBy = ref('all');
 
 export default {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -79,6 +79,9 @@ import { scrollEndMonitor } from '@/helpers/utils';
 import { useInfiniteLoader } from '@/composables/useInfiniteLoader';
 import { subgraphRequest } from '@snapshot-labs/snapshot.js/src/utils';
 
+// Persistant filter state
+const filterBy = ref('all');
+
 export default {
   setup() {
     const store = useStore();
@@ -92,7 +95,6 @@ export default {
 
     const loading = ref(false);
     const proposals = ref([]);
-    const filterBy = ref('all');
 
     // Infinite scroll with pagination
     const {


### PR DESCRIPTION
Stops filter from resetting to `all` on route change.