### PR TITLE
fixed position for actions block on settings page

### DIFF
--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -639,20 +639,22 @@ watchEffect(() => {
       </template>
     </template>
     <template v-if="(loaded && isOwner) || (loaded && isAdmin)" #sidebar-right>
-      <Block :title="$t('actions')">
-        <UiButton @click="handleReset" class="block w-full mb-2">
-          {{ $t('reset') }}
-        </UiButton>
-        <UiButton
-          :disabled="uploadLoading"
-          @click="handleSubmit"
-          :loading="clientLoading"
-          class="block w-full"
-          primary
-        >
-          {{ $t('save') }}
-        </UiButton>
-      </Block>
+      <div class="lg:fixed lg:w-[300px]">
+        <Block :title="$t('actions')">
+          <UiButton @click="handleReset" class="block w-full mb-2">
+            {{ $t('reset') }}
+          </UiButton>
+          <UiButton
+            :disabled="uploadLoading"
+            @click="handleSubmit"
+            :loading="clientLoading"
+            class="block w-full"
+            primary
+          >
+            {{ $t('save') }}
+          </UiButton>
+        </Block>
+      </div>
     </template>
   </Layout>
   <teleport to="#modal">


### PR DESCRIPTION
Did really nobody ask for this yet?

Just wrapped it in a `<div class="lg:fixed lg:w-[300px]">`.

![settings-block-fixed-position](https://user-images.githubusercontent.com/6792578/151627042-b7f60009-68d4-4ebb-8fb4-96dc2a6a963d.gif)
