### PR TITLE
Added workflow to update submodules

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   update-submodule:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'snapshot-labs' }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Instead of:
- https://github.com/snapshot-labs/snapshot-plugins/blob/master/.github/workflows/update-snapshot-submodule.yml
- https://github.com/snapshot-labs/snapshot-spaces/blob/master/.github/workflows/update-snapshot-submodule.yml

Removed here:
https://github.com/snapshot-labs/snapshot-spaces/pull/1640
https://github.com/snapshot-labs/snapshot-plugins/pull/22

This workflow does not directly push to the repository but opens a pull request.
It is also just a single workflow that works with the default `GITHUB_TOKEN` permissions, instead of two individual workflows that require a more permissive personal access token.
Runs once per hour and can be triggered manually.
So, updates are now "pulled" instead of "pushed", so to say.