### PR TITLE
Set scores api url as env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 VITE_HUB_URL=https://testnet.snapshot.org
+VITE_SCORES_URL=https://score.snapshot.org
 VITE_IPFS_GATEWAY=gateway.ipfs.io
 VITE_DEFAULT_NETWORK=1

--- a/src/composables/useApp.ts
+++ b/src/composables/useApp.ts
@@ -27,7 +27,7 @@ export function useApp() {
 
   async function getStrategies() {
     const strategiesObj: any = await fetch(
-      'https://score.snapshot.org/api/strategies'
+      `${import.meta.env.VITE_SCORES_URL}/api/strategies`
     ).then(res => res.json());
     strategies.value = strategiesObj;
     return;


### PR DESCRIPTION
Just cloned the scores repo and noticed that the url is hardcoded in the UI and moved it to `.env`.