### PR TITLE
Space settings fix for followerCount

### DIFF
--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -228,7 +228,7 @@ function formatSpace(spaceRaw) {
   const space = clone(spaceRaw);
   if (!space) return;
   delete space.id;
-  delete space._activeProposals;
+  delete space.followersCount;
   Object.entries(space).forEach(([key, value]) => {
     if (value === null) delete space[key];
   });


### PR DESCRIPTION

There is an issue with `followerCount` field added here https://github.com/snapshot-labs/snapshot/pull/1475/files

To reproduce go to a space that has followers and save settings, It won't allow saving space, it shows the following error:
![image](https://user-images.githubusercontent.com/15967809/150291204-7717e57f-6717-4ae3-a292-360d37a35c3b.png)

