### PR TITLE
Fix proposal redirection

### DIFF
--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -75,7 +75,7 @@ async function loadProposal() {
   proposal.value = proposalObj.proposal;
 
   // Redirect to proposal spaceId if it doesn't match route key
-  if (route.key !== proposal.value.space.id)
+  if (route.key && route.key !== proposal.value.space.id)
     router.push({
       name: 'proposal',
       params: {

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -75,7 +75,7 @@ async function loadProposal() {
   proposal.value = proposalObj.proposal;
 
   // Redirect to proposal spaceId if it doesn't match route key
-  if (route.key && route.key !== proposal.value.space.id)
+  if (route.params.key && route.params.key !== proposal.value.space.id)
     router.push({
       name: 'proposal',
       params: {


### PR DESCRIPTION
If you click to open a proposal then click on the snapshot logo before proposal load it will send you back to the proposal after proposal load.