### PR TITLE
Remove dependence on explore for skins

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { computed, onMounted, provide, watch } from 'vue';
-import { useRoute } from 'vue-router';
 import { useModal } from '@/composables/useModal';
 import { useI18n } from '@/composables/useI18n';
 import { useDomain } from '@/composables/useDomain';
@@ -8,30 +7,23 @@ import { useUserSkin } from '@/composables/useUserSkin';
 import { useApp } from '@/composables/useApp';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useNotifications } from '@/composables/useNotifications';
-import aliases from '@/../snapshot-spaces/spaces/aliases.json';
 
 const { domain } = useDomain();
 const { loadLocale } = useI18n();
-const route = useRoute();
 const { modalOpen } = useModal();
 const { userSkin } = useUserSkin();
-const { init, explore, app } = useApp();
+const { init, skinName, app } = useApp();
 const { web3 } = useWeb3();
 const { notify } = useNotifications();
 
 provide('web3', web3);
 provide('notify', notify);
 
-const space = computed(() => {
-  const key = aliases[domain] || domain || route.params.key;
-  return explore.value.spaces?.[key];
-});
-
 const skin = computed(() => {
-  if (domain && space.value?.skin) {
-    let skinClass = space.value.skin;
+  if (domain && skinName.value !== 'default') {
+    let skinClass = skinName.value;
     if (userSkin.value === 'dark-mode')
-      skinClass += ` ${space.value.skin}-dark-mode`;
+      skinClass += ` ${skinName.value}-dark-mode`;
     return skinClass;
   }
   return userSkin.value;
@@ -50,6 +42,7 @@ watch(modalOpen, val => {
 
 <template>
   <div
+    v-if="skinName"
     :class="skin"
     class="overflow-hidden pb-6 font-serif text-base min-h-screen bg-skin-bg text-skin-text antialiased"
   >

--- a/src/composables/useApp.ts
+++ b/src/composables/useApp.ts
@@ -13,7 +13,6 @@ const state = reactive({
   loading: false
 });
 
-const spaces = ref({});
 const strategies = ref({});
 const explore: any = ref({});
 
@@ -126,7 +125,6 @@ export function useApp() {
     init,
     getExplore,
     app: computed(() => state),
-    spaces: computed(() => spaces.value),
     strategies: computed(() => strategies.value),
     explore: computed(() => explore.value),
     orderedSpaces,

--- a/src/composables/useApp.ts
+++ b/src/composables/useApp.ts
@@ -7,6 +7,10 @@ import { useFollowSpace } from '@/composables/useFollowSpace';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import verified from '@/../snapshot-spaces/spaces/verified.json';
 import verifiedSpacesCategories from '@/../snapshot-spaces/spaces/categories.json';
+import { useDomain } from '@/composables/useDomain';
+import aliases from '@/../snapshot-spaces/spaces/aliases.json';
+import { useApolloQuery } from '@/composables/useApolloQuery';
+import { SPACE_SKIN_QUERY } from '@/helpers/queries';
 
 const state = reactive({
   init: false,
@@ -25,7 +29,7 @@ export function useApp() {
   async function init() {
     const auth = getInstance();
     state.loading = true;
-    await Promise.all([getStrategies(), getExplore()]);
+    await Promise.all([getStrategies(), getExplore(), getSkin()]);
 
     // Auto connect with gnosis-connector when inside gnosis-safe iframe
     if (window?.parent === window)
@@ -67,6 +71,34 @@ export function useApp() {
 
     explore.value = exploreObj;
     return;
+  }
+
+  const { domain } = useDomain();
+  const { apolloQuery } = useApolloQuery();
+
+  const skin = ref('');
+
+  async function getSkin() {
+    const key = aliases[domain] || domain;
+    if (key) {
+      try {
+        const spaceObj = await apolloQuery(
+          {
+            query: SPACE_SKIN_QUERY,
+            variables: {
+              id: key
+            }
+          },
+          'space'
+        );
+        skin.value = spaceObj?.skin ?? 'default';
+      } catch (e) {
+        console.error(e);
+        skin.value = 'default';
+      }
+    } else {
+      skin.value = 'default';
+    }
   }
 
   const selectedCategory = ref('');
@@ -127,6 +159,7 @@ export function useApp() {
     app: computed(() => state),
     strategies: computed(() => strategies.value),
     explore: computed(() => explore.value),
+    skinName: computed(() => skin.value),
     orderedSpaces,
     orderedSpacesByCategory,
     selectedCategory

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -190,3 +190,11 @@ export const ENS_QUERY = gql`
     }
   }
 `;
+
+export const SPACE_SKIN_QUERY = gql`
+  query Space($id: String!) {
+    space(id: $id) {
+      skin
+    }
+  }
+`;


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/1437

Changes proposed in this pull request:
- Remove dependence on explore for skins
- Query space skin on init if custom domain
- Remove redundant space var from `useApp`
- Don't show loader until skinName is defined