### PR TITLE
💬 Text: More Copy updates

### DIFF
--- a/src/locales/ar-SA.json
+++ b/src/locales/ar-SA.json
@@ -306,7 +306,7 @@
     "no_poap_header": "لم يتم إعداد POAP لهذا الاقتراح بعد :'(",
     "no_voted_header": "التصويت للحصول على هذا POAP",
     "unclaimed_header": "المطالبة بأنني صوتت على POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "تم إضافة POAP إلى مجموعتك",
     "button_claim": "الحصول عليه",
     "button_show": "تصفح المجموعة",

--- a/src/locales/bn-BD.json
+++ b/src/locales/bn-BD.json
@@ -306,7 +306,7 @@
     "no_poap_header": "এই প্রস্তাবটির জন্য একটি POAPএখনও সেটআপ করা হয়নি: '(",
     "no_voted_header": "এই POAP পেতে ভোট দিন",
     "unclaimed_header": "আপনার দাবি করুন আমি ভোট দিয়েছি POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "আপনার সংগ্রহে POAP যোগ করা হচ্ছে",
     "button_claim": "দাবি",
     "button_show": "Browse collection",

--- a/src/locales/cs-CZ.json
+++ b/src/locales/cs-CZ.json
@@ -306,7 +306,7 @@
     "no_poap_header": "POAP zatím nebylo nastaveno pro tento návrh :'(",
     "no_voted_header": "Hlasujte pro získání tohoto POAP",
     "unclaimed_header": "Požádejte o svůj hlas POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP je přidáváno do vaší kolekce",
     "button_claim": "Území",
     "button_show": "Browse collection",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -306,7 +306,7 @@
     "no_poap_header": "En POAP er ikke blevet opsat til dette forslag endnu :' (",
     "no_voted_header": "Stem for at få denne POAP",
     "unclaimed_header": "Gør krav på din jeg stemte POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP'en bliver tilføjet til din samling",
     "button_claim": "Modtag",
     "button_show": "Browse collection",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -306,7 +306,7 @@
     "no_poap_header": "Ein POAP wurde für diesen Vorschlag noch nicht eingerichtet :'(",
     "no_voted_header": "Stimme ab um diesen POAP zu erhalten",
     "unclaimed_header": "Beanspruche deinen POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "Der POAP wird Ihrer Sammlung hinzugefügt",
     "button_claim": "Beanspruchen",
     "button_show": "Browse collection",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -323,10 +323,10 @@
   "poap": {
     "no_poap_header": "A POAP hasn't been setup for this proposal yet :'(",
     "no_voted_header": "Vote to get this POAP",
-    "unclaimed_header": "Mint",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "unclaimed_header": "Mint your I voted POAP",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "The POAP is being minted to your collection",
-    "button_claim": "Claim",
+    "button_claim": "Mint",
     "button_show": "Browse collection",
     "success_claim": "The POAP has been minted to your collection",
     "error_claim": "There was a problem minting the token"

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -305,8 +305,8 @@
   "poap": {
     "no_poap_header": "Aun no se ha creado un POAP para esta oferta :'(",
     "no_voted_header": "Vote para obtener este POAP",
-    "unclaimed_header": "Mint",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "unclaimed_header": "Mint your I voted POAP",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "The POAP is being minted to your collection",
     "button_claim": "Reclamar",
     "button_show": "Browse collection",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -306,7 +306,7 @@
     "no_poap_header": "POAP-palvelua ei ole vielä perustettu tälle ehdotukselle: '(",
     "no_voted_header": "Äänestää saadaksesi tämän POAP: n",
     "unclaimed_header": "Lunasta sinun äänestin POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP on lisätty kokoelmaasi",
     "button_claim": "Lunasta",
     "button_show": "Browse collection",

--- a/src/locales/fil-PH.json
+++ b/src/locales/fil-PH.json
@@ -305,10 +305,10 @@
   "poap": {
     "no_poap_header": "A POAP hasn't been setup for this proposal yet :'(",
     "no_voted_header": "Vote to get this POAP",
-    "unclaimed_header": "Mint",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "unclaimed_header": "Mint your I voted POAP",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "The POAP is being minted to your collection",
-    "button_claim": "Claim",
+    "button_claim": "Mint",
     "button_show": "Browse collection",
     "success_claim": "The POAP has been minted to your collection",
     "error_claim": "There was a problem minting the token"

--- a/src/locales/he-IL.json
+++ b/src/locales/he-IL.json
@@ -306,7 +306,7 @@
     "no_poap_header": "עוד לא נוצר POAP להצעה זו :'(",
     "no_voted_header": "הצבעה בכדי לקבל POAP זה",
     "unclaimed_header": "קבל את ה-POAP שלך",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "ה-POAP מתווסף לקולקציה שלך ברגע זה",
     "button_claim": "תבע",
     "button_show": "Browse collection",

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -306,7 +306,7 @@
     "no_poap_header": "इस प्रस्ताव के लिए अभी तक POAP सेटअप नहीं किया गया है :'(",
     "no_voted_header": "इस POAP को पाने के लिए वोट करें",
     "unclaimed_header": "दावा करें कि मैंने पीओएपी को वोट दिया है",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP को आपके संग्रह में जोड़ा जा रहा है",
     "button_claim": "दावा करें",
     "button_show": "Browse collection",

--- a/src/locales/id-ID.json
+++ b/src/locales/id-ID.json
@@ -306,7 +306,7 @@
     "no_poap_header": "POAP belum dipersiapkan untuk proposal ini :'(",
     "no_voted_header": "Pilih untuk menerima POAP",
     "unclaimed_header": "Klaim POAP voting anda",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP ini dimasukan kedalam koleksi anda",
     "button_claim": "Klaim",
     "button_show": "Browse collection",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -306,7 +306,7 @@
     "no_poap_header": "Non è stato ancora stabilito un POAP per questa proposta: '(",
     "no_voted_header": "Vota per ottenere questo POAP",
     "unclaimed_header": "Rivendica il tuo voto POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "Il POAP è stato aggiunto alla tua raccolta",
     "button_claim": "Rivendica",
     "button_show": "Browse collection",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -305,10 +305,10 @@
   "poap": {
     "no_poap_header": "A POAP hasn't been setup for this proposal yet :'(",
     "no_voted_header": "Vote to get this POAP",
-    "unclaimed_header": "Mint",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "unclaimed_header": "Mint your I voted POAP",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "The POAP is being minted to your collection",
-    "button_claim": "Claim",
+    "button_claim": "Mint",
     "button_show": "Browse collection",
     "success_claim": "The POAP has been minted to your collection",
     "error_claim": "There was a problem minting the token"

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -306,7 +306,7 @@
     "no_poap_header": "ㅏ피영형에이피 이 제안은 아직 설정되지 않았습니다:'(",
     "no_voted_header": "이것을 얻으려면 투표하십시오 피영형에이피",
     "unclaimed_header": "내가 당신의 내가 투표를 요구했다 피영형에이피",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "그만큼 피영형에이피 컬렉션에 추가되고",
     "button_claim": "청구",
     "button_show": "Browse collection",

--- a/src/locales/mr-IN.json
+++ b/src/locales/mr-IN.json
@@ -306,7 +306,7 @@
     "no_poap_header": "या प्रस्तावासाठी अद्याप एक पीओएपी सेट केला गेला नाही :'(",
     "no_voted_header": "हे पीओएपी मिळविण्यासाठी मतदान करा",
     "unclaimed_header": "आपला मी मत नोंदविलेला पीओएपी चा दावा करा",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "आपल्या संग्रहात पीओएपी जोडला जात आहे",
     "button_claim": "दावा करा",
     "button_show": "Browse collection",

--- a/src/locales/nl-NL.json
+++ b/src/locales/nl-NL.json
@@ -306,7 +306,7 @@
     "no_poap_header": "Er is nog geen POAP ingesteld voor dit voorstel :'(",
     "no_voted_header": "Stem om deze POAP te krijgen",
     "unclaimed_header": "Claim je stem op POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "De POAP wordt toegevoegd aan je collectie",
     "button_claim": "Claimen",
     "button_show": "Browse collection",

--- a/src/locales/pl-PL.json
+++ b/src/locales/pl-PL.json
@@ -305,10 +305,10 @@
   "poap": {
     "no_poap_header": "A POAP hasn't been setup for this proposal yet :'(",
     "no_voted_header": "Vote to get this POAP",
-    "unclaimed_header": "Mint",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "unclaimed_header": "Mint your I voted POAP",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "The POAP is being minted to your collection",
-    "button_claim": "Claim",
+    "button_claim": "Mint",
     "button_show": "Browse collection",
     "success_claim": "The POAP has been minted to your collection",
     "error_claim": "There was a problem minting the token"

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -306,7 +306,7 @@
     "no_poap_header": "Um POAP ainda não foi configurado para esta proposta :'(",
     "no_voted_header": "Vote para obter este POAP",
     "unclaimed_header": "Reivindique seu voto no POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "O POAP está sendo adicionado à sua coleção",
     "button_claim": "Reivindicar",
     "button_show": "Browse collection",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -306,7 +306,7 @@
     "no_poap_header": "POAP еще не был настроен для этого предложения :'(",
     "no_voted_header": "Проголосуйте, чтобы получить этот POAP",
     "unclaimed_header": "Я проголосовал, забрать свой POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP добавляется в вашу коллекцию",
     "button_claim": "Получить",
     "button_show": "Browse collection",

--- a/src/locales/sh-HR.json
+++ b/src/locales/sh-HR.json
@@ -305,10 +305,10 @@
   "poap": {
     "no_poap_header": "A POAP hasn't been setup for this proposal yet :'(",
     "no_voted_header": "Vote to get this POAP",
-    "unclaimed_header": "Mint",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "unclaimed_header": "Mint your I voted POAP",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "The POAP is being minted to your collection",
-    "button_claim": "Claim",
+    "button_claim": "Mint",
     "button_show": "Browse collection",
     "success_claim": "The POAP has been minted to your collection",
     "error_claim": "There was a problem minting the token"

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -306,7 +306,7 @@
     "no_poap_header": "En POAP har inte installerats för detta förslag ännu :'(",
     "no_voted_header": "Rösta för att få denna POAP",
     "unclaimed_header": "Gör anspråk på din jag röstade på POAP",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP läggs till i din kollektion",
     "button_claim": "Anspråk",
     "button_show": "Browse collection",

--- a/src/locales/te-IN.json
+++ b/src/locales/te-IN.json
@@ -305,10 +305,10 @@
   "poap": {
     "no_poap_header": "A POAP hasn't been setup for this proposal yet :'(",
     "no_voted_header": "Vote to get this POAP",
-    "unclaimed_header": "Mint",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "unclaimed_header": "Mint your I voted POAP",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "The POAP is being minted to your collection",
-    "button_claim": "Claim",
+    "button_claim": "Mint",
     "button_show": "Browse collection",
     "success_claim": "The POAP has been minted to your collection",
     "error_claim": "There was a problem minting the token"

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -305,10 +305,10 @@
   "poap": {
     "no_poap_header": "A POAP hasn't been setup for this proposal yet :'(",
     "no_voted_header": "Vote to get this POAP",
-    "unclaimed_header": "Mint",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "unclaimed_header": "Mint your I voted POAP",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "The POAP is being minted to your collection",
-    "button_claim": "Claim",
+    "button_claim": "Mint",
     "button_show": "Browse collection",
     "success_claim": "The POAP has been minted to your collection",
     "error_claim": "There was a problem minting the token"

--- a/src/locales/tr-TR.json
+++ b/src/locales/tr-TR.json
@@ -306,7 +306,7 @@
     "no_poap_header": "Bu teklif için henüz bir POAP kurulmadı :'(",
     "no_voted_header": "Bu POAP'ı almak için oy verin",
     "unclaimed_header": "Oy verdiğiniz POAP'ınızı talep edin",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP topladıklarınıza ekleniyor",
     "button_claim": "Topla",
     "button_show": "Browse collection",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -306,7 +306,7 @@
     "no_poap_header": "POAP ще не налаштований для цієї пропозиції :'(",
     "no_voted_header": "Проголосуйте, щоб отримати POAP",
     "unclaimed_header": "Отримайте свій POAP за те що проголосували",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP в процесі додавання до вашої колекції",
     "button_claim": "Забрати",
     "button_show": "Browse collection",

--- a/src/locales/ur-IN.json
+++ b/src/locales/ur-IN.json
@@ -306,7 +306,7 @@
     "no_poap_header": "ابھی تک اس تجویز کے لئے ایک POAP ترتیب نہیں دیا گیا ہے: '(",
     "no_voted_header": "اس POAP کو حاصل کرنے کے لئے ووٹ دیں",
     "unclaimed_header": "آپ کا دعوی کریں کہ میں نے پی او اے پی کو ووٹ دیا ہے",
-    "claimed_header": "Congratulations! The POAP has been minted to your account",
+    "claimed_header": "Congratulations! The POAP has been minted to your collection",
     "loading_header": "POAP آپ کے جمع کرنے میں شامل کیا جارہا ہے",
     "button_claim": "دعوی",
     "button_show": "Browse collection",


### PR DESCRIPTION
Updated multiple locales

Instead of ``Mint`` (in header) say --> ``Mint your I voted POAP``.
Instead of ``Claim`` (in button) say --> ``Mint``
Instead of ``Congratulations! The POAP has been minted to your account`` say --> ``Congratulations! The POAP has been minted to your collection``