### PR TITLE
Add a method to retrieve scores on delegates and sort them on a list

### DIFF
--- a/src/helpers/delegation.ts
+++ b/src/helpers/delegation.ts
@@ -44,3 +44,23 @@ export async function getDelegators(network, address, snapshot = 'latest') {
   }
   return await subgraphRequest(SNAPSHOT_SUBGRAPH_URL[network], params);
 }
+
+export async function getDelegatesBySpace(network, space, snapshot = 'latest') {
+  const params = {
+    delegations: {
+      __args: {
+        where: {
+          space
+        },
+        first: 1000
+      },
+      delegate: true,
+      delegator: true
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.delegations.__args.block = { number: snapshot };
+  }
+  return await subgraphRequest(SNAPSHOT_SUBGRAPH_URL[network], params);
+}

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -151,7 +151,8 @@
     "delegations": "Your delegation(s)",
     "allSpaces": "For all spaces",
     "delegated": "Delegated to you",
-    "pendingTransaction": "no pending transaction | 1 pending transaction | {count} pending transactions"
+    "pendingTransaction": "no pending transaction | 1 pending transaction | {count} pending transactions",
+    "topDelegates": "Top delegates"
   },
   "proposal": {
     "castVote": "Cast your vote",

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -261,6 +261,7 @@ onMounted(async () => {
           v-if="delegatesLoading || delegatesWithScore.length > 0"
           :title="$t('delegate.topDelegates')"
           :slim="true"
+          :loading="delegatesLoading"
         >
           <div
             v-for="(delegate, i) in delegatesWithScore"

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -133,10 +133,11 @@ async function getDelegatesWithScore() {
   );
 
   uniqueDelegators.forEach(delegate => {
+    delegate.score = 0;
     scores.forEach(score => {
       Object.entries(score).forEach(([address, score]) => {
         if (address === delegate.delegate) {
-          delegate.score = score;
+          delegate.score += score;
         }
       });
     });

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -123,9 +123,12 @@ async function getDelegatesWithScore() {
 
   const provider = getProvider(space.value.network);
   const delegatesAddresses = uniqueDelegators.map(d => d.delegate);
+  const delegationStrategy = space.value.strategies.filter(
+    strategy => strategy.name === 'delegation'
+  );
   const scores = await getScores(
     space.value.id,
-    space.value.strategies,
+    delegationStrategy,
     space.value.network,
     provider,
     delegatesAddresses,
@@ -133,13 +136,11 @@ async function getDelegatesWithScore() {
   );
 
   uniqueDelegators.forEach(delegate => {
-    delegate.score = 0;
-    scores.forEach(score => {
-      Object.entries(score).forEach(([address, score]) => {
-        if (address === delegate.delegate) {
-          delegate.score += score;
-        }
-      });
+    const delegationScore = scores[0];
+    Object.entries(delegationScore).forEach(([address, score]) => {
+      if (address === delegate.delegate) {
+        delegate.score = score;
+      }
     });
   });
 

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -154,9 +154,12 @@ watch(networkKey, (val, prev) => {
   if (val !== prev) load();
 });
 
+watchEffect(() => {
+  if (space.value) getDelegatesWithScore();
+});
+
 onMounted(async () => {
   await load();
-  await getDelegatesWithScore();
   loaded.value = true;
 });
 </script>

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -51,9 +51,7 @@ const { profiles, addressArray } = useProfiles();
 
 const web3Account = computed(() => web3.value.account);
 const networkKey = computed(() => web3.value.network.key);
-const space = computed(
-  () => spaces.value[form.value.id] || spaces.value[route.params.key]
-);
+const space = computed(() => spaces.value[form.value.id]);
 
 const isValid = computed(() => {
   const address = form.value.address;
@@ -166,7 +164,11 @@ watch(networkKey, (val, prev) => {
 });
 
 watchEffect(() => {
-  if (space.value) getDelegatesWithScore();
+  if (spaces.value[form.value.id]) {
+    getDelegatesWithScore();
+  } else {
+    delegatesWithScore.value = [];
+  }
 });
 
 onMounted(async () => {
@@ -253,7 +255,7 @@ onMounted(async () => {
         </Block>
         <Block
           v-if="delegatesWithScore.length > 0"
-          :title="$t('Top delegates')"
+          :title="$t('delegate.topDelegates')"
           :slim="true"
         >
           <div

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -22,7 +22,6 @@ import { sleep } from '@/helpers/utils';
 import { useApp } from '@/composables/useApp';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useTxStatus } from '@/composables/useTxStatus';
-import { getBlockNumber } from '@snapshot-labs/snapshot.js/src/utils/web3';
 
 const abi = ['function setDelegate(bytes32 id, address delegate)'];
 
@@ -39,6 +38,7 @@ const currentId = ref('');
 const currentDelegate = ref('');
 const loaded = ref(false);
 const loading = ref(false);
+const delegatesLoading = ref(false);
 const delegates = ref([]);
 const delegatesWithScore = ref([]);
 const delegators = ref([]);
@@ -110,6 +110,7 @@ function clearDelegate(id, delegate) {
 }
 
 async function getDelegatesWithScore() {
+  delegatesLoading.value = true;
   const { delegations } = await getDelegatesBySpace(
     space.value.network,
     space.value.id
@@ -149,6 +150,7 @@ async function getDelegatesWithScore() {
     .sort((a, b) => b.score - a.score);
 
   delegatesWithScore.value = sortedDelegates;
+  delegatesLoading.value = false;
 }
 
 watchEffect(() => {
@@ -256,7 +258,7 @@ onMounted(async () => {
           </div>
         </Block>
         <Block
-          v-if="delegatesWithScore.length > 0"
+          v-if="delegatesLoading || delegatesWithScore.length > 0"
           :title="$t('delegate.topDelegates')"
           :slim="true"
         >
@@ -273,7 +275,7 @@ onMounted(async () => {
               class="column"
             />
             <div class="flex-auto column text-right link-color">
-              {{ parseFloat(delegate.score).toFixed(2) }} {{ space.symbol }}
+              {{ _n(delegate.score) }} {{ space.symbol }}
             </div>
           </div>
         </Block>


### PR DESCRIPTION
Fixes #659

Changes proposed in this pull request:
Added a method on Delegate to add scores on delegates and sort them by score, if they have any.
Since I am missing in balance on testnet on spaces with delegation enabled I am marking this as WIP.