### PR TITLE
Add country flags for languages

### DIFF
--- a/src/locales/languages.json
+++ b/src/locales/languages.json
@@ -1,105 +1,105 @@
 {
   "en-US": {
-    "name": "English"
+    "name": "🇺🇸 English"
   },
   "da-DK": {
-    "name": "Danish",
+    "name": "🇩🇰 Danish",
     "nativeName": "Dansk"
   },
   "cs-CZ": {
-    "name": "Czech",
+    "name": "🇨🇿 Czech",
     "nativeName": "Čeština"
   },
   "de-DE": {
-    "name": "German",
+    "name": "🇩🇪 German",
     "nativeName": "Deutsch"
   },
   "es-ES": {
-    "name": "Spanish",
+    "name": "🇪🇸 Spanish",
     "nativeName": "Español"
   },
   "fil-PH": {
-    "name": "Filipino",
+    "name": "🇵🇭 Filipino",
     "nativeName": "Filipino"
   },
   "fr-FR": {
-    "name": "French",
+    "name": "🇫🇷 French",
     "nativeName": "Français"
   },
   "id-ID": {
-    "name": "Indonesian",
+    "name": "🇮🇩 Indonesian",
     "nativeName": "Behasa Indonesia"
   },
   "it-IT": {
-    "name": "Italian",
+    "name": "🇮🇹 Italian",
     "nativeName": "Italiano"
   },
   "nl-NL": {
-    "name": "Nederlands",
+    "name": "🇳🇱 Nederlands",
     "nativeName": "Nederlands"
   },
   "pl-PL": {
-    "name": "Polish",
+    "name": "🇵🇱 Polish",
     "nativeName": "Polski"
   },
   "pt-PT": {
-    "name": "Portuguese",
+    "name": "🇵🇹 Portuguese",
     "nativeName": "Português"
   },
   "sv-SE": {
-    "name": "Swedish",
+    "name": "🇸🇪 Swedish",
     "nativeName": "Svenska"
   },
   "tr-TR": {
-    "name": "Turkish",
+    "name": "🇹🇷 Turkish",
     "nativeName": "Türkçe"
   },
   "vi-VN": {
-    "name": "Vietnamese",
+    "name": "🇻🇳 Vietnamese",
     "nativeName": "Tiếng Việt"
   },
   "zh-CN": {
-    "name": "Chinese",
+    "name": "🇨🇳 Chinese",
     "nativeName": "简体中文"
   },
   "sh-HR": {
-    "name": "Serbian",
+    "name": "🇷🇸 Serbian",
     "nativeName": "Српски"
   },
   "ar-SA": {
-    "name": "Arabic",
+    "name": "🇸🇦 Arabic",
     "nativeName": "العربية"
   },
   "ru-RU": {
-    "name": "Russian",
+    "name": "🇷🇺 Russian",
     "nativeName": "Русский"
   },
   "te-IN": {
-    "name": "Telugu",
+    "name": "🇮🇳 Telugu",
     "nativeName": "తెలుగు"
   },
   "th-TH": {
-    "name": "Thai",
+    "name": "🇹🇭 Thai",
     "nativeName": "ไทย"
   },
   "ja-JP": {
-    "name": "Japanese",
+    "name": "🇯🇵 Japanese",
     "nativeName": "日本語"
   },
   "mr-IN": {
-    "name": "Marathi",
+    "name": "🇮🇳 Marathi",
     "nativeName": "मराठी"
   },
   "ko-KR": {
-    "name": "Korean",
+    "name": "🇰🇷 Korean",
     "nativeName": "한국어"
   },
   "uk-UA": {
-    "name": "Ukrainian",
+    "name": "🇺🇦 Ukrainian",
     "nativeName": "Українська мова"
   },
   "he-IL": {
-    "name": "Hebrew",
+    "name": "🇮🇱 Hebrew",
     "nativeName": "עִבְרִית"
   }
 }


### PR DESCRIPTION
Fixes #1212 

Changes proposed in this pull request:
- I approached the issue about adding flags to the language selection by adding emoji. This seems to be working well.

<img width="387" alt="スクリーンショット 2021-12-12 1 04 05" src="https://user-images.githubusercontent.com/701242/145683449-76158f9b-17a2-498b-b3e0-4e5fbf4a032c.png">
<img width="382" alt="スクリーンショット 2021-12-12 1 04 21" src="https://user-images.githubusercontent.com/701242/145683456-9854666b-d7fb-480b-8e90-db04d28f4f9e.png">

- However, associating a language with a flag may cause problems...
  - Arabic is also used outside the United Arab Emirates https://www.quora.com/Which-flag-represents-the-Arabic-language
  - English is also used in the US and UK
  - Perhaps Telugu and Marathi are both used in India

If you don't like the idea of emoji, or if you are concerned about the differences between the above languages and flags, you can close this PR.