### PR TITLE
fixed: aboutPage margin style

### DIFF
--- a/src/views/SpaceAbout.vue
+++ b/src/views/SpaceAbout.vue
@@ -51,7 +51,7 @@ watchEffect(() => {
             (!space.validation || space.validation?.name === 'basic') &&
             space.filters?.minScore
           "
-          class="mb-3"
+          :class="{'mb-3': space.terms || space.strategies || Object.keys(space.plugins || {}).length }"
         >
           <h4 class="link-color mb-2">
             {{ $t('settings.proposalThreshold') }}
@@ -59,7 +59,7 @@ watchEffect(() => {
           {{ _n(space.filters.minScore) }} {{ space.symbol }}
         </div>
 
-        <div v-if="space.terms" class="mb-3">
+        <div v-if="space.terms" :class="{'mb-3': space.strategies || Object.keys(space.plugins || {}).length }">
           <h4 class="link-color mb-2">{{ $t('settings.terms') }}</h4>
           <a :href="space.terms" target="_blank" rel="noopener noreferrer">
             <UiText :text="getUrl(space.terms)" :truncate="35" />
@@ -67,14 +67,14 @@ watchEffect(() => {
           </a>
         </div>
 
-        <div v-if="space.strategies" class="mb-3">
+        <div v-if="space.strategies" :class="{'mb-3': Object.keys(space.plugins || {}).length}">
           <h4 class="link-color mb-2">{{ $t('settings.strategies') }}</h4>
           <div v-for="(strategy, i) in space.strategies" :key="i">
             <div>{{ strategy.name }}</div>
           </div>
         </div>
 
-        <div v-if="Object.keys(space.plugins || {}).length" class="mb-3">
+        <div v-if="Object.keys(space.plugins || {}).length">
           <h4 class="link-color mb-2">{{ $t('plugins') }}</h4>
           <div v-for="(plugin, i) in space.plugins" :key="i">
             <div>{{ i }}</div>


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- There is a problem with the use of the margin style on the about page. The last element should not have a lower margin

before fix:
![image](https://user-images.githubusercontent.com/12671205/144445475-ab38d71e-d50b-48fe-8ba9-468dfd9db9d5.png)

fixed:
![image](https://user-images.githubusercontent.com/12671205/144445511-0371241c-a078-4975-95d0-317df3190f2c.png)

