### PR TITLE
Basic voting "hide abstain" option

### DIFF
--- a/src/components/Block/Results.vue
+++ b/src/components/Block/Results.vue
@@ -28,8 +28,7 @@ const choices = computed(() =>
 
 const getPercentage = (n, of) => 100 / of * n / 1e2;
 
-// TODO: take from space settings
-const hideAbstain = true;
+const hideAbstain = props.space?.voting?.hideAbstain ?? false;
 </script>
 
 <template>

--- a/src/components/Block/Results.vue
+++ b/src/components/Block/Results.vue
@@ -26,7 +26,7 @@ const choices = computed(() =>
     )
 );
 
-const getPercentage = (n, of) => 100 / of * n / 1e2;
+const getPercentage = (n, max) => 100 / max * n / 1e2;
 
 const hideAbstain = props.space?.voting?.hideAbstain ?? false;
 </script>

--- a/src/components/Block/Results.vue
+++ b/src/components/Block/Results.vue
@@ -25,6 +25,11 @@ const choices = computed(() =>
         props.results.resultsByVoteBalance[a.i]
     )
 );
+
+const getPercentage = (n, of) => 100 / of * n / 1e2;
+
+// TODO: take from space settings
+const hideAbstain = true;
 </script>
 
 <template>
@@ -33,45 +38,64 @@ const choices = computed(() =>
     :title="ts >= proposal.end ? $t('results') : $t('currentResults')"
   >
     <div v-for="choice in choices" :key="choice.i">
-      <div class="link-color mb-1">
-        <span
-          v-tippy="{
-            content: choice.choice.length > 12 ? choice.choice : null
-          }"
-          class="mr-1"
-          v-text="_shorten(choice.choice, 'choice')"
-        />
+      <template v-if="!(proposal.type === 'basic' && hideAbstain && choice.i === 2)">
+        <div class="link-color mb-1">
+          <span
+            v-tippy="{
+              content: choice.choice.length > 12 ? choice.choice : null
+            }"
+            class="mr-1"
+            v-text="_shorten(choice.choice, 'choice')"
+          />
 
-        <span
-          class="inline-block"
-          v-tippy="{
-            content: results.resultsByStrategyScore[choice.i]
-              .map((score, index) => `${_n(score)} ${titles[index]}`)
-              .join(' + ')
-          }"
-        >
-          {{ _n(results.resultsByVoteBalance[choice.i]) }}
-          {{ _shorten(space.symbol, 'symbol') }}
-        </span>
-        <span
-          class="float-right"
-          v-text="
-            _n(
-              !results.sumOfResultsBalance
-                ? 0
-                : ((100 / results.sumOfResultsBalance) *
-                    results.resultsByVoteBalance[choice.i]) /
-                    1e2,
-              '0.[00]%'
-            )
-          "
+          <span
+            class="inline-block"
+            v-tippy="{
+              content: results.resultsByStrategyScore[choice.i]
+                .map((score, index) => `${_n(score)} ${titles[index]}`)
+                .join(' + ')
+            }"
+          >
+            {{ _n(results.resultsByVoteBalance[choice.i]) }}
+            {{ _shorten(space.symbol, 'symbol') }}
+          </span>
+          <span
+            v-if="proposal.type === 'basic' && hideAbstain && choice.i === 0"
+            class="float-right"
+            v-text="
+              _n(
+                getPercentage(results.resultsByVoteBalance[0], results.resultsByVoteBalance[0] + results.resultsByVoteBalance[1]),
+                '0.[00]%'
+              )
+            "
+          />
+          <span
+            v-else-if="proposal.type === 'basic' && hideAbstain && choice.i === 1"
+            class="float-right"
+            v-text="
+              _n(
+                getPercentage(results.resultsByVoteBalance[1], results.resultsByVoteBalance[0] + results.resultsByVoteBalance[1]),
+                '0.[00]%'
+              )
+            "
+          />
+          <span
+            v-else
+            class="float-right"
+            v-text="
+              _n(
+                getPercentage(results.resultsByVoteBalance[choice.i], results.sumOfResultsBalance),
+                '0.[00]%'
+              )
+            "
+          />
+        </div>
+        <UiProgress
+          :value="results.resultsByStrategyScore[choice.i]"
+          :max="proposal.type === 'basic' && hideAbstain ? results.resultsByVoteBalance[0] + results.resultsByVoteBalance[1] : results.sumOfResultsBalance"
+          class="mb-3"
         />
-      </div>
-      <UiProgress
-        :value="results.resultsByStrategyScore[choice.i]"
-        :max="results.sumOfResultsBalance"
-        class="mb-3"
-      />
+      </template>
     </div>
     <div v-if="props.space?.voting?.quorum" class="text-skin-link">
       {{ $t('settings.quorum') }}

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -158,6 +158,7 @@ export const SPACES_QUERY = gql`
         period
         type
         quorum
+        hideAbstain
       }
       strategies {
         name

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -222,7 +222,7 @@
     "quorum": "Quorum",
     "type": "Type",
     "anyType": "Any",
-    "hideAbstain": "Ignore abstain votes in basic voting results."
+    "hideAbstain": "Ignore abstain votes in basic voting results"
   },
   "setup": {
     "example": "e.g. yam.eth",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -221,7 +221,8 @@
     "voting": "Voting",
     "quorum": "Quorum",
     "type": "Type",
-    "anyType": "Any"
+    "anyType": "Any",
+    "hideAbstain": "Ignore abstain votes in basic voting results."
   },
   "setup": {
     "example": "e.g. yam.eth",

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -588,6 +588,15 @@ watchEffect(async () => {
                 </select>
               </template>
             </UiInput>
+            <UiInput
+              v-model="form.voting.quorum"
+              :number="true"
+              placeholder="1000"
+            >
+              <template v-slot:label>
+                {{ $t('settings.quorum') }}
+              </template>
+            </UiInput>
             <UiInput>
               <template v-slot:label>
                 {{ $t('settings.type') }}
@@ -602,15 +611,10 @@ watchEffect(async () => {
                 </div>
               </template>
             </UiInput>
-            <UiInput
-              v-model="form.voting.quorum"
-              :number="true"
-              placeholder="1000"
-            >
-              <template v-slot:label>
-                {{ $t('settings.quorum') }}
-              </template>
-            </UiInput>
+            <div class="flex items-center px-2 mb-2">
+              <Checkbox v-model="form.voting.hideAbstain" class="mr-2 mt-1" />
+              {{ $t('settings.hideAbstain') }}
+            </div>
           </Block>
           <Block :title="$t('plugins')">
             <div v-if="form?.plugins">


### PR DESCRIPTION
Fixes #1120

Hub PR: https://github.com/snapshot-labs/snapshot-hub/pull/203

![image](https://user-images.githubusercontent.com/6792578/143506505-cde643de-c329-4b09-b497-224dc6e87c65.png)

`hideAbstain = false`
![image](https://user-images.githubusercontent.com/6792578/143506515-453798f7-3268-4197-b0d6-ff8d65c1ef46.png)

`hideAbstain = true`
![image](https://user-images.githubusercontent.com/6792578/143506524-76c05038-a1d5-4b65-bc54-bf763dc8dde5.png)

Using multiple strategies (2x `eth-balance`) to see the split progress bar.