### PR TITLE
#654 Use same margins for all icons on Sidebar

### DIFF
--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -113,6 +113,7 @@ onMounted(() => {
           </router-link>
         </div>
         <draggable
+          v-if="draggableSpaces.length > 0"
           v-model="draggableSpaces"
           :component-data="{ name: 'list' }"
           item-key="id"
@@ -144,7 +145,7 @@ onMounted(() => {
             justify-center
             !mb-0
             !mt-auto
-            py-[14px]
+            py-2
           "
         >
           <UiSidebarButton @click="toggleSkin">

--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -140,7 +140,7 @@ onMounted(() => {
           class="
             flex flex-col
             items-center
-            space-y-[14px]
+            space-y-2
             justify-center
             !mb-0
             !mt-auto


### PR DESCRIPTION
Fixes #654 

Changes proposed in this pull request:
I just managed to use the same vertical space found for top icons on Sidebar and used on bottom elements.