### PR TITLE
Use network env var in getSpaceUri

### DIFF
--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -237,7 +237,10 @@ function formatSpace(spaceRaw) {
 watchEffect(async () => {
   if (!props.spaceLoading) {
     try {
-      const uri = await getSpaceUri(props.spaceId);
+      const uri = await getSpaceUri(
+        props.spaceId,
+        import.meta.env.VITE_DEFAULT_NETWORK
+      );
       console.log('URI', uri);
       currentTextRecord.value = uri;
     } catch (e) {


### PR DESCRIPTION
As suggested here: https://github.com/snapshot-labs/snapshot.js/pull/420

Would allow to set `VITE_DEFAULT_NETWORK=4` and use a Rinkeby ENS domain to create a space.