### PR TITLE
chore: use `space-y-2` instead of `mb-2`

### DIFF
--- a/src/components/Modal/Account.vue
+++ b/src/components/Modal/Account.vue
@@ -93,10 +93,7 @@ watch(open, () => (step.value = null));
         <UiButton @click="step = 'connect'" class="button-outline w-full mb-2">
           {{ $t('connectWallet') }}
         </UiButton>
-        <UiButton
-          @click="handleLogout"
-          class="button-outline w-full !text-red mb-2"
-        >
+        <UiButton @click="handleLogout" class="button-outline w-full !text-red">
           {{ $t('logout') }}
         </UiButton>
       </div>

--- a/src/components/Modal/Account.vue
+++ b/src/components/Modal/Account.vue
@@ -71,11 +71,11 @@ watch(open, () => (step.value = null));
       </div>
     </div>
     <div v-else>
-      <div v-if="$auth.isAuthenticated.value" class="m-4">
+      <div v-if="$auth.isAuthenticated.value" class="m-4 space-y-2">
         <a
           :href="_explorer(web3.network.key, web3.account)"
           target="_blank"
-          class="mb-2 block"
+          class="block"
         >
           <UiButton class="button-outline w-full">
             <UiAvatar
@@ -90,7 +90,7 @@ watch(open, () => (step.value = null));
             <Icon name="external-link" class="ml-1" />
           </UiButton>
         </a>
-        <UiButton @click="step = 'connect'" class="button-outline w-full mb-2">
+        <UiButton @click="step = 'connect'" class="button-outline w-full">
           {{ $t('connectWallet') }}
         </UiButton>
         <UiButton @click="handleLogout" class="button-outline w-full !text-red">


### PR DESCRIPTION
Use `space-y-2` instead of `mb-2` which also removed extra space below the logout button

**Before**

![Screenshot 2021-12-10 at 9 00 06 AM](https://user-images.githubusercontent.com/69431456/145512600-3807589f-98a8-442c-95e8-7b268a65ae0f.png)

**After**

![Screenshot 2021-12-10 at 8 59 52 AM](https://user-images.githubusercontent.com/69431456/145512586-d1d348be-dd7c-4e80-bc27-798a2b3695f0.png)

