### PR TITLE
Proposal spacing and alignments 

### DIFF
--- a/src/components/Block/Results.vue
+++ b/src/components/Block/Results.vue
@@ -44,69 +44,71 @@ const hideAbstain = props.space?.voting?.hideAbstain ?? false;
       <template
         v-if="!(proposal.type === 'basic' && hideAbstain && choice.i === 2)"
       >
-        <div class="link-color mb-1">
-          <span
-            v-tippy="{
-              content: choice.choice.length > 12 ? choice.choice : null
-            }"
-            class="mr-1"
-            v-text="shorten(choice.choice, 'choice')"
-          />
+        <div class="link-color mb-1 flex justify-between">
+          <div class="flex overflow-hidden">
+            <span
+              v-tippy="{
+                content: choice.choice.length > 24 ? choice.choice : null
+              }"
+              class="mr-1 truncated"
+              v-text="choice.choice"
+            />
 
-          <span
-            class="inline-block"
-            v-tippy="{
-              content: results.resultsByStrategyScore[choice.i]
-                .map(
-                  (score, index) =>
-                    `${formatCompactNumber(score)} ${titles[index]}`
+            <span
+              class="whitespace-nowrap"
+              v-tippy="{
+                content: results.resultsByStrategyScore[choice.i]
+                  .map(
+                    (score, index) =>
+                      `${formatCompactNumber(score)} ${titles[index]}`
+                  )
+                  .join(' + ')
+              }"
+            >
+              {{ formatCompactNumber(results.resultsByVoteBalance[choice.i]) }}
+              {{ shorten(space.symbol, 'symbol') }}
+            </span>
+          </div>
+
+          <div class="ml-2">
+            <span
+              v-if="proposal.type === 'basic' && hideAbstain && choice.i === 0"
+              v-text="
+                formatPercentNumber(
+                  getPercentage(
+                    results.resultsByVoteBalance[0],
+                    results.resultsByVoteBalance[0] +
+                      results.resultsByVoteBalance[1]
+                  )
                 )
