### PR TITLE
Fix: First set bond bug fix

### DIFF
--- a/src/components/Plugin/SafeSnap/CustomBlock.vue
+++ b/src/components/Plugin/SafeSnap/CustomBlock.vue
@@ -42,6 +42,7 @@
     />
     <teleport to="#modal">
       <PluginSafeSnapModalOptionApproval
+        :minimumBond="questionDetails?.minimumBond"
         :open="modalApproveDecisionOpen"
         :isApproved="questionDetails?.isApproved"
         :bond="questionDetails?.currentBond"

--- a/src/components/Plugin/SafeSnap/Modal/OptionApproval.vue
+++ b/src/components/Plugin/SafeSnap/Modal/OptionApproval.vue
@@ -49,8 +49,9 @@
 </template>
 
 <script>
+import { BigNumber } from '@ethersproject/bignumber';
 export default {
-  props: ['open', 'isApproved', 'bond', 'questionId'],
+  props: ['open', 'isApproved', 'bond', 'questionId', 'minimumBond'],
   emits: ['close', 'setApproval'],
   methods: {
     async handleSetApproval(option) {
@@ -64,8 +65,11 @@ export default {
     },
     bondData() {
       const dontHasBond = this.bond === '0.0';
+      const minimumBond = BigNumber.from(this.minimumBond).eq(0)
+        ? 0.001
+        : this.minimumBond;
       return {
-        toSet: dontHasBond ? 0.1 : Number(this.bond) * 2,
+        toSet: dontHasBond ? minimumBond : BigNumber.from(this.bond).mul(2),
         current: dontHasBond ? '--' : this.bond
       };
     },


### PR DESCRIPTION
There is a bug where, if a DaoModule has a different `minimumBond` than 0.01 ETH (i.e: 0.2 ETH) - We were not showing the correct bond to set (when there's none), now we are showing the `minimumBond` as expected