### PR TITLE
Added zIndex for timeline dropdown menu

### DIFF
--- a/src/components/Ui/Dropdown.vue
+++ b/src/components/Ui/Dropdown.vue
@@ -103,6 +103,7 @@ li:hover {
   border: 1px solid var(--border-color);
   border-radius: 8px;
   box-shadow: 0 0 20px -6px var(--border-color);
+  z-index: 1;
 }
 
 .sub-menu-wrapper.hidden {


### PR DESCRIPTION
Fixes #1268

Changes proposed in this pull request:
- Added z-index for the `sub-menu-wrapper`

![image](https://user-images.githubusercontent.com/29498872/146551392-1eb18163-4c32-4962-83b3-058c6e14a297.png)
![image](https://user-images.githubusercontent.com/29498872/146551681-fea40617-e1f6-49e1-85f6-e7ba9ed600ea.png)
