### PR TITLE
use onChange when updating route

### DIFF
--- a/src/views/Playground.vue
+++ b/src/views/Playground.vue
@@ -197,7 +197,7 @@ onMounted(async () => {
           <UiButton class="block w-full px-3" style="height: auto">
             <TextareaArray
               v-model="form.addresses"
-              @update:modelValue="handleURLUpdate"
+              @change:modelValue="handleURLUpdate"
               :placeholder="`0x8C28Cf33d9Fd3D0293f963b1cd27e3FF422B425c\n0xeF8305E140ac520225DAf050e2f71d5fBcC543e7`"
               class="input w-full text-left"
               style="font-size: 18px"


### PR DESCRIPTION
## Why?
The route was being updated on load due to using `@update:modelValue` rather then an onChange event

Fixes #885 

Changes proposed in this pull request:
- change `@update:modelValue` to `@change:modelValue`