### PR TITLE
Fix terms modal showing when space has no terms set

### DIFF
--- a/src/components/FollowButton.vue
+++ b/src/components/FollowButton.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { computed } from 'vue';
 import { useFollowSpace } from '@/composables/useFollowSpace';
 import { useTerms } from '@/composables/useTerms';
 
@@ -9,16 +10,24 @@ const { modalTermsOpen, termsAccepted, acceptTerms } = useTerms(props.space.id);
 const { clickFollow, loadingFollow, isFollowing, hoverJoin } = useFollowSpace(
   props.space
 );
+
+const canFollow = computed(() => {
+  if (props.space.terms) {
+    if (termsAccepted.value || isFollowing.value) return true;
+    else return false;
+  } else return true;
+});
 </script>
 
 <template>
   <UiButton
+    v-bind="$attrs"
     @click.stop="
       loadingFollow !== ''
         ? null
-        : !termsAccepted && !isFollowing
-        ? (modalTermsOpen = true)
-        : clickFollow(space.id)
+        : canFollow
+        ? clickFollow(space.id)
+        : (modalTermsOpen = true)
     "
     @mouseenter="hoverJoin = space.id"
     @mouseleave="hoverJoin = ''"


### PR DESCRIPTION
@bonustrack  for follow terms to work on the Home we need to have the terms available inside explore endpoint. Currently it will just let you follow without accepting the terms.