### PR TITLE
Add strategy generated form

### DIFF
--- a/src/components/Modal/Strategy.vue
+++ b/src/components/Modal/Strategy.vue
@@ -2,6 +2,7 @@
 import { ref, computed, toRefs, watch } from 'vue';
 import { useSearchFilters } from '@/composables/useSearchFilters';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
+import { useApp } from '../../composables/useApp';
 
 const defaultParams = {
   symbol: 'DAI',
@@ -20,6 +21,8 @@ const input = ref({
   params: JSON.stringify(defaultParams, null, 2)
 });
 
+const form = ref({});
+
 const isValid = computed(() => {
   try {
     const params = JSON.parse(input.value.params);
@@ -29,8 +32,16 @@ const isValid = computed(() => {
   }
 });
 
+const { strategies } = useApp();
+
+const definition = computed(() => {
+  return input.value.name && strategies.value[input.value.name].schema?.$ref
+    ? strategies.value[input.value.name].schema.definitions.Strategy
+    : false;
+});
+
 const { filteredStrategies } = useSearchFilters();
-const strategies = computed(() => filteredStrategies(searchInput.value));
+const strategiesResults = computed(() => filteredStrategies(searchInput.value));
 
 function handleSubmit() {
   const strategyObj = clone(input.value);
@@ -41,7 +52,6 @@ function handleSubmit() {
 
 function handleClick(strategy) {
   const params = strategy.examples[0]?.strategy?.params || defaultParams;
-
   input.value = {
     name: strategy.key,
     params: JSON.stringify(params, null, 2)
@@ -65,9 +75,7 @@ watch(open, () => {
 <template>
   <UiModal :open="open" @close="$emit('close')">
     <template v-slot:header>
-      <h3>
-        {{ strategy.name ? $t('editStrategy') : $t('settings.addStrategy') }}
-      </h3>
+      <h3 v-text="input.name ? input.name : $t('settings.addStrategy')" />
     </template>
     <Search
       v-if="!strategy.name && !input.name"
@@ -75,39 +83,40 @@ watch(open, () => {
       :placeholder="$t('searchPlaceholder')"
       :modal="true"
     />
-    <div class="mt-4 mx-0 md:mx-4">
-      <div v-if="input.name" class="p-4 mb-4 border rounded-md link-color">
-        <h4 v-text="input.name" class="mb-3 text-center" />
-        <UiButton
-          class="block w-full mb-3 overflow-x-auto"
-          style="height: auto"
-        >
-          <TextareaAutosize
-            v-model="input.params"
-            :placeholder="$t('strategyParameters')"
-            class="input text-left no-scrollbar"
-            style="width: 560px"
-          />
-        </UiButton>
-        <UiButton
-          @click="handleSubmit"
-          :disabled="!isValid"
-          class="w-full"
-          primary
-        >
-          {{ strategy.name ? $t('save') : $t('add') }}
-        </UiButton>
-      </div>
-      <div v-if="!input.name">
-        <a
-          v-for="strategy in strategies"
-          :key="strategy.key"
-          @click="handleClick(strategy)"
-        >
-          <BlockStrategy :strategy="strategy" />
-        </a>
-        <NoResults v-if="Object.keys(strategies).length < 1" />
-      </div>
+    <div v-if="input.name" class="m-4">
+      <SObject v-if="definition" v-model="form" :definition="definition" />
+      <UiButton
+        v-else
+        class="block w-full mb-3 overflow-x-auto"
+        style="height: auto"
+      >
+        <TextareaAutosize
+          v-model="input.params"
+          :placeholder="$t('strategyParameters')"
+          class="input text-left no-scrollbar"
+          style="width: 560px"
+        />
+      </UiButton>
     </div>
+    <div v-else class="my-4 mx-0 md:mx-4">
+      <a
+        v-for="strategy in strategiesResults"
+        :key="strategy.key"
+        @click="handleClick(strategy)"
+      >
+        <BlockStrategy :strategy="strategy" />
+      </a>
+      <NoResults v-if="Object.keys(strategiesResults).length < 1" />
+    </div>
+    <template v-if="input.name" v-slot:footer>
+      <UiButton
+        @click="handleSubmit"
+        :disabled="!isValid"
+        class="w-full"
+        primary
+      >
+        {{ strategy.name ? $t('save') : $t('add') }}
+      </UiButton>
+    </template>
   </UiModal>
 </template>

--- a/src/components/S/Array.vue
+++ b/src/components/S/Array.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { onMounted, ref, watch } from 'vue';
+
+const props = defineProps({
+  modelValue: Array,
+  definition: Object
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const input = ref(props.modelValue || props.definition.default || []);
+
+onMounted(() => emit('update:modelValue', input.value));
+
+watch(input, () => emit('update:modelValue', input.value));
+
+function addItem() {
+  input.value.push('');
+}
+</script>
+
+<template>
+  <SBase :definition="definition">
+    <div v-for="(item, i) in input" :key="i">
+      <SString :definition="{ title: '' }" v-model="input[i]" />
+    </div>
+    <a @click="addItem">Add</a>
+  </SBase>
+</template>

--- a/src/components/S/Base.vue
+++ b/src/components/S/Base.vue
@@ -1,0 +1,9 @@
+<script setup>
+defineProps({ definition: Object });
+</script>
+
+<template>
+  <label v-if="definition.title" v-text="definition.title" class="s-label" />
+  <slot />
+  <legend v-if="definition.description" v-text="definition.description" />
+</template>

--- a/src/components/S/Boolean.vue
+++ b/src/components/S/Boolean.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+  modelValue: Boolean,
+  definition: Object
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const input = ref(props.modelValue || props.definition.default || undefined);
+
+watch(input, () => emit('update:modelValue', input.value));
+</script>
+
+<template>
+  <SBase :definition="definition">
+    <input type="checkbox" v-model="input" />
+  </SBase>
+</template>

--- a/src/components/S/Number.vue
+++ b/src/components/S/Number.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+  modelValue: Number,
+  definition: Object
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const input = ref(props.modelValue || props.definition.default || undefined);
+
+watch(input, () => emit('update:modelValue', parseFloat(input.value)));
+</script>
+
+<template>
+  <SBase :definition="definition">
+    <input type="number" v-model="input" class="s-input mb-3" />
+  </SBase>
+</template>

--- a/src/components/S/Object.vue
+++ b/src/components/S/Object.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { onMounted, ref, watch } from 'vue';
+
+const props = defineProps({
+  modelValue: Object,
+  definition: Object
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const input = ref(props.modelValue || props.definition.default || {});
+
+onMounted(() => emit('update:modelValue', input.value));
+
+watch(input, () => emit('update:modelValue', input.value));
+</script>
+
+<template>
+  <div v-for="(property, i) in definition.properties" :key="i">
+    <SObject
+      v-if="property.type === 'object'"
+      :definition="property"
+      v-model="input[i]"
+    />
+    <SArray
+      v-if="property.type === 'array'"
+      :definition="property"
+      v-model="input[i]"
+    />
+    <SString
+      v-if="property.type === 'string'"
+      :definition="property"
+      v-model="input[i]"
+    />
+    <SNumber
+      v-if="property.type === 'number'"
+      :definition="property"
+      v-model="input[i]"
+    />
+    <SBoolean
+      v-if="property.type === 'boolean'"
+      :definition="property"
+      v-model="input[i]"
+    />
+  </div>
+</template>

--- a/src/components/S/String.vue
+++ b/src/components/S/String.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+  modelValue: String,
+  definition: Object
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const input = ref(props.modelValue || props.definition.default || undefined);
+
+watch(input, () => emit('update:modelValue', input.value));
+</script>
+
+<template>
+  <SBase :definition="definition">
+    <input
+      type="text"
+      v-model="input"
+      class="s-input mb-3"
+      :placeholder="definition.examples && definition.examples[0]"
+    />
+  </SBase>
+</template>

--- a/src/components/Ui/Modal.vue
+++ b/src/components/Ui/Modal.vue
@@ -22,7 +22,7 @@ watch(open, (val, prev) => {
     <div v-if="open" class="modal mx-auto">
       <div class="backdrop" @click="$emit('close')" />
       <div class="shell overflow-hidden relative rounded-none md:rounded-lg">
-        <div v-if="$slots.header" class="border-b pt-4 pb-3 text-center">
+        <div v-if="$slots.header" class="border-b pt-3 pb-2 text-center">
           <slot name="header" />
         </div>
         <div class="modal-body">

--- a/src/style.scss
+++ b/src/style.scss
@@ -270,6 +270,11 @@ select {
   border: 0 !important;
 }
 
+.sliding {
+  overflow: auto;
+  white-space: nowrap;
+}
+
 .border-color {
   color: var(--border-color);
 }
@@ -375,4 +380,17 @@ input[type='number']::-webkit-outer-spin-button {
   position: relative;
   padding: 5px 9px;
   z-index: 1;
+}
+
+
+// Shot UI kit
+
+.s-input {
+  color: var(--heading-color);
+  border: 1px solid var(--border-color);
+  @apply block rounded-full py-2 px-3 w-full bg-transparent;
+}
+
+.s-label {
+  @apply block mb-1;
 }


### PR DESCRIPTION
Generate form when a schema is available (see https://score.snapshot.org/api/strategies and test erc20-balance-of or erc721 strategies on space settings)

![image](https://user-images.githubusercontent.com/16245250/145730133-1c1713fa-b4bc-46c0-a247-18de1a4536e4.png)

TODO:

- [ ] Persist params when fill the generated form
- [ ] Replace textarea with JSON with a component TextareaJson (to move parse / stringify logic)