### PR TITLE
re-added fortmatic dependency to apply patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dayjs": "^1.10.7",
     "eslint": "^7.32.0",
     "ethereum-blockies-base64": "^1.0.2",
+    "fortmatic": "^2.2.1",
     "graphql": "^16.2.0",
     "graphql-tag": "^2.12.6",
     "lodash": "^4.17.21",


### PR DESCRIPTION
> `Error: Patch file found for package fortmatic which is not present at node_modules/fortmatic`
https://github.com/snapshot-labs/snapshot/runs/4769785596?check_suite_focus=true

If we still need [this patch](https://github.com/snapshot-labs/snapshot/tree/develop/patches) then we need to add it as a dependency again. Otherwise it seems to break the build process.