### PR TITLE
[snapshot] make static call (avoid hash calculation)

### DIFF
--- a/src/components/Plugin/SafeSnap/Config.vue
+++ b/src/components/Plugin/SafeSnap/Config.vue
@@ -16,19 +16,28 @@ export default {
   ],
   emits: ['update:modelValue'],
   data() {
-    const initialValue = {
-      safes: coerceConfig(this.config, this.network).safes.map(safe => ({
-        ...safe,
-        hash: null,
-        txs: []
-      })),
-      valid: true
-    };
-    return {
-      input: this.modelValue
-        ? coerceConfig(clone(this.modelValue), this.network)
-        : initialValue
-    };
+    let input;
+    if (!this.modelValue) {
+      input = {
+        safes: coerceConfig(this.config, this.network).safes.map(safe => ({
+          ...safe,
+          hash: null,
+          txs: []
+        })),
+        valid: true
+      };
+    } else {
+      const value = clone(this.modelValue);
+      if (value.safes && this.config && Array.isArray(this.config.safes)) {
+        value.safes = value.safes.map((safe, index) => ({
+          ...this.config.safes[index],
+          ...safe
+        }));
+      }
+      input = coerceConfig(value, this.network);
+    }
+
+    return { input };
   },
   methods: {
     updateSafeTransactions() {


### PR DESCRIPTION
**:warning: [THIS PR](https://github.com/snapshot-labs/snapshot-plugins/pull/66) IN THE [SNAPSHOT-PLUGINS REPO](https://github.com/snapshot-labs/snapshot-plugins) NEEDS TO BE MERGED FIRST :warning:**

### Summary
Changing the multi-send contract logic and setting by default the newest version of the contract, causes some retro-compatibility errors.
To avoid this, multi-send transactions are also stored in IPFS and some logic was added to support older version.
now all versions should work properly. 