### PR TITLE
Enabling Hal Plugin

### DIFF
--- a/src/components/Plugin/Hal/CustomBlock.vue
+++ b/src/components/Plugin/Hal/CustomBlock.vue
@@ -1,36 +1,22 @@
 <script setup>
+import { computed } from 'vue';
 const props = defineProps({
   space: Object
 });
-
-const getSpaceId = () => {
-  const spaceId = props.space.id;
-  return spaceId;
-};
-
-const getSpaceName = () => {
-  const spaceName = props.space.name;
-  return spaceName;
-};
-
-const getHalUrl = () => {
-  const spaceId = getSpaceId();
-  return `https://9000.staging.hal.xyz/recipes/snapshot-follow-new-proposals?space-id=${spaceId}&status=end`;
-};
-
-const getLogoUrl = () => {
-  return `https://hal-snapshot-plugin.s3.eu-west-1.amazonaws.com/hal_bell.svg`;
-};
+const halUrl = computed(
+  () =>
+    `https://9000.hal.xyz/recipes/snapshot-follow-new-proposals?space-id=${props.space.id}&status=end`
+);
+const halLogoUrl = computed(
+  () => 'https://hal-snapshot-plugin.s3.eu-west-1.amazonaws.com/hal_bell.svg'
+);
 </script>
 
 <template>
-  <Block
-    :title="$t('hal.title', { spaceName: getSpaceName() })"
-    :loading="loading"
-  >
+  <Block :title="$t('hal.title', { spaceName: space.name })" :loading="loading">
     <div class="flex flex-col items-center">
       <div>
-        <a :href="getHalUrl()" target="_blank">
+        <a :href="halUrl" target="_blank">
           <img
             class="
               rounded-full
@@ -39,7 +25,7 @@ const getLogoUrl = () => {
               mx-auto
               mb-2
             "
-            :src="getLogoUrl()"
+            :src="halLogoUrl"
             alt="Hal"
             width="100"
             height="100"
@@ -47,7 +33,7 @@ const getLogoUrl = () => {
         </a>
       </div>
       <div class="link-color text-center mb-2">{{ $t('hal.text') }}</div>
-      <a :href="getHalUrl()" target="_blank">
+      <a :href="halUrl" target="_blank">
         <UiButton>Be notified</UiButton>
       </a>
     </div>

--- a/src/components/Plugin/Hal/CustomBlock.vue
+++ b/src/components/Plugin/Hal/CustomBlock.vue
@@ -1,0 +1,55 @@
+<script setup>
+const props = defineProps({
+  space: Object
+});
+
+const getSpaceId = () => {
+  const spaceId = props.space.id;
+  return spaceId;
+};
+
+const getSpaceName = () => {
+  const spaceName = props.space.name;
+  return spaceName;
+};
+
+const getHalUrl = () => {
+  const spaceId = getSpaceId();
+  return `https://9000.staging.hal.xyz/recipes/snapshot-follow-new-proposals?space-id=${spaceId}&status=end`;
+};
+
+const getLogoUrl = () => {
+  return `https://hal-snapshot-plugin.s3.eu-west-1.amazonaws.com/hal_bell.svg`;
+};
+</script>
+
+<template>
+  <Block
+    :title="$t('hal.title', { spaceName: getSpaceName() })"
+    :loading="loading"
+  >
+    <div class="flex flex-col items-center">
+      <div>
+        <a :href="getHalUrl()" target="_blank">
+          <img
+            class="
+              rounded-full
+              border-2 border-transparent
+              hover:border-white
+              mx-auto
+              mb-2
+            "
+            :src="getLogoUrl()"
+            alt="Hal"
+            width="100"
+            height="100"
+          />
+        </a>
+      </div>
+      <div class="link-color text-center mb-2">{{ $t('hal.text') }}</div>
+      <a :href="getHalUrl()" target="_blank">
+        <UiButton>Be notified</UiButton>
+      </a>
+    </div>
+  </Block>
+</template>

--- a/src/components/Plugin/config.json
+++ b/src/components/Plugin/config.json
@@ -8,6 +8,9 @@
   "gnosis": {
     "proposalParams": true
   },
+  "hal": {
+    "proposalParams": false
+  },
   "poap": {
     "proposalParams": false
   },

--- a/src/components/ProposalPluginsSidebar.vue
+++ b/src/components/ProposalPluginsSidebar.vue
@@ -41,5 +41,6 @@ defineProps({
       :votes="votes"
       :strategies="strategies"
     />
+    <PluginHalCustomBlock v-if="space.plugins?.hal" :space="space" />
   </div>
 </template>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -393,5 +393,9 @@
       "strategy": "{key} strategy",
       "delegate": "Delegate"
     }
+  },
+  "hal": {
+    "title": "Track proposals for {spaceName}",
+    "text": "Receive notifications every time a new proposal is created or ends"
   }
 }


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- integrate HAL Plugin on the Snapshot UI

## Goal
To integrate HAL on the Snapshot UI, so that users can set up a trigger to notify them when a proposal is created or ends for a any given space and receive notifications over email, Telegram, Discord, Slack, or connect it to webhooks to create further automation.

## Flow
1. User on the Snapshot website wants to be notified when a proposal is created or ends for a specific space.
![Screenshot%202021-12-16%20at%2017 13 11](https://user-images.githubusercontent.com/1284304/146437187-8d9a2ff4-2f77-47dd-8443-f0ba5332fa14.png)
2. User gets redirect to a custom made recipe on the HAL website, e.g. https://9000.hal.xyz/recipes/snapshot-follow-new-proposals?space-id=test3.shot.eth&status=end.
3. All fields in the recipe are already pre-filled and a custom template is ready to be used right away. The users choose the relevant action (Email, Telegram etc).
![Screenshot%202021-12-16%20at%2017 15 13](https://user-images.githubusercontent.com/1284304/146437288-166b721b-f223-4943-a044-71e0e82be1d5.png)
4. From HAL website, the user can see their triggers and interact with them (edit, delete etc).

