### PR TITLE
fix(SafeSnap): show correct recipient addresses for transactions

### DIFF
--- a/src/components/Plugin/SafeSnap/Form/Transaction.vue
+++ b/src/components/Plugin/SafeSnap/Form/Transaction.vue
@@ -40,25 +40,26 @@ export default {
     title() {
       if (this.modelValue) {
         try {
-          const addr = this._shorten(this.modelValue.to);
+          const recipientAddr = this._shorten(this.modelValue.recipient);
+          const toAddr = this._shorten(this.modelValue.to);
           const type = this.modelValue.type || this.type;
           switch (type) {
             case 'contractInteraction':
               return `${getAbiFirstFunctionName(this.modelValue.abi)}() - ${
                 this.modelValue.value
-              } wei to ${addr}`;
+              } wei to ${toAddr}`;
             case 'transferFunds':
               return `Transfer ${formatUnits(
                 this.modelValue.amount,
                 this.modelValue.token.decimals
-              )} ${this.modelValue.token.symbol} to ${addr}`;
+              )} ${this.modelValue.token.symbol} to ${recipientAddr}`;
             case 'transferNFT':
               return `Send ${this.modelValue.collectable.name} #${this._shorten(
                 this.modelValue.collectable.id,
                 10
-              )} to ${addr}`;
+              )} to ${recipientAddr}`;
             case 'raw':
-              return `Send ${this.modelValue.value} wei to ${addr}`;
+              return `Send ${this.modelValue.value} wei to ${recipientAddr}`;
           }
         } catch (error) {
           console.log('could not determine title', error);


### PR DESCRIPTION
In SafeSnap's transaction view, the transaction titles are misleading for ERC20 and NFT transfers. Instead of the recipient's address it renders the token contract address:

<img width="632" alt="snapshot ui bug" src="https://user-images.githubusercontent.com/524089/133584907-75772ce1-4e55-4cac-b48f-e9cf5798a2cf.png">

This PR fixes it.