### PR TITLE
Add border hover effect to spaces, networks, strategies

### DIFF
--- a/src/components/Block/Network.vue
+++ b/src/components/Block/Network.vue
@@ -7,7 +7,7 @@ function getLogoUrl(key) {
 </script>
 
 <template>
-  <Block>
+  <Block class="hover-border">
     <div class="flex items-center mb-1">
       <UiAvatar
         class="mr-2 mb-2"

--- a/src/components/Block/Plugin.vue
+++ b/src/components/Block/Plugin.vue
@@ -7,7 +7,7 @@ function getLogoUrl(key) {
 </script>
 
 <template>
-  <Block>
+  <Block class="hover-border">
     <div class="flex items-center mb-1">
       <a
         :href="`https://github.com/snapshot-labs/snapshot-plugins/tree/master/src/plugins/${plugin.key}`"

--- a/src/components/Block/Strategy.vue
+++ b/src/components/Block/Strategy.vue
@@ -5,7 +5,7 @@ export default {
 </script>
 
 <template>
-  <Block>
+  <Block class="hover-border">
     <div class="flex items-baseline">
       <h3>
         {{ strategy.key }}

--- a/src/style.scss
+++ b/src/style.scss
@@ -248,6 +248,12 @@ select {
   }
 }
 
+.hover-border {
+  &:hover {
+    border-color: var(--link-color) !important;
+  }
+}
+
 .markdown-body blockquote {
   color: var(--text-color);
   border-left-color: var(--text-color);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -88,7 +88,7 @@ const { endElement } = useScrollMonitor(() => (limit.value += loadBy));
           <div>
             <!-- Added mb-0 to remove mb-4 added by block component -->
             <Block
-              class="text-center extra-icon-container mb-0"
+              class="text-center extra-icon-container mb-0 hover-border"
               style="height: 266px"
             >
               <div class="relative inline-block mb-2">


### PR DESCRIPTION
## Summary
Add hover border effect to spaces, networks, strategies and plugins as part of this https://github.com/snapshot-labs/snapshot/issues/1000

## Test
test it in localhost

- Spaces
![image](https://user-images.githubusercontent.com/3824034/142551230-9e7de8df-acf1-417b-be07-b216e95db181.png)
![image](https://user-images.githubusercontent.com/3824034/142551398-8ddf46a7-6a03-4148-a23f-28d54b710751.png)

- Networks
![image](https://user-images.githubusercontent.com/3824034/142551249-f98bb2c9-ee44-46c5-8ed8-2c66850513f5.png)
![image](https://user-images.githubusercontent.com/3824034/142551375-5e1f4b57-6c7a-4fff-9d0a-a6eb0490619f.png)

- Strategies
![image](https://user-images.githubusercontent.com/3824034/142551273-f614eff4-70b1-4834-8185-986d89e1c3b8.png)
![image](https://user-images.githubusercontent.com/3824034/142551364-3c0d3e6b-90f5-4ceb-9e93-faf36fbcc5b3.png)

- Plugins
![image](https://user-images.githubusercontent.com/3824034/142551286-18bdc9e6-48a3-4a94-9701-a588f7dee4e0.png)
![image](https://user-images.githubusercontent.com/3824034/142551340-8b4a14f5-5ab8-4a40-94e4-352fb4789e41.png)

## Reviewers
@bonustrack 