### PR TITLE
Fix exported filename have undefined

### DIFF
--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -302,6 +302,7 @@ onMounted(async () => {
         </div>
       </Block>
       <BlockResults
+        :id="id"
         :loaded="loadedResults"
         :space="space"
         :proposal="proposal"


### PR DESCRIPTION
The exported file name is now generated as `snapshot-report-undefined` fixed it to have proposal id in it instead of `undefined`

You can test it after merging #520 