### PR TITLE
Fix repo name for strategies

### DIFF
--- a/src/views/Strategy.vue
+++ b/src/views/Strategy.vue
@@ -51,7 +51,7 @@ const strategy = computed(() =>
             <a
               target="_blank"
               class="float-right"
-              :href="`https://github.com/snapshot-labs/snapshot.js/tree/master/src/strategies/${strategy.key}`"
+              :href="`https://github.com/snapshot-labs/snapshot-strategies/tree/master/src/strategies/${strategy.key}`"
             >
               {{ strategy.version }}
               <Icon name="external-link" class="ml-1" />


### PR DESCRIPTION
Right now when we click on version number in strategy page it redirects to old repository