### PR TITLE
use tailwind classes

### DIFF
--- a/src/components/Sticky.vue
+++ b/src/components/Sticky.vue
@@ -34,10 +34,11 @@ onBeforeUnmount(() => {
   <div>
     <div v-if="isFixed" :style="`height: ${offsetHeight}px;`" />
     <div
-      style="z-index: 20; right: 0px"
-      class="left-0"
       ref="sticky"
-      :class="{ 'fixed top-0': isFixed, 'sm:left-[68px]': !domain }"
+      :class="[
+        'z-20 inset-x-0',
+        { 'fixed top-0': isFixed, 'sm:left-[68px]': !domain }
+      ]"
     >
       <slot />
     </div>


### PR DESCRIPTION
I saw a lot of custom CSS that can be replaced by existing tailwind classes. Will add more commits to this PR over time.

I also need to test if...

```javascript
:class="[
    'z-20 inset-x-0',
    { 'fixed top-0': isFixed, 'sm:left-[68px]': !domain }
]"
```

...conflicts with tailwinds just-in-time mode.