### PR TITLE
[safesnap] pass tuple params for contract interactions

### DIFF
--- a/src/components/Plugin/SafeSnap/Form/ContractInteraction.vue
+++ b/src/components/Plugin/SafeSnap/Form/ContractInteraction.vue
@@ -225,8 +225,7 @@ export default {
         :key="input.name"
         :disabled="config.preview"
         :modelValue="parameters[index]"
-        :name="input.name"
-        :type="input.type"
+        :parameter="input"
         @update:modelValue="handleParameterChanged(index, $event)"
       />
     </div>

--- a/src/components/Plugin/SafeSnap/Input/ArrayType.vue
+++ b/src/components/Plugin/SafeSnap/Input/ArrayType.vue
@@ -10,7 +10,7 @@ import {
 
 const getPlaceholder = (name, type) => {
   if (isAddress(type)) {
-    return 'E.g.: ["0xACa94ef8bD5ffEE41947b4585a84BdA5a3d3DA6E","0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e"]';
+    return 'E.g.: ["0xACa9...DA6E","0x1dF6...006e"]';
   }
 
   if (isBoolean(type)) {
@@ -32,12 +32,25 @@ const getPlaceholder = (name, type) => {
   return 'E.g.: ["first value", "second value", "third value"]';
 };
 
+function getLabel(parameter) {
+  let type = parameter.type;
+  if (parameter.baseType === 'tuple') {
+    const components = parameter.components.map(param => param.type).join(', ');
+    type = `${type}(${components})`;
+  }
+  if (parameter.name) return `${parameter.name} (${type})`;
+  return type;
+}
+
 export default {
-  props: ['name', 'type', 'disabled'],
+  props: ['parameter', 'disabled'],
   emits: [],
   data() {
-    const label = `${this.name} (${this.type})`;
-    const placeholder = getPlaceholder(this.name, this.type);
+    const label = getLabel(this.parameter);
+    const placeholder = getPlaceholder(
+      this.parameter.name,
+      this.parameter.type
+    );
     return {
       input: '',
       dirty: false,

--- a/src/components/Plugin/SafeSnap/Input/MethodParameter.vue
+++ b/src/components/Plugin/SafeSnap/Input/MethodParameter.vue
@@ -1,17 +1,20 @@
 <script>
-import { isArrayParameter, isParameterValue } from '@/helpers/validator';
+import { isParameterValue } from '@/helpers/validator';
+import { isArrayParameter } from '@/../snapshot-plugins/src/plugins/safeSnap';
 
 export default {
-  props: ['modelValue', 'name', 'type', 'disabled'],
+  props: ['modelValue', 'disabled', 'parameter'],
   emits: ['update:modelValue', 'isValid'],
   mounted() {
     if (this.modelValue) this.value = this.modelValue;
   },
   data() {
-    const placeholder = this.name ? `${this.name} (${this.type})` : this.type;
+    const placeholder = this.parameter.name
+      ? `${this.parameter.name} (${this.parameter.type})`
+      : this.parameter.type;
 
     let value;
-    if (this.type === 'bool') value = false;
+    if (this.parameter.type === 'bool') value = false;
 
     return {
       placeholder,
@@ -29,7 +32,7 @@ export default {
   },
   computed: {
     isValid() {
-      return isParameterValue(this.type, this.value);
+      return isParameterValue(this.parameter.baseType, this.value);
     }
   },
   methods: {
@@ -40,7 +43,7 @@ export default {
       this.$emit('isValid', this.isValid);
     },
     isArrayType() {
-      return isArrayParameter(this.type);
+      return isArrayParameter(this.parameter.baseType);
     }
   }
 };
@@ -48,7 +51,7 @@ export default {
 
 <template>
   <UiSelect
-    v-if="type === 'bool'"
+    v-if="parameter.type === 'bool'"
     :disabled="disabled"
     :modelValue="value"
     @update:modelValue="handleInput($event)"
@@ -60,11 +63,9 @@ export default {
 
   <!-- ADDRESS -->
   <PluginSafeSnapInputAddress
-    v-else-if="type === 'address'"
+    v-else-if="parameter.type === 'address'"
     :disabled="disabled"
-    :inputProps="{
-      required: true
-    }"
+    :inputProps="{ required: true }"
     :label="this.placeholder"
     :modelValue="value"
     @update:modelValue="handleInput($event)"
@@ -74,15 +75,14 @@ export default {
     v-else-if="isArrayType()"
     :disabled="disabled"
     :modelValue="value"
-    :name="name"
-    :type="type"
+    :parameter="parameter"
     @update:modelValue="handleInput($event)"
   />
   <!-- Text input -->
   <UiInput
     v-else
     :disabled="disabled"
-    :error="dirty && !isValid && `Invalid ${type}`"
+    :error="dirty && !isValid && `Invalid ${parameter.type}`"
     :modelValue="value"
     @update:modelValue="handleInput($event)"
   >

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -1,4 +1,7 @@
-import { mustBeEthereumAddress } from '@/../snapshot-plugins/src/plugins/safeSnap';
+import {
+  mustBeEthereumAddress,
+  isArrayParameter
+} from '@/../snapshot-plugins/src/plugins/safeSnap';
 
 export const isAddress = (type: string): boolean =>
   type.indexOf('address') === 0;
@@ -7,9 +10,6 @@ export const isString = (type: string): boolean => type.indexOf('string') === 0;
 export const isUint = (type: string): boolean => type.indexOf('uint') === 0;
 export const isInt = (type: string): boolean => type.indexOf('int') === 0;
 export const isByte = (type: string): boolean => type.indexOf('byte') === 0;
-
-export const isArrayParameter = (parameter: string): boolean =>
-  /(\[\d*])+$/.test(parameter);
 
 export const isStringArray = (text: string): boolean => {
   try {


### PR DESCRIPTION
**:warning: [THIS PR](https://github.com/snapshot-labs/snapshot-plugins/pull/68) IN THE [SNAPSHOT-PLUGINS REPO](https://github.com/snapshot-labs/snapshot-plugins) NEEDS TO BE MERGED FIRST :warning:**

### Summary
As described in this issue https://github.com/snapshot-labs/snapshot-plugins/issues/65, creating contract interactions using functions with a tuple as a param was not possible.
This PR adds logic to handle tuples as params.