### PR TITLE
move computed web3Account to useWeb3 composable

### DIFF
--- a/src/components/Block/Space.vue
+++ b/src/components/Block/Space.vue
@@ -12,14 +12,12 @@ const props = defineProps({
 });
 
 const auth = getInstance();
-const { web3 } = useWeb3();
+const { web3Account } = useWeb3();
 
 const { explore } = useApp();
 
 const nbrMembers = explore.value.spaces[props.space.id].followers;
 const isVerified = verified[props.space.id] || 0;
-
-const web3Account = computed(() => web3.value.account);
 
 const isAdmin = computed(() => {
   const admins = props.space?.admins?.map(address => address.toLowerCase());

--- a/src/components/Block/Votes.vue
+++ b/src/components/Block/Votes.vue
@@ -21,12 +21,11 @@ defineEmits(['loadVotes']);
 const format = getChoiceString;
 
 const { votes } = toRefs(props);
-const { web3 } = useWeb3();
+const { web3Account } = useWeb3();
 
 const authorIpfsHash = ref('');
 const modalReceiptOpen = ref(false);
 
-const web3Account = computed(() => web3.value.account);
 const isFinalProposal = computed(() => props.proposal.scores_state === 'final');
 
 const voteCount = computed(() =>

--- a/src/components/Plugin/CommentBox/Comment.vue
+++ b/src/components/Plugin/CommentBox/Comment.vue
@@ -18,14 +18,13 @@ const props = defineProps({
   mainThread: String,
   space: Object
 });
-const { web3 } = useWeb3();
+const { web3Account } = useWeb3();
 const item2 = toRef(props, 'item');
 const comment = ref(
   props.method === 'edit' && item2.value?.markdown
     ? clone(item2.value?.markdown)
     : ''
 );
-const web3Account = computed(() => web3.value.account);
 const loading = ref(false);
 const togglePreview = ref(true);
 const closeModal = ref(false);

--- a/src/components/Plugin/CommentBox/Comment.vue
+++ b/src/components/Plugin/CommentBox/Comment.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, toRef, watch } from 'vue';
+import { ref, toRef, watch } from 'vue';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 import { useNotifications } from '@/composables/useNotifications';
 import { useModal } from '@/composables/useModal';

--- a/src/components/Plugin/CommentBox/CommentBlock.vue
+++ b/src/components/Plugin/CommentBox/CommentBlock.vue
@@ -9,8 +9,7 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 const auth = getInstance();
 const { modalOpen, modalAccountOpen } = useModal();
-const { web3 } = useWeb3();
-const web3Account = computed(() => web3.value.account);
+const { web3Account } = useWeb3();
 const props = defineProps({
   profiles: Object,
   space: Object,

--- a/src/components/Plugin/CommentBox/CustomBlock.vue
+++ b/src/components/Plugin/CommentBox/CustomBlock.vue
@@ -16,9 +16,8 @@ const props = defineProps({
 });
 const { notify } = useNotifications();
 const auth = getInstance();
-const { web3 } = useWeb3();
+const { web3Account } = useWeb3();
 const { profiles } = useProfiles();
-const web3Account = computed(() => web3.value.account);
 const { modalAccountOpen } = useModal();
 const loading = ref(false);
 const comment = ref('');

--- a/src/components/Plugin/CommentBox/CustomBlock.vue
+++ b/src/components/Plugin/CommentBox/CustomBlock.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useModal } from '@/composables/useModal';
 import { useWeb3 } from '@/composables/useWeb3';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';

--- a/src/components/Plugin/CommentBox/ReplyBlock.vue
+++ b/src/components/Plugin/CommentBox/ReplyBlock.vue
@@ -9,8 +9,7 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 const auth = getInstance();
 const { modalOpen, modalAccountOpen } = useModal();
-const { web3 } = useWeb3();
-const web3Account = computed(() => web3.value.account);
+const { web3Account } = useWeb3();
 const props = defineProps({
   item: Object,
   space: Object,

--- a/src/components/Scroller.vue
+++ b/src/components/Scroller.vue
@@ -9,7 +9,7 @@ import { useUnseenProposals } from '@/composables/useUnseenProposals';
 import { lsSet, lsGet } from '@/helpers/utils';
 
 const { explore } = useApp();
-const { web3 } = useWeb3();
+const { web3Account } = useWeb3();
 const { loadFollows, followingSpaces } = useFollowSpace();
 const { domain } = useDomain();
 const {
@@ -22,8 +22,6 @@ const {
 const modalAboutOpen = ref(false);
 const modalLangOpen = ref(false);
 const draggableSpaces = ref([]);
-
-const web3Account = computed(() => web3.value.account);
 
 function saveSpaceOrder() {
   if (web3Account.value)

--- a/src/components/Scroller.vue
+++ b/src/components/Scroller.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, watch, onMounted, ref, watchEffect } from 'vue';
+import { watch, onMounted, ref, watchEffect } from 'vue';
 import draggable from 'vuedraggable';
 import { useFollowSpace } from '@/composables/useFollowSpace';
 import { useWeb3 } from '@/composables/useWeb3';

--- a/src/composables/useFollowSpace.ts
+++ b/src/composables/useFollowSpace.ts
@@ -12,7 +12,7 @@ const following = ref([]);
 const loadingFollows = ref(false);
 
 export function useFollowSpace(spaceObj: any = {}) {
-  const { web3 } = useWeb3();
+  const { web3, web3Account } = useWeb3();
   const { modalAccountOpen } = useModal();
   const { apolloQuery } = useApolloQuery();
   const { setAlias, aliasWallet, isValidAlias, checkAlias } = useAliasAction();
@@ -22,8 +22,6 @@ export function useFollowSpace(spaceObj: any = {}) {
 
   const loadingFollow = ref('');
   const hoverJoin = ref('');
-
-  const web3Account = computed(() => web3.value.account);
 
   const followingSpaces = computed(() =>
     following.value.map((f: any) => f.space.id)

--- a/src/composables/useSpaceSubscription.ts
+++ b/src/composables/useSpaceSubscription.ts
@@ -11,13 +11,12 @@ import client from '@/helpers/clientEIP712';
 const subscriptions = ref<any[] | undefined>(undefined);
 
 export function useSpaceSubscription(spaceId: any) {
-  const { web3 } = useWeb3();
+  const { web3, web3Account } = useWeb3();
   const { apolloQuery } = useApolloQuery();
   const { setAlias, aliasWallet, isValidAlias, checkAlias } = useAliasAction();
   const { notify } = useNotifications();
   const { t } = useI18n();
   const loading = ref(false);
-  const web3Account = computed(() => web3.value.account);
   const isSubscribed = computed(() => {
     return (
       subscriptions.value?.some((subscription: any) => {

--- a/src/composables/useUsername.ts
+++ b/src/composables/useUsername.ts
@@ -3,15 +3,13 @@ import { shorten } from '@/helpers/utils';
 import { useWeb3 } from '@/composables/useWeb3';
 
 export function useUsername() {
-  const { web3 } = useWeb3();
+  const { web3Account } = useWeb3();
 
   const address = ref('');
   const profile = ref({
     name: '',
     ens: ''
   });
-
-  const web3Account = computed(() => web3.value.account);
 
   const username = computed(() => {
     if (

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -110,6 +110,7 @@ export function useWeb3() {
     logout,
     loadProvider,
     handleChainChanged,
-    web3: computed(() => state)
+    web3: computed(() => state),
+    web3Account: computed(() => state.account)
   };
 }

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -31,7 +31,7 @@ const { t } = useI18n();
 const auth = getInstance();
 const notify = inject('notify');
 const { explore } = useApp();
-const { web3 } = useWeb3();
+const { web3, web3Account } = useWeb3();
 const { pendingCount } = useTxStatus();
 const { loadExtentedSpaces, extentedSpaces, spaceLoading } =
   useExtendedSpaces();
@@ -52,7 +52,6 @@ const form = ref({
 
 const { profiles, loadProfiles } = useProfiles();
 
-const web3Account = computed(() => web3.value.account);
 const networkKey = computed(() => web3.value.network.key);
 const space = computed(() => explore.value.spaces[form.value.id]);
 

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -29,7 +29,7 @@ const router = useRouter();
 const { t } = useI18n();
 const auth = getInstance();
 const { domain } = useDomain();
-const { web3 } = useWeb3();
+const { web3, web3Account } = useWeb3();
 const { getExplore } = useApp();
 const { spaceLoading } = useExtendedSpaces();
 const { send, clientLoading } = useClient();
@@ -59,7 +59,6 @@ const nameForm = ref(null);
 const passValidation = ref([true]);
 const loadingSnapshot = ref(true);
 
-const web3Account = computed(() => web3.value.account);
 const proposal = computed(() =>
   Object.assign(form.value, { choices: choices.value })
 );

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -29,7 +29,7 @@ const route = useRoute();
 const router = useRouter();
 const { domain } = useDomain();
 const { t } = useI18n();
-const { web3 } = useWeb3();
+const { web3, web3Account } = useWeb3();
 const { send, clientLoading } = useClient();
 const { getExplore } = useApp();
 const notify = inject('notify');
@@ -49,7 +49,6 @@ const totalScore = ref(0);
 const scores = ref([]);
 const modalStrategiesOpen = ref(false);
 
-const web3Account = computed(() => web3.value.account);
 const isCreator = computed(() => proposal.value.author === web3Account.value);
 const loaded = computed(() => !props.spaceLoading && !loading.value);
 const isAdmin = computed(() => {

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -15,7 +15,7 @@ import { setPageTitle } from '@/helpers/utils';
 const props = defineProps({ space: Object, spaceId: String });
 
 const { lastSeenProposals, updateLastSeenProposal } = useUnseenProposals();
-const { web3 } = useWeb3();
+const { web3Account } = useWeb3();
 const { store } = useStore();
 
 const loading = ref(false);
@@ -23,7 +23,6 @@ const loading = ref(false);
 const spaceMembers = computed(() =>
   props.space.members.length < 1 ? ['none'] : props.space.members
 );
-const web3Account = computed(() => web3.value.account);
 
 const { loadBy, loadingMore, stopLoadingMore, loadMore } = useInfiniteLoader();
 

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -30,7 +30,7 @@ const basicValidation = { name: 'basic', params: {} };
 
 const { t } = useI18n();
 const { copyToClipboard } = useCopy();
-const { web3 } = useWeb3();
+const { web3Account } = useWeb3();
 const { send, clientLoading } = useClient();
 const notify = inject('notify');
 
@@ -59,8 +59,6 @@ const form = ref({
   voting: {},
   validation: basicValidation
 });
-
-const web3Account = computed(() => web3.value.account);
 
 const validate = computed(() => {
   if (form.value.terms === '') delete form.value.terms;

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -21,7 +21,7 @@ const loading = ref(false);
 
 const route = useRoute();
 const { followingSpaces, loadingFollows } = useFollowSpace();
-const { web3 } = useWeb3();
+const { web3, web3Account } = useWeb3();
 
 const spaces = computed(() => {
   const verifiedSpaces = Object.entries(verified)
@@ -40,7 +40,6 @@ watch(spaces, () => {
 });
 
 const isTimeline = computed(() => route.name === 'timeline');
-const web3Account = computed(() => web3.value.account);
 
 const { updateLastSeenProposal } = useUnseenProposals();
 const { loadBy, loadingMore, stopLoadingMore, loadMore } = useInfiniteLoader();


### PR DESCRIPTION
Reduces code duplication a bit.

`const web3Account = computed(() => web3.value.account);` was repeated in several components/composables. Moved it to the `useWeb3` composable.