-                .join(' + ')
-            }"
-          >
-            {{ formatCompactNumber(results.resultsByVoteBalance[choice.i]) }}
-            {{ shorten(space.symbol, 'symbol') }}
-          </span>
-          <span
-            v-if="proposal.type === 'basic' && hideAbstain && choice.i === 0"
-            class="float-right"
-            v-text="
-              formatPercentNumber(
-                getPercentage(
-                  results.resultsByVoteBalance[0],
-                  results.resultsByVoteBalance[0] +
-                    results.resultsByVoteBalance[1]
+              "
+            />
+            <span
+              v-else-if="
+                proposal.type === 'basic' && hideAbstain && choice.i === 1
+              "
+              v-text="
+                formatPercentNumber(
+                  getPercentage(
+                    results.resultsByVoteBalance[1],
+                    results.resultsByVoteBalance[0] +
+                      results.resultsByVoteBalance[1]
+                  )
                 )
-              )
-            "
-          />
-          <span
-            v-else-if="
-              proposal.type === 'basic' && hideAbstain && choice.i === 1
-            "
-            class="float-right"
-            v-text="
-              formatPercentNumber(
-                getPercentage(
-                  results.resultsByVoteBalance[1],
-                  results.resultsByVoteBalance[0] +
-                    results.resultsByVoteBalance[1]
+              "
+            />
+            <span
+              v-else
+              v-text="
+                formatPercentNumber(
+                  getPercentage(
+                    results.resultsByVoteBalance[choice.i],
+                    results.sumOfResultsBalance
+                  )
                 )
-              )
-            "
-          />
-          <span
-            v-else
-            class="float-right"
-            v-text="
-              formatPercentNumber(
-                getPercentage(
-                  results.resultsByVoteBalance[choice.i],
-                  results.sumOfResultsBalance
-                )
-              )
-            "
-          />
+              "
+            />
+          </div>
         </div>
         <UiProgress
           :value="results.resultsByStrategyScore[choice.i]"

--- a/src/components/Block/Votes.vue
+++ b/src/components/Block/Votes.vue
@@ -98,9 +98,9 @@ watch(visibleVotes, () => {
         :address="vote.voter"
         :space="space"
         :proposal="proposal"
-        class="column"
+        class="min-w-[90px]"
       />
-      <div class="flex-auto text-center link-color">
+      <div class="flex-auto text-center link-color truncated px-3">
         <span
           class="text-center link-color"
           v-tippy="{
@@ -110,11 +110,11 @@ watch(visibleVotes, () => {
                 : null
           }"
         >
-          {{ shorten(format(proposal, vote.choice), 24) }}
+          {{ format(proposal, vote.choice) }}
         </span>
       </div>
 
-      <div class="column text-right link-color">
+      <div class="min-w-[80px] text-right link-color whitespace-nowrap">
         <span
           v-tippy="{
             content: vote.scores

--- a/src/components/Modal/Confirm.vue
+++ b/src/components/Modal/Confirm.vue
@@ -61,7 +61,15 @@ async function handleSubmit() {
       <div class="m-4 p-4 border rounded-md link-color">
         <div class="flex">
           <span v-text="$t('options')" class="flex-auto text-color mr-1" />
-          <span class="text-right ml-4">
+          <span
+            v-tippy="{
+              content:
+                format(proposal, selectedChoices).length > 30
+                  ? format(proposal, selectedChoices)
+                  : null
+            }"
+            class="text-right ml-4 truncated"
+          >
             {{ format(proposal, selectedChoices) }}
           </span>
         </div>

--- a/src/components/SpaceSidebarHeader.vue
+++ b/src/components/SpaceSidebarHeader.vue
@@ -42,7 +42,7 @@ watchEffect(() => {
       <Token :space="space" symbolIndex="space" size="80" class="mt-3 mb-2" />
       <h3 class="mb-[2px] mx-2 flex justify-center items-center">
         <div
-          class="max-w-[70%] truncate mr-1"
+          class="truncated mr-1"
           v-tippy="{
             content: space.name.length > 16 ? space.name : null
           }"

--- a/src/components/Voting/Quadratic.vue
+++ b/src/components/Voting/Quadratic.vue
@@ -54,22 +54,19 @@ watch(selectedChoices.value, currentValue => {
   <div class="mb-3">
     <div v-for="(choice, i) in proposal.choices" :key="i">
       <UiButton
-        class="block w-full mb-2"
+        class="mb-2 flex justify-between items-center w-full overflow-hidden"
         :class="selectedChoices[i + 1] > 0 && 'button--active'"
       >
         <div
-          class="inline-block w-7/12 sm:w-8/12 float-left text-left pr-3"
+          class="text-left pr-3 truncated"
           v-tippy="{
-            content: choice
+            content: choice.length > 20 && isSmallScreen ? choice : null
           }"
         >
-          <span class="truncated w-full">
-            {{ choice }}
-          </span>
+          {{ choice }}
         </div>
-        <div class="w-4/12 flex items-center justify-end float-right">
+        <div class="flex items-center justify-end">
           <button
-            v-if="!isSmallScreen"
             :disabled="!selectedChoices[i + 1]"
             class="btn-choice"
             @click="removeVote(i + 1)"
@@ -77,6 +74,7 @@ watch(selectedChoices.value, currentValue => {
             -
           </button>
           <input
+            v-if="!isSmallScreen"
             class="input text-center"
             :class="{ 'btn-choice': isSmallScreen }"
             style="width: 40px; height: 44px"
@@ -84,14 +82,15 @@ watch(selectedChoices.value, currentValue => {
             type="number"
             v-model.number="selectedChoices[i + 1]"
           />
-          <button
+          <div v-if="isSmallScreen" style="min-width: 56px">
+            {{ percentage(i) }}%
+          </div>
+          <button class="btn-choice" @click="addVote(i + 1)">+</button>
+          <div
             v-if="!isSmallScreen"
-            class="btn-choice"
-            @click="addVote(i + 1)"
+            style="min-width: 52px; margin-right: -5px"
+            class="text-right"
           >
-            +
-          </button>
-          <div style="min-width: 52px; margin-right: -5px" class="text-right">
             {{ percentage(i) }}%
           </div>
         </div>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -51,7 +51,7 @@
   "confirmRemove": "Are you sure you want to remove your delegation to",
   "removeSpace": "for the space {0}",
   "confirmVote": "Confirm vote",
-  "sureToVote": "Are you sure you want to vote \"{0}\"?",
+  "sureToVote": "Are you sure you want to cast this vote?",
   "cannotBeUndone": "This action cannot be undone.",
   "options": "Option(s)",
   "votingPower": "Your voting power",

--- a/src/style.scss
+++ b/src/style.scss
@@ -273,6 +273,10 @@ input[type='number']::-webkit-outer-spin-button {
   margin: 0;
 }
 
+input[type='number'] {
+  -moz-appearance: textfield;
+}
+
 .tippy-box[data-animation='fade'][data-state='hidden'] {
   opacity: 0;
 }


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/1527 and https://github.com/snapshot-labs/snapshot/issues/1526

Changes proposed in this pull request:
- Remove html increment button on firefox 
![image](https://user-images.githubusercontent.com/51686767/151178120-abf20064-5228-4391-8503-ab197d4b2d39.png)
- Fix RCV and weighted voting alignments
- Fix confirm modal choice string length and show tooltip

Before:
![image](https://user-images.githubusercontent.com/51686767/151180813-1bd26f4a-4a47-4dc9-bac9-6c95fc5adb47.png)


After:
![image](https://user-images.githubusercontent.com/51686767/151181097-034c3e4d-dd06-4506-8d86-98690268a256.png)
![image](https://user-images.githubusercontent.com/51686767/151181428-0cbb860d-950e-4576-ad17-9497ec090b98.png)

- Fix choice string not filling up available space in multiple components on proposal page


Before - After
<img width="237" alt="Screen Shot 2022-01-26 at 9 04 37 PM" src="https://user-images.githubusercontent.com/51686767/151177693-d286d911-88e3-41b5-9641-df30b3c226d4.png"> <img width="237" alt="Screen Shot 2022-01-26 at 9 04 18 PM" src="https://user-images.githubusercontent.com/51686767/151177680-9675c53c-2fb7-4e8e-9ab9-3297751757aa.png">



