### PR TITLE
formatted numbers for members count

### DIFF
--- a/src/components/Block/Space.vue
+++ b/src/components/Block/Space.vue
@@ -32,7 +32,7 @@ const isAdmin = computed(() => {
     <Block :slim="true" class="overflow-hidden">
       <div class="text-center border-b bg-skin-header-bg">
         <Token :space="space" symbolIndex="space" size="80" class="mt-3 mb-2" />
-        <h3 class="mb-0 pb-0 mt-0 text-[22px] !h-[32px] overflow-hidden">{{ space.name }}</h3>
+        <h3 class="mb-[2px]">{{ space.name }}</h3>
         <div class="mb-[12px] text-color">
           {{ $tc('members', nbrMembers,{count:_n(nbrMembers)}) }}
         </div>

--- a/src/components/Block/Space.vue
+++ b/src/components/Block/Space.vue
@@ -32,9 +32,9 @@ const isAdmin = computed(() => {
     <Block :slim="true" class="overflow-hidden">
       <div class="text-center border-b bg-skin-header-bg">
         <Token :space="space" symbolIndex="space" size="80" class="mt-3 mb-2" />
-        <h3 class="mb-3 px-4">{{ space.name }}</h3>
+        <h3 class="mb-0 pb-0 mt-0 text-[22px] !h-[32px] overflow-hidden">{{ space.name }}</h3>
         <div class="mb-[12px] text-color">
-          {{ $tc('members', nbrMembers) }}
+          {{ $tc('members', nbrMembers,{count:_n(nbrMembers)}) }}
         </div>
         <FollowButton :space="space" />
       </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -86,7 +86,11 @@ const { endElement } = useScrollMonitor(() => (limit.value += loadBy));
                 class="mb-0 pb-0 mt-0 text-[22px] !h-[32px] overflow-hidden"
               />
               <div class="mb-[12px] text-color">
-                {{ $tc('members', space.followers) }}
+                {{
+                  $tc('members', space.followers, {
+                    count: _n(space.followers)
+                  })
+                }}
               </div>
               <FollowButton :space="space" />
             </Block>


### PR DESCRIPTION
Fixes #667 
Fixes #677 

Changes proposed in this pull request:
- change `$tc('members', space.followers)` to `$tc('members', space.followers, {  count: _n(space.followers)  })`

