### PR TITLE
Remove automatic updates from lock package

### DIFF
--- a/.github/workflows/update-snapshot-packages.yml
+++ b/.github/workflows/update-snapshot-packages.yml
@@ -15,10 +15,7 @@ jobs:
           node-version: '14.x'
       - name: Update snapshot.js
         run: |
-          yarn upgrade @snapshot-labs/snapshot.js  --latest
-      - name: Update snapshot lock
-        run: |
-          yarn upgrade @snapshot-labs/lock@github:snapshot-labs/lock#master  --latest
+          yarn upgrade @snapshot-labs/snapshot.js --latest
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
Right now updating a GitHub package with yarn (lock repo) updates all the packages on yarn.lock, so for now it is better to gt updates only from snapshot.js

#1506 