### PR TITLE
Delegate Call does not need transaction value.

### DIFF
--- a/src/helpers/abi/utils.ts
+++ b/src/helpers/abi/utils.ts
@@ -303,10 +303,7 @@ export const multiSendTransaction = (
       .map(encodePackageMultiSendTransaction)
       .map(removeHexPrefix)
       .join('');
-  const value: string = transactions.reduce(
-    (total, tx) => BigNumber.from(tx.value).add(total).toString(),
-    '0'
-  );
+  const value: string = '0';
   const data = multiSendContract.encodeFunctionData('multiSend', [
     transactionsEncoded
   ]);


### PR DESCRIPTION
@rmeissner mentioned that delegate calls don't need transaction value. So we can just hardcode this to 0.
