### PR TITLE
fix alignment in sidebar in firefox

### DIFF
--- a/src/components/Scroller.vue
+++ b/src/components/Scroller.vue
@@ -87,7 +87,7 @@ onMounted(() => {
       bg-skin-block-bg
     "
   >
-    <div class="flex flex-col h-full overflow-scroll menu-tabs">
+    <div class="flex flex-col h-full overflow-auto menu-tabs">
       <div class="min-h-[78px] h-[78px] flex items-center justify-center">
         <router-link :to="{ path: '/' }">
           <Icon


### PR DESCRIPTION
Fixes #892 .

`overflow: scroll` makes firefox reserve space for a scrollbar even though no scrolling is needed. Setting it to `overflow: auto` fixes that and makes the sidebar items centered in firefox.