### PR TITLE
avoid redundant prop update

### DIFF
--- a/src/components/Block/Votes.vue
+++ b/src/components/Block/Votes.vue
@@ -69,9 +69,7 @@ watch(votes, () => {
 });
 
 watch(visibleVotes, () => {
-  loadProfiles(
-    sortedVotes.value.slice(0, nbrVisibleVotes.value).map(vote => vote.voter)
-  );
+  loadProfiles(visibleVotes.value.map(vote => vote.voter));
 });
 </script>
 

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -111,11 +111,11 @@ async function loadResults() {
     });
     loadedVotes.value = true;
   } else {
-    votes.value = await getProposalVotes(id);
+    const votesTmp = await getProposalVotes(id);
     const resultsObj = await getResults(
       props.space,
       proposal.value,
-      votes.value
+      votesTmp
     );
     results.value = resultsObj.results;
     loadedResults.value = true;


### PR DESCRIPTION
For proposals with `state != 'final'` `votes.value` was assigned twice, triggering watchers multiple times.
**The general rule here I think is: You should avoid assigning temporary values to properties that are meant to be displayed. If something's temporary, keep it local and don't render it.**

Also for the `visibleVotes` watcher, the existing property is used now, instead of slicing `sortedVotes` twice.