### PR TITLE
Fix infinite update loop

### DIFF
--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -71,7 +71,9 @@ async function load() {
 }
 
 watchEffect(() => {
-  if (store.space.proposals[0]?.space.id !== props.spaceId) {
+  // hotfix for infinite update loop when there are no proposals
+  // if (store.space.proposals[0]?.space.id !== props.spaceId) {
+  if (store.space.proposals.length && store.space.proposals[0].space.id !== props.spaceId) {
     store.space.proposals = [];
     load();
   }


### PR DESCRIPTION
On space proposals page when there are no proposals:

![wtf](https://user-images.githubusercontent.com/6792578/147937055-43a00180-6017-4f10-bcc8-57462c20e5f8.gif)

Only glanced over it so far. Not sure if that's the proper fix. Works for me.