### PR TITLE
fix: space categories params

### DIFF
--- a/src/components/Modal/Category.vue
+++ b/src/components/Modal/Category.vue
@@ -1,0 +1,108 @@
+<script setup>
+import { ref, computed, toRefs, watchEffect } from 'vue';
+
+const props = defineProps({
+  open: Boolean,
+  categories: Array
+});
+
+const emit = defineEmits(['add', 'close']);
+
+const { open } = toRefs(props);
+
+const categories = [
+  'protocol',
+  'social',
+  'investment',
+  'grant',
+  'service',
+  'media',
+  'creator',
+  'collector'
+];
+
+const checkedCategories = computed(() => props.categories);
+
+const selectedCategories = ref([]);
+
+watchEffect(() => {
+  selectedCategories.value = checkedCategories.value;
+});
+
+function hasCategory(category) {
+  return selectedCategories.value.find(el => el.includes(category));
+}
+
+function selectCategoriesHandler(category) {
+  if (hasCategory(category)) {
+    selectedCategories.value = selectedCategories.value.filter(
+      el => !el.includes(category)
+    );
+  } else if (selectedCategories.value.length < 2) {
+    selectedCategories.value = [...selectedCategories.value, category];
+  }
+}
+
+function handleSubmit() {
+  emit('add', selectedCategories.value);
+  emit('close');
+}
+
+function handleClose() {
+  selectedCategories.value = checkedCategories.value;
+  emit('close');
+}
+</script>
+
+<template>
+  <UiModal :open="open" @close="handleClose">
+    <template v-slot:header>
+      <h3>
+        {{ $t('settings.selectCategories') }}
+      </h3>
+    </template>
+
+    <div class="mt-4 mx-0 md:mx-4 flex flex-col justify-between">
+      <div class="ml-4 md:ml-0 mb-4">
+        {{ $t('create.categorie(s)') }}
+      </div>
+      <Block
+        @click="selectCategoriesHandler(category)"
+        v-for="(category, i) in categories"
+        :key="i"
+        :class="[
+          {
+            'hover:border-skin-link cursor-pointer':
+              hasCategory(category) || selectedCategories.length < 2,
+            '!border-skin-link': hasCategory(category)
+          },
+          'relative capitalize'
+        ]"
+      >
+        <h3 v-text="category" />
+        <i
+          v-if="hasCategory(category)"
+          class="iconfont iconcheck1 absolute top-2 right-2 text-lg"
+        />
+      </Block>
+    </div>
+    <template v-slot:footer>
+      <div class="w-2/4 float-left pr-2">
+        <UiButton @click="handleClose" type="button" class="w-full">
+          {{ $t('cancel') }}
+        </UiButton>
+      </div>
+      <div class="w-2/4 float-left pl-2">
+        <UiButton
+          @click="handleSubmit"
+          :disabled="!selectedCategories.length"
+          type="submit"
+          class="w-full"
+          primary
+        >
+          {{ $t('confirm') }}
+        </UiButton>
+      </div>
+    </template>
+  </UiModal>
+</template>

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -146,6 +146,7 @@ export const SPACES_QUERY = gql`
       domain
       members
       admins
+      categories
       plugins
       voting {
         delay

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -128,6 +128,7 @@
   },
   "create": {
     "question": "Ask a question...",
+    "categorie(s)": "Select up to 2 categorie(s)",
     "content": "Tell more about your proposal (optional)",
     "preview": "Preview",
     "choices": "Choices",
@@ -194,6 +195,8 @@
     "customDomain": "Custom domain",
     "domain": "Domain name",
     "strategies": "Strategie(s)",
+    "categories": "Categorie(s)",
+    "selectCategories": "Select categories",
     "hideSpace": "Hide space from homepage",
     "addStrategy": "Add strategy",
     "authors": "Authors",

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -41,6 +41,7 @@ const currentStrategyIndex = ref(false);
 const modalNetworksOpen = ref(false);
 const modalSkinsOpen = ref(false);
 const modalStrategyOpen = ref(false);
+const modalCategoryOpen = ref(false);
 const modalVotingTypeOpen = ref(false);
 const modalPluginsOpen = ref(false);
 const modalValidationOpen = ref(false);
@@ -51,6 +52,7 @@ const delayUnit = ref('h');
 const periodUnit = ref('h');
 const form = ref({
   strategies: [],
+  categories: [],
   plugins: {},
   filters: {},
   voting: {},
@@ -104,6 +106,10 @@ const votingPeriod = computed({
       : undefined)
 });
 
+const categoriesString = computed(() => {
+  return form.value.categories ? form.value.categories.join(', ') : '';
+});
+
 const { filteredPlugins } = useSearchFilters();
 const plugins = computed(() => filteredPlugins());
 
@@ -151,6 +157,7 @@ function handleReset() {
   if (currentSettings.value) return (form.value = currentSettings.value);
   form.value = {
     strategies: [],
+    categories: [],
     plugins: {},
     filters: {}
   };
@@ -166,6 +173,10 @@ function handleRemoveStrategy(i) {
   form.value.strategies = form.value.strategies.filter(
     (strategy, index) => index !== i
   );
+}
+
+function handleSubmitAddCategories(categories) {
+  form.value.categories = categories;
 }
 
 function handleAddStrategy() {
@@ -361,6 +372,16 @@ watchEffect(async () => {
                 </template>
                 <template v-slot:label>
                   {{ $t(`settings.network`) }}*
+                </template>
+              </UiInput>
+              <UiInput @click="modalCategoryOpen = true">
+                <template v-slot:label>
+                  {{ $t(`settings.categories`) }}
+                </template>
+                <template v-slot:selected>
+                  <span class="capitalize">
+                    {{ categoriesString }}
+                  </span>
                 </template>
               </UiInput>
               <UiInput
@@ -651,6 +672,12 @@ watchEffect(async () => {
       :strategy="currentStrategy"
       @close="modalStrategyOpen = false"
       @add="handleSubmitAddStrategy"
+    />
+    <ModalCategory
+      :open="modalCategoryOpen"
+      :categories="form.categories"
+      @close="modalCategoryOpen = false"
+      @add="handleSubmitAddCategories"
     />
     <ModalPlugins
       :open="modalPluginsOpen"


### PR DESCRIPTION
Fixes #816

Changes proposed in this pull request:
- Category modal with multiselect.
scenarios:
1) when you click on confirm, applies the pre-selected categories
2) clicking cancel just closes the modal window
- In space settings page add space categories with displaying the selected categories
- default locales for categories
- add categories in graphQL query
