### PR TITLE
Use composable filters instead of helper filters

### DIFF
--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -79,7 +79,7 @@ import { scrollEndMonitor } from '@/helpers/utils';
 import { useInfiniteLoader } from '@/composables/useInfiniteLoader';
 import { subgraphRequest } from '@snapshot-labs/snapshot.js/src/utils';
 
-// Persistant filter state
+// Persistent filter state
 const filterBy = ref('all');
 
 export default {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -79,6 +79,9 @@ import { scrollEndMonitor } from '@/helpers/utils';
 import { useInfiniteLoader } from '@/composables/useInfiniteLoader';
 import { subgraphRequest } from '@snapshot-labs/snapshot.js/src/utils';
 
+// Persistant filter state
+const filterBy = ref('all');
+
 export default {
   setup() {
     const store = useStore();
@@ -92,7 +95,6 @@ export default {
 
     const loading = ref(false);
     const proposals = ref([]);
-    const filterBy = ref('all');
 
     // Infinite scroll with pagination
     const {


### PR DESCRIPTION
@bonustrack instead of switching the whole component to the CAPI, which would easily create another huge PR mess, I think we could move part by part (like I did here). This way we can focus on each part separately and keep things organized.