### PR TITLE
Fix for "false" in tooltip

### DIFF
--- a/src/components/Block/Results.vue
+++ b/src/components/Block/Results.vue
@@ -6,13 +6,14 @@
     <div v-for="choice in choices" :key="choice.i">
       <div class="text-white mb-1">
         <span
-          class="mr-1 tooltipped"
+          class="mr-1"
           :class="[
-            isSmallScreen
-              ? 'tooltipped-ne tooltipped-align-left-2'
-              : 'tooltipped-n'
+            choice.choice.length > 12 &&
+              (isSmallScreen
+                ? 'tooltipped tooltipped-ne tooltipped-align-left-2'
+                : 'tooltipped tooltipped-n')
           ]"
-          :aria-label="choice.choice.length > 12 && choice.choice"
+          :aria-label="choice.choice"
           v-text="_shorten(choice.choice, 'choice')"
         />
         <span


### PR DESCRIPTION
Looks like an issue with 

```choice.choice.length > 12 && choice.choice```

Assumed this condition is added to not to show a tooltip when length is less that 12