### PR TITLE
Use space query instead of explore for follower count

### DIFF
--- a/src/components/SpaceSidebarHeader.vue
+++ b/src/components/SpaceSidebarHeader.vue
@@ -62,8 +62,8 @@ watchEffect(() => {
       </h3>
       <div class="mb-[12px] text-color">
         {{
-          $tc('members', space.followerCount, {
-            count: formatCompactNumber(space.followerCount)
+          $tc('members', space.followersCount, {
+            count: formatCompactNumber(space.followersCount)
           })
         }}
       </div>

--- a/src/components/SpaceSidebarHeader.vue
+++ b/src/components/SpaceSidebarHeader.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { ref, watchEffect } from 'vue';
-import { useApp } from '@/composables/useApp';
+import { ref, watchEffect, computed } from 'vue';
 import { useSpaceSubscription } from '@/composables/useSpaceSubscription';
 import { useFollowSpace } from '@/composables/useFollowSpace';
 import verified from '@/../snapshot-spaces/spaces/verified.json';
@@ -11,12 +10,9 @@ const props = defineProps({
   spaceId: String
 });
 
-const { explore } = useApp();
 const { formatCompactNumber } = useIntl();
 
-// TODO: Use space.followers instead of explore
-const nbrMembers = explore.value.spaces[props.spaceId].followers;
-const isVerified = verified[props.spaceId] || 0;
+const isVerified = computed(() => verified[props.spaceId] || 0);
 
 const {
   loading,
@@ -66,7 +62,9 @@ watchEffect(() => {
       </h3>
       <div class="mb-[12px] text-color">
         {{
-          $tc('members', nbrMembers, { count: formatCompactNumber(nbrMembers) })
+          $tc('members', space.followerCount, {
+            count: formatCompactNumber(space.followerCount)
+          })
         }}
       </div>
     </div>

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -158,7 +158,7 @@ export const SPACES_QUERY = gql`
       admins
       categories
       plugins
-      followerCount
+      followersCount
       voting {
         delay
         period

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -158,6 +158,7 @@ export const SPACES_QUERY = gql`
       admins
       categories
       plugins
+      followerCount
       voting {
         delay
         period


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/1467

Requires https://github.com/snapshot-labs/snapshot-hub/pull/233

Changes proposed in this pull request:
- Use the new `followerCount` on space query instead of explore 
