### PR TITLE
watch votes array to catch initial load

### DIFF
--- a/src/components/Block/Votes.vue
+++ b/src/components/Block/Votes.vue
@@ -68,7 +68,7 @@ watch(votes, () => {
   sortedVotes.value = votes;
 });
 
-watch(nbrVisibleVotes, () => {
+watch([nbrVisibleVotes, sortedVotes], () => {
   updateAddressArray(
     sortedVotes.value.slice(0, nbrVisibleVotes.value).map(vote => vote.voter)
   );

--- a/src/components/Block/Votes.vue
+++ b/src/components/Block/Votes.vue
@@ -68,7 +68,7 @@ watch(votes, () => {
   sortedVotes.value = votes;
 });
 
-watch([nbrVisibleVotes, sortedVotes], () => {
+watch(visibleVotes, () => {
   updateAddressArray(
     sortedVotes.value.slice(0, nbrVisibleVotes.value).map(vote => vote.voter)
   );

--- a/src/components/Block/Votes.vue
+++ b/src/components/Block/Votes.vue
@@ -53,7 +53,7 @@ function openReceiptModal(vote) {
   modalReceiptOpen.value = true;
 }
 
-const { profiles, updateAddressArray } = useProfiles();
+const { profiles, loadProfiles } = useProfiles();
 
 watch(votes, () => {
   const votes = props.votes;
@@ -69,7 +69,7 @@ watch(votes, () => {
 });
 
 watch(visibleVotes, () => {
-  updateAddressArray(
+  loadProfiles(
     sortedVotes.value.slice(0, nbrVisibleVotes.value).map(vote => vote.voter)
   );
 });

--- a/src/composables/useProfiles.ts
+++ b/src/composables/useProfiles.ts
@@ -1,37 +1,27 @@
 import { getProfiles } from '@/helpers/profile';
-import { ref, computed, watch } from 'vue';
+import { ref } from 'vue';
 
 const profiles = ref({});
-const addressArray = ref<string[]>([]);
-
-const filteredArray = computed(() =>
-  addressArray.value.filter(address => {
-    return !Object.keys(profiles.value).includes(address);
-  })
-);
-
-watch(addressArray, async () => {
-  console.time('getProfiles');
-  const response =
-    filteredArray.value.length > 0
-      ? await getProfiles(filteredArray.value)
-      : {};
-  console.timeEnd('getProfiles');
-
-  profiles.value = { ...profiles.value, ...response };
-});
 
 export function useProfiles() {
-  const updateAddressArray = (addresses: string[]) => {
+  
+  const loadProfiles = async (addresses: string[]) => {
     const addressesToAdd = addresses.filter(
-      address => !addressArray.value.includes(address)
+      address => !Object.keys(profiles.value).includes(address)
     );
 
-    addressArray.value = addressArray.value.concat(addressesToAdd);
+    console.time('getProfiles');
+    const response =
+      addressesToAdd.length > 0
+        ? await getProfiles(addressesToAdd)
+        : {};
+    console.timeEnd('getProfiles');
+
+    profiles.value = { ...profiles.value, ...response };
   };
 
   return {
     profiles,
-    updateAddressArray
+    loadProfiles
   };
 }

--- a/src/composables/useProfiles.ts
+++ b/src/composables/useProfiles.ts
@@ -1,10 +1,14 @@
 import { getProfiles } from '@/helpers/profile';
 import { ref } from 'vue';
 
+// holds profile data (ENS name/images) for all addresses appearing in the frontend
 const profiles = ref({});
 
 export function useProfiles() {
   
+  /**
+   * Populates global ref with profile data for batches of addresses.
+   */
   const loadProfiles = async (addresses: string[]) => {
     const addressesToAdd = addresses.filter(
       address => !Object.keys(profiles.value).includes(address)

--- a/src/composables/useProfiles.ts
+++ b/src/composables/useProfiles.ts
@@ -4,6 +4,23 @@ import { ref, computed, watch } from 'vue';
 const profiles = ref({});
 const addressArray = ref<string[]>([]);
 
+const filteredArray = computed(() =>
+  addressArray.value.filter(address => {
+    return !Object.keys(profiles.value).includes(address);
+  })
+);
+
+watch(addressArray, async () => {
+  console.time('getProfiles');
+  const response =
+    filteredArray.value.length > 0
+      ? await getProfiles(filteredArray.value)
+      : {};
+  console.timeEnd('getProfiles');
+
+  profiles.value = { ...profiles.value, ...response };
+});
+
 export function useProfiles() {
   const updateAddressArray = (addresses: string[]) => {
     const addressesToAdd = addresses.filter(
@@ -12,23 +29,6 @@ export function useProfiles() {
 
     addressArray.value = addressArray.value.concat(addressesToAdd);
   };
-
-  const filteredArray = computed(() =>
-    addressArray.value.filter(address => {
-      return !Object.keys(profiles.value).includes(address);
-    })
-  );
-
-  watch(addressArray, async () => {
-    console.time('getProfiles');
-    const response =
-      filteredArray.value.length > 0
-        ? await getProfiles(filteredArray.value)
-        : {};
-    console.timeEnd('getProfiles');
-
-    profiles.value = { ...profiles.value, ...response };
-  });
 
   return {
     profiles,

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -49,7 +49,7 @@ const form = ref({
   id: route.params.key || ''
 });
 
-const { profiles, updateAddressArray } = useProfiles();
+const { profiles, loadProfiles } = useProfiles();
 
 const web3Account = computed(() => web3.value.account);
 const networkKey = computed(() => web3.value.network.key);
@@ -169,7 +169,7 @@ async function getDelegatesWithScore() {
 }
 
 watchEffect(() => {
-  updateAddressArray(
+  loadProfiles(
     delegates.value
       .map(delegate => delegate.delegate)
       .concat(delegators.value.map(delegator => delegator.delegator))

--- a/src/views/SpaceAbout.vue
+++ b/src/views/SpaceAbout.vue
@@ -11,11 +11,11 @@ const props = defineProps({
 
 const network = computed(() => networks[props.space.network]);
 
-const { profiles, updateAddressArray } = useProfiles();
+const { profiles, loadProfiles } = useProfiles();
 
 watchEffect(() => {
   if (props.space.admins)
-    updateAddressArray(props.space.admins.concat(props.space.members));
+    loadProfiles(props.space.admins.concat(props.space.members));
 });
 </script>
 

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -182,10 +182,10 @@ function selectFromShareDropdown(e) {
     shareToClipboard(props.space, proposal.value);
 }
 
-const { profiles, updateAddressArray } = useProfiles();
+const { profiles, loadProfiles } = useProfiles();
 
 watch(proposal, () => {
-  updateAddressArray([proposal.value.author]);
+  loadProfiles([proposal.value.author]);
 });
 
 watch(web3Account, (val, prev) => {

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -65,10 +65,10 @@ function selectState(e) {
   load();
 }
 
-const { profiles, updateAddressArray } = useProfiles();
+const { profiles, loadProfiles } = useProfiles();
 
 watch(proposals, () => {
-  updateAddressArray(proposals.value.map(proposal => proposal.author));
+  loadProfiles(proposals.value.map(proposal => proposal.author));
 });
 
 watch([proposals, web3Account], () => {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -55,10 +55,10 @@ async function loadProposals(skip = 0) {
   proposals.value = proposals.value.concat(proposalsObj);
 }
 
-const { profiles, updateAddressArray } = useProfiles();
+const { profiles, loadProfiles } = useProfiles();
 
 watch(proposals, () => {
-  updateAddressArray(proposals.value.map(proposal => proposal.author));
+  loadProfiles(proposals.value.map(proposal => proposal.author));
 });
 
 // Initialize


### PR DESCRIPTION
Fixes #1036 

The `updateAddressArray` function in `Votes.vue` was called only when the number of votes to show in the list changed, thus on click on "see more". Now also watching votes array itself, so it runs after they are loaded initially.
