### PR TITLE
hot fix for browsers without service worker support

### DIFF
--- a/src/composables/useSpaceSubscription.ts
+++ b/src/composables/useSpaceSubscription.ts
@@ -69,7 +69,7 @@ export function useSpaceSubscription(spaceId: any) {
   const configurePush = async () => {
     try {
       const isNotificationsAllowed = await checkBrowserNotification();
-      if (isNotificationsAllowed) {
+      if (isNotificationsAllowed && beams) {
         await beams.start();
         await beams.addDeviceInterest(web3Account.value);
         await client.subscribe(aliasWallet.value, aliasWallet.value.address, {

--- a/src/helpers/beams.ts
+++ b/src/helpers/beams.ts
@@ -1,7 +1,13 @@
 import * as PusherPushNotifications from '@pusher/push-notifications-web';
 
-const beams = new PusherPushNotifications.Client({
-  instanceId: (import.meta.env.VITE_PUSHER_BEAMS_INSTANCE_ID as string) ?? ''
-});
+let beams: any;
+
+try {
+  beams = new PusherPushNotifications.Client({
+    instanceId: (import.meta.env.VITE_PUSHER_BEAMS_INSTANCE_ID as string) ?? ''
+  });
+} catch (e) {
+  console.log(e);
+}
 
 export { beams };


### PR DESCRIPTION
Fixes page not loading for browser without service worker support.

The pusher beams package performs a check for service worker support (`"serviceWorker" in navigator`) when initializing the client. I put that initialization in a try-catch block to swallow the error.