### PR TITLE
fixed icon alignments

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -17,6 +17,5 @@ defineProps({
 .iconfont {
   font-size: 16px;
   line-height: 16px;
-  vertical-align: baseline;
 }
 </style>

--- a/src/components/Ui/Dropdown.vue
+++ b/src/components/Ui/Dropdown.vue
@@ -49,7 +49,7 @@ onBeforeUnmount(() => window.removeEventListener('click', close));
             v-if="item.icon"
             :name="item.icon"
             size="21"
-            class="align-text-bottom mr-2"
+            class="align-middle mr-2"
           />
           {{ item.text }}
         </li>


### PR DESCRIPTION
Fixes #814

Changes proposed in this pull request:
- remove `vertical-align: baseline` for `.iconfont` (default anyway)
- overwrite in dropdown with tailwind class `align-middle`
