### PR TITLE
[fix] Select Component - defineEmits used an array instead of a function

### DIFF
--- a/src/components/Ui/Select.vue
+++ b/src/components/Ui/Select.vue
@@ -3,7 +3,7 @@ import { defineEmits, defineProps } from 'vue';
 
 defineProps({ modelValue: String, disabled: Boolean });
 
-const emit = defineEmits[('update:modelValue', 'change')];
+const emit = defineEmits(['update:modelValue', 'change']);
 
 function handleChange(event) {
   emit('update:modelValue', event.target.value);


### PR DESCRIPTION
the defineEmits functions is used as an array instead of a function (parentheses and brackets got inverted). 