### PR TITLE
Add optional chaining to prevent timeline from breaking

### DIFF
--- a/src/components/TimelineProposal.vue
+++ b/src/components/TimelineProposal.vue
@@ -3,23 +3,23 @@
     class="px-4 py-3 pt-4 d-block text-gray"
     :to="{
       name: 'proposal',
-      params: { key: proposal.space.id, id: proposal.id }
+      params: { key: proposal?.space.id, id: proposal?.id }
     }"
   >
     <div>
       <div class="mb-1">
-        <Token :space="proposal.space.id" symbolIndex="space" size="28" />
-        <span class="ml-2" v-text="proposal.space.name" />
+        <Token :space="proposal?.space.id" symbolIndex="space" size="28" />
+        <span class="ml-2" v-text="proposal?.space.name" />
       </div>
-      <h3 v-text="_shorten(proposal.name, 124)" />
+      <h3 v-text="_shorten(proposal?.name, 124)" />
       <div class="mb-2">
-        <UiState :state="proposal.state" class="d-inline-block mr-1" />
+        <UiState :state="proposal?.state" class="d-inline-block mr-1" />
         {{ $tc('proposalBy', [author]) }}
         <Badges
-          :address="proposal.author.address"
-          :members="proposal.space.members"
+          :address="proposal?.author.address"
+          :members="proposal?.space.members"
         />
-        {{ $tc(period, [_ms(proposal.start), _ms(proposal.end)]) }}
+        {{ $tc(period, [_ms(proposal?.start), _ms(proposal?.end)]) }}
       </div>
       <p
         v-text="_shorten(body, 140)"
@@ -35,15 +35,18 @@ import removeMd from 'remove-markdown';
 
 export default {
   props: {
-    proposal: Object
+    proposal: {
+      type: Object,
+      required: true
+    }
   },
   computed: {
     body() {
-      return removeMd(this.proposal.body);
+      return removeMd(this.proposal?.body);
     },
     period() {
-      if (this.proposal.state === 'closed') return 'endedAgo';
-      if (this.proposal.state === 'active') return 'endIn';
+      if (this.proposal?.state === 'closed') return 'endedAgo';
+      if (this.proposal?.state === 'active') return 'endIn';
       return 'startIn';
     },
     author() {


### PR DESCRIPTION
Add optional chaining to prevent timeline from breaking, when a proposal has missing data. I'm not sure if we need it everywhere, but it shouldn't do any harm right?