### PR TITLE
TimelineProposalPreview shows time since starting date instead of rem…

### DIFF
--- a/src/components/TimelineProposalPreview.vue
+++ b/src/components/TimelineProposalPreview.vue
@@ -93,7 +93,7 @@ watchEffect(() => {
           {{ $t(`proposals.states.${proposal.state}`) }},
           <span
             v-if="proposal.scores_state !== 'final'"
-            v-text="$tc(period, [_toNow(proposal.start)])"
+            v-text="$tc(period, [_toNow(proposal.end)])"
           />
           <span v-if="proposal.scores_state === 'final'" class="mt-2">
             {{ _n(proposal.votes, '0,00') }} votes


### PR DESCRIPTION
The TimelineProposalPreview component shows all active proposals, with a text "XYZ time left".
the time is calculated from the proposal.start time instead of proposal.end, giving the wrong amount of remaining time.

In the following example the displayed time should be something similar to "14 days left" 

<img width="334" alt="image" src="https://user-images.githubusercontent.com/1133032/144810467-07332bff-206d-406f-a0c9-e85e4a7cca5e.png">


<img width="550" alt="image" src="https://user-images.githubusercontent.com/1133032/144810448-3856d3c6-b153-439b-8ba2-023a7176a9ce.png">


