### PR TITLE
Move Trezor connector up inside connector modal

### DIFF
--- a/src/helpers/connectors.json
+++ b/src/helpers/connectors.json
@@ -3,10 +3,6 @@
     "id": "injected",
     "name": "MetaMask"
   },
-  "trezor": {
-    "id": "trezor",
-    "name": "Trezor (with MetaMask)"
-  },
   "walletconnect": {
     "id": "walletconnect",
     "name": "WalletConnect",
@@ -18,6 +14,10 @@
         "42": "https://eth-kovan.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO"
       }
     }
+  },
+  "trezor": {
+    "id": "trezor",
+    "name": "Trezor (with MetaMask)"
   },
   "torus": {
     "id": "torus",

--- a/src/helpers/connectors.json
+++ b/src/helpers/connectors.json
@@ -3,6 +3,10 @@
     "id": "injected",
     "name": "MetaMask"
   },
+  "trezor": {
+    "id": "trezor",
+    "name": "Trezor (with MetaMask)"
+  },
   "walletconnect": {
     "id": "walletconnect",
     "name": "WalletConnect",
@@ -45,9 +49,5 @@
     "options": {
       "apiKey": "pk_live_9CE8FD92E54684ED"
     }
-  },
-  "trezor": {
-    "id": "trezor",
-    "name": "Trezor (with MetaMask)"
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Users are having trouble using the right connector for Trezor because the connector is at the bottom of the modal. In this PR we move it to 2nd position under Metamask.

![image](https://user-images.githubusercontent.com/51686767/139381261-f9a6a470-d67c-4b13-896c-d8d885261537.png)
