### PR TITLE
Use composable filters instead of helper filters

### DIFF
--- a/src/components/Modal/Networks.vue
+++ b/src/components/Modal/Networks.vue
@@ -22,27 +22,27 @@
 </template>
 
 <script>
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
-import { filterNetworks } from '@/helpers/utils';
+import { ref, computed } from 'vue';
+import { useSearchFilters } from '@/composables/useSearchFilters';
 
 export default {
-  props: ['open'],
-  emits: ['update:modelValue', 'close'],
-  data() {
-    return {
-      searchInput: ''
-    };
-  },
-  computed: {
-    networks() {
-      return filterNetworks(networks, this.app.spaces, this.searchInput);
+  props: {
+    open: {
+      type: Boolean,
+      required: true
     }
   },
-  methods: {
-    select(key) {
-      this.$emit('update:modelValue', key);
-      this.$emit('close');
+  setup(_, { emit }) {
+    const searchInput = ref('');
+    const { filteredNetworks } = useSearchFilters();
+    const networks = computed(() => filteredNetworks(searchInput.value));
+
+    function select(key) {
+      emit('update:modelValue', key);
+      emit('close');
     }
+
+    return { networks, searchInput, select };
   }
 };
 </script>

--- a/src/components/Modal/Plugins.vue
+++ b/src/components/Modal/Plugins.vue
@@ -42,30 +42,39 @@
       </div>
       <div v-if="!selectedPlugin?.key">
         <a
-          v-for="(plugin, i) in filteredPlugins"
+          v-for="(plugin, i) in filteredPlugins(searchInput)"
           :key="i"
           @click="select(plugin)"
         >
           <BlockPlugin :plugin="plugin" />
         </a>
-        <NoResults v-if="Object.keys(filteredPlugins).length < 1" />
+        <NoResults
+          v-if="Object.keys(filteredPlugins(searchInput)).length < 1"
+        />
       </div>
     </div>
   </UiModal>
 </template>
 
 <script>
-import { clone, filterPlugins } from '@/helpers/utils';
-import plugins from '@snapshot-labs/snapshot.js/src/plugins';
+import { ref, computed } from 'vue';
+import { useSearchFilters } from '@/composables/useSearchFilters';
+import { clone } from '@/helpers/utils';
 
 export default {
+  setup() {
+    const searchInput = ref('');
+    const { filteredPlugins } = useSearchFilters();
+    const plugins = computed(() => filteredPlugins());
+
+    return { searchInput, filteredPlugins, plugins };
+  },
   props: ['open', 'plugin'],
   emits: ['add', 'close'],
   data() {
     return {
       input: '',
-      selectedPlugin: {},
-      searchInput: ''
+      selectedPlugin: {}
     };
   },
   watch: {
@@ -83,12 +92,6 @@ export default {
     }
   },
   computed: {
-    filteredPlugins() {
-      return filterPlugins(plugins, this.app.spaces, this.searchInput);
-    },
-    plugins() {
-      return filterPlugins(plugins, this.app.spaces, '');
-    },
     isValid() {
       try {
         const params = JSON.parse(this.input);

--- a/src/components/Modal/Skins.vue
+++ b/src/components/Modal/Skins.vue
@@ -18,27 +18,27 @@
 </template>
 
 <script>
-import skins from '@/helpers/skins';
-import { filterSkins } from '@/helpers/utils';
+import { ref, computed } from 'vue';
+import { useSearchFilters } from '@/composables/useSearchFilters';
 
 export default {
-  props: ['open'],
-  emits: ['update:modelValue', 'close'],
-  data() {
-    return {
-      searchInput: ''
-    };
-  },
-  computed: {
-    skins() {
-      return filterSkins(skins, this.app.spaces, this.searchInput);
+  props: {
+    open: {
+      type: Boolean,
+      required: true
     }
   },
-  methods: {
-    select(key) {
-      this.$emit('update:modelValue', key);
-      this.$emit('close');
+  setup(_, { emit }) {
+    const searchInput = ref('');
+    const { filteredSkins } = useSearchFilters();
+    const skins = computed(() => filteredSkins(searchInput.value));
+
+    function select(key) {
+      emit('update:modelValue', key);
+      emit('close');
     }
+
+    return { skins, searchInput, select };
   }
 };
 </script>

--- a/src/components/Modal/Strategy.vue
+++ b/src/components/Modal/Strategy.vue
@@ -48,8 +48,9 @@
 </template>
 
 <script>
-import { clone, filterStrategies } from '@/helpers/utils';
-import strategies from '@/helpers/strategies';
+import { ref, computed } from 'vue';
+import { useSearchFilters } from '@/composables/useSearchFilters';
+import { clone } from '@/helpers/utils';
 
 const defaultParams = {
   symbol: 'DAI',
@@ -58,6 +59,13 @@ const defaultParams = {
 };
 
 export default {
+  setup() {
+    const searchInput = ref('');
+    const { filteredStrategies } = useSearchFilters();
+    const strategies = computed(() => filteredStrategies(searchInput.value));
+
+    return { searchInput, strategies };
+  },
   props: ['open', 'strategy'],
   emits: ['add', 'close'],
   data() {
@@ -65,8 +73,7 @@ export default {
       input: {
         name: '',
         params: JSON.stringify(defaultParams, null, 2)
-      },
-      searchInput: ''
+      }
     };
   },
   watch: {
@@ -84,9 +91,6 @@ export default {
     }
   },
   computed: {
-    strategies() {
-      return filterStrategies(strategies, this.app.spaces, this.searchInput);
-    },
     isValid() {
       try {
         const params = JSON.parse(this.input.params);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -67,18 +67,6 @@ export function formatProposals(proposals) {
   );
 }
 
-export function filterSkins(skins, spaces, q) {
-  return skins
-    .map(skin => ({
-      key: skin,
-      spaces: Object.entries(spaces)
-        .filter((space: any) => space[1].skin === skin)
-        .map(space => space[0])
-    }))
-    .filter(skin => skin.key.toLowerCase().includes(q.toLowerCase()))
-    .sort((a, b) => b.spaces.length - a.spaces.length);
-}
-
 export function getStrategy(strategy, spaces) {
   strategy.spaces = Object.entries(spaces)
     .filter(

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -80,26 +80,6 @@ export function getStrategy(strategy, spaces) {
   return strategy;
 }
 
-export function filterPlugins(plugins, spaces, q = '') {
-  return Object.entries(plugins)
-    .map(([key, pluginClass]: any) => {
-      const plugin = new pluginClass();
-      plugin.key = key;
-      plugin.spaces = Object.entries(spaces)
-        .filter(
-          (space: any) =>
-            space[1].plugins &&
-            Object.keys(space[1].plugins).includes(plugin.key)
-        )
-        .map(space => space[0]);
-      return plugin;
-    })
-    .filter(plugin =>
-      JSON.stringify(plugin).toLowerCase().includes(q.toLowerCase())
-    )
-    .sort((a, b) => b.spaces.length - a.spaces.length);
-}
-
 export function formatSpace(key, space) {
   space = {
     key,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -80,15 +80,6 @@ export function getStrategy(strategy, spaces) {
   return strategy;
 }
 
-export function filterStrategies(strategies, spaces, q = '') {
-  return Object.values(strategies)
-    .map((strategy: any) => getStrategy(strategy, spaces))
-    .filter(strategy =>
-      JSON.stringify(strategy).toLowerCase().includes(q.toLowerCase())
-    )
-    .sort((a, b) => b.spaces.length - a.spaces.length);
-}
-
 export function filterPlugins(plugins, spaces, q = '') {
   return Object.entries(plugins)
     .map(([key, pluginClass]: any) => {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -67,21 +67,6 @@ export function formatProposals(proposals) {
   );
 }
 
-export function filterNetworks(networks, spaces, q) {
-  return Object.entries(networks)
-    .map((network: any) => {
-      network[1].key = network[0];
-      network[1].spaces = Object.entries(spaces)
-        .filter((space: any) => space[1].network === network[0])
-        .map(space => space[0]);
-      return network[1];
-    })
-    .filter(network =>
-      JSON.stringify(network).toLowerCase().includes(q.toLowerCase())
-    )
-    .sort((a, b) => b.spaces.length - a.spaces.length);
-}
-
 export function filterSkins(skins, spaces, q) {
   return skins
     .map(skin => ({

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -311,19 +311,33 @@
 
 <script>
 import { mapActions } from 'vuex';
+import { computed } from 'vue';
+import { useSearchFilters } from '@/composables/useSearchFilters';
 import { getAddress } from '@ethersproject/address';
 import { validateSchema } from '@snapshot-labs/snapshot.js/src/utils';
 import schemas from '@snapshot-labs/snapshot.js/src/schemas';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import gateways from '@snapshot-labs/snapshot.js/src/gateways.json';
-import { clone, filterPlugins } from '@/helpers/utils';
-import plugins from '@snapshot-labs/snapshot.js/src/plugins';
+import { clone } from '@/helpers/utils';
 import { getSpaceUri, uriGet } from '@/helpers/ens';
 import defaults from '@/locales/default';
 
 const gateway = process.env.VUE_APP_IPFS_GATEWAY || gateways[0];
 
 export default {
+  setup() {
+    const { filteredPlugins } = useSearchFilters();
+    const plugins = computed(() => filteredPlugins());
+
+    function pluginName(key) {
+      const plugin = plugins.value.find(obj => {
+        return obj.key === key;
+      });
+      return plugin.name;
+    }
+
+    return { pluginName };
+  },
   data() {
     return {
       key: this.$route.params.key,
@@ -364,9 +378,6 @@ export default {
     },
     isReady() {
       return this.currentContenthash === this.contenthash;
-    },
-    plugins() {
-      return filterPlugins(plugins, this.app.spaces, '');
     }
   },
   async created() {
@@ -479,12 +490,6 @@ export default {
     },
     handleSubmitAddPlugins(payload) {
       this.form.plugins[payload.key] = payload.input;
-    },
-    pluginName(key) {
-      const plugin = this.plugins.find(obj => {
-        return obj.key === key;
-      });
-      return plugin.name;
     }
   }
 };


### PR DESCRIPTION
@bonustrack instead of switching the whole component to the CAPI, which would easily create another huge PR mess, I think we could move part by part (like I did here). This way we can focus on each part separately and keep things organized.