### PR TITLE
Dropdown improvements

### DIFF
--- a/src/components/Ui/Dropdown.vue
+++ b/src/components/Ui/Dropdown.vue
@@ -44,7 +44,12 @@ onBeforeUnmount(() => window.removeEventListener('click', close));
     </div>
     <div class="sub-menu-wrapper" :class="{ hidden: !open }" :style="cssVars">
       <ul class="sub-menu my-2">
-        <li v-for="item in items" :key="item" @click="handleClick(item.action)" :class="{ selected: item.selected }">
+        <li
+          v-for="item in items"
+          :key="item"
+          @click="handleClick(item.action)"
+          :class="{ selected: item.selected }"
+        >
           <slot name="item" :item="item" :key="key">
             <Icon
               v-if="item.icon"

--- a/src/components/Ui/Dropdown.vue
+++ b/src/components/Ui/Dropdown.vue
@@ -44,7 +44,7 @@ onBeforeUnmount(() => window.removeEventListener('click', close));
     </div>
     <div class="sub-menu-wrapper" :class="{ hidden: !open }" :style="cssVars">
       <ul class="sub-menu my-2">
-        <li v-for="item in items" :key="item" @click="handleClick(item.action)">
+        <li v-for="item in items" :key="item" @click="handleClick(item.action)" :class="{ selected: item.selected }">
           <Icon
             v-if="item.icon"
             :name="item.icon"
@@ -82,6 +82,7 @@ li.disabled {
   cursor: not-allowed;
 }
 
+li.selected,
 li:hover {
   background-color: var(--border-color);
   color: var(--link-color);

--- a/src/components/Ui/Dropdown.vue
+++ b/src/components/Ui/Dropdown.vue
@@ -45,13 +45,15 @@ onBeforeUnmount(() => window.removeEventListener('click', close));
     <div class="sub-menu-wrapper" :class="{ hidden: !open }" :style="cssVars">
       <ul class="sub-menu my-2">
         <li v-for="item in items" :key="item" @click="handleClick(item.action)" :class="{ selected: item.selected }">
-          <Icon
-            v-if="item.icon"
-            :name="item.icon"
-            size="21"
-            class="align-middle mr-2"
-          />
-          {{ item.text }}
+          <slot name="item" :item="item" :key="key">
+            <Icon
+              v-if="item.icon"
+              :name="item.icon"
+              size="21"
+              class="align-middle mr-2"
+            />
+            {{ item.text }}
+          </slot>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Allows custom HTML for items.

```html
<UiDropdown :items="[...]">
  <UiButton>
    My Button
  </UiButton>
  <template v-slot:item="{ item }">
    {{ item.text }}
    <span class="badge">{{ item.count }}</span>
  </template>
</UiDropdown>
```

The item slot defaults to what it was before:

```html
<Icon
  v-if="item.icon"
  :name="item.icon"
  size="21"
  class="align-middle mr-2"
/>
{{ item.text }}
```

Second change: If an item has a `selected` property, it now adds a `selected` class to the `<li>`, sharing same style with hover state.

E.g.:
```html
<UiDropdown
  :items="[
    { text: $t('proposals.states.all'), action: 'all', selected: filterBy === 'all' },
    ...
  }"
>
```

![image](https://user-images.githubusercontent.com/6792578/143932686-1768ee59-9422-42b9-9ee2-becb9afe7796.png)
