### PR TITLE
SafeSnap: switch to right network when requesting execution

### DIFF
--- a/src/components/Plugin/SafeSnap/SafeTransactions.vue
+++ b/src/components/Plugin/SafeSnap/SafeTransactions.vue
@@ -131,7 +131,7 @@ export default {
       style="padding-bottom: 12px"
     >
       <UiAvatar
-        class="mr-2 float-left mt-[-2px]"
+        class="mr-2 float-left"
         :imgsrc="networkIcon"
         :seed="network"
         size="28"

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -23,7 +23,7 @@ export function useWeb3() {
     state.authLoading = true;
     await auth.login(connector);
     if (auth.provider.value) {
-      auth.web3 = new Web3Provider(auth.provider.value);
+      auth.web3 = new Web3Provider(auth.provider.value, 'any');
       await loadProvider();
     }
     state.authLoading = false;

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -287,6 +287,7 @@
       "executed": "All transactions have been executed",
       "error": "Something went wrong",
       "connectWallet": "Connect wallet to see execution details",
+      "switchChain": "Switch your wallet to {0} to request execution",
       "question": "Did this proposal pass and does it meet the",
       "criteria": "acceptance criteria?"
     }


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot-plugins/issues/12.

Now that we support multiple Safes on different networks, users need to be connected to the right network when submitting oracle transactions or requesting execution of the transactions. This PR improves the UX by:

- auto-switching to the correct network when using MetaMask
- showing a hint "Switch your wallet to `NAME OF CHAIN` to request execution" when using another wallet 