### PR TITLE
feat(): display unread indicator for timeline.

### DIFF
--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -22,6 +22,17 @@ const modalLangOpen = ref(false);
 
 const web3Account = computed(() => web3.value.account);
 
+const hasUnseenProposalsBySpace = space => {
+  return proposalIds.value.some(p => {
+    return (
+      p.space.id === space && p.created > (lastSeenProposals.value[space] || 0)
+    );
+  });
+};
+
+const hasUnseenProposals = () =>
+  followingSpaces.value.some(fs => hasUnseenProposalsBySpace(fs));
+
 watch(web3Account, () => {
   loadFollows();
   updateLastSeenProposal(web3Account.value);
@@ -67,35 +78,21 @@ onMounted(() => {
           pt-2
         "
       >
-        <router-link :to="{ name: 'timeline' }">
-          <UiSidebarButton>
-            <Icon size="20" name="feed" />
-          </UiSidebarButton>
-        </router-link>
+        <div class="flex items-center">
+          <UiUnreadIndicator v-if="hasUnseenProposals()" />
+          <router-link :to="{ name: 'timeline' }">
+            <UiSidebarButton>
+              <Icon size="20" name="feed" />
+            </UiSidebarButton>
+          </router-link>
+        </div>
         <div
           class="w-full flex items-center justify-center relative group"
           v-for="space in followingSpaces"
           :key="space"
         >
-          <div
-            v-if="
-              lastSeenProposals[space]
-                ? proposalIds
-                    .filter(p => p.space.id === space)
-                    .map(p => p.created)[0] > lastSeenProposals[space]
-                : true
-            "
-            class="
-              w-[8px]
-              h-[8px]
-              !bg-skin-link
-              absolute
-              left-[-4px]
-              rounded-full
-              opacity-70
-              group-hover:opacity-100
-            "
-          />
+          <UiUnreadIndicator v-if="hasUnseenProposalsBySpace(space)" />
+
           <router-link :to="{ name: 'proposals', params: { key: space } }">
             <Token :space="spaces[space]" symbolIndex="space" size="44" />
           </router-link>

--- a/src/components/Ui/UnreadIndicator.vue
+++ b/src/components/Ui/UnreadIndicator.vue
@@ -1,0 +1,16 @@
+<script setup></script>
+
+<template>
+  <div
+    class="
+      w-[8px]
+      h-[8px]
+      !bg-skin-link
+      absolute
+      left-[-4px]
+      rounded-full
+      opacity-70
+      group-hover:opacity-100
+    "
+  />
+</template>

--- a/src/composables/useUnseenProposals.ts
+++ b/src/composables/useUnseenProposals.ts
@@ -5,6 +5,10 @@ import { lsGet } from '@/helpers/utils';
 const proposalIds = ref([]);
 const lastSeenProposals = ref({});
 
+/**
+ * Fixme: This will not work if one of the followed spaces has more than 100 proposals created before
+ * other spaces had proposals.
+ */
 export function useUnseenProposals() {
   async function getProposalIds(followingSpaces) {
     if (followingSpaces[0]) {
@@ -33,15 +37,6 @@ export function useUnseenProposals() {
       }
     }
   }
-
-  // const numberOfUnseenProposals = computed(() => {
-  //   const index = proposalIds.value
-  //     .map((proposal: { id: string }) => proposal.id)
-  //     .indexOf(lsGet('lastSeenProposalId', ''));
-  //   const numberOfUnseen = index < 0 ? proposalIds.value.length : index;
-
-  //   return numberOfUnseen > 99 ? '99+' : numberOfUnseen;
-  // });
 
   function updateLastSeenProposal(account) {
     if (account) {

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -82,7 +82,7 @@ watch([proposals, web3Account], () => {
     lsSet(
       `lastSeenProposals.${web3Account.value.slice(0, 8).toLowerCase()}`,
       Object.assign(lastSeenProposals.value, {
-        [spaceId]: proposals.value[0].created
+        [spaceId]: new Date().getTime()
       })
     );
   }

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -10,7 +10,7 @@ import { PROPOSALS_QUERY } from '@/helpers/queries';
 import { useProfiles } from '@/composables/useProfiles';
 import { useFollowSpace } from '@/composables/useFollowSpace';
 import { useWeb3 } from '@/composables/useWeb3';
-
+import zipObject from 'lodash/zipObject';
 const filterBy = ref('all');
 const loading = ref(false);
 const proposals = ref([]);
@@ -78,12 +78,22 @@ function selectState(e) {
   load();
 }
 
-// Save the most recently seen proposalId in localStorage
-const { getProposalIds, proposalIds } = useUnseenProposals();
-onMounted(async () => {
-  await getProposalIds(following.value);
-  if (proposalIds.value[0])
-    lsSet('lastSeenProposalId', proposalIds.value[0].id);
+const { updateLastSeenProposal } = useUnseenProposals();
+
+const web3Account = computed(() => web3.value.account);
+
+// Save the lastSeenProposal times for all spaces
+watch([proposals, web3Account], () => {
+  if (web3Account.value) {
+    lsSet(
+      `lastSeenProposals.${web3Account.value.slice(0, 8).toLowerCase()}`,
+      zipObject(
+        followingSpaces.value,
+        Array(followingSpaces.value.length).fill(new Date().getTime())
+      )
+    );
+  }
+  updateLastSeenProposal(web3Account.value);
 });
 </script>
 


### PR DESCRIPTION
- refactor condition to handle unseen proposals for each space.
- refactor unreadIndicator to a component
- added a comment when the unseen proposals could break
- instead of saving the created time of last proposal for space, saving the current timestamp of the user.
- remove lastSeenProposalId as it is useless

Fixes #645 