### PR TITLE
[safesnap] Value field as wei in batch json transactions

### DIFF
--- a/src/components/Plugin/SafeSnap/Form/TransactionBatch.vue
+++ b/src/components/Plugin/SafeSnap/Form/TransactionBatch.vue
@@ -72,7 +72,7 @@ export default {
         const base = {
           to: tx.to,
           operation: tx.operation,
-          value: formatEther(tx.value)
+          value: tx.value.toString()
         };
 
         let abi = tx.abi;


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot-plugins/issues/71

## Summary
In the Batch JSON transactions section, the transactions within a batch are listed as JSON.
The value field unit was ETH, this is now changed to WEI.


## Screenshots
| Before | After |
| - | - |
| <img width="574" alt="Screen Shot 2022-02-02 at 3 12 59 AM" src="https://user-images.githubusercontent.com/2939980/152109988-9f1ae43e-ff7c-4f03-8576-77e526d4d9e8.png"> | <img width="563" alt="Screen Shot 2022-02-02 at 3 12 28 AM" src="https://user-images.githubusercontent.com/2939980/152109987-468fc4a2-e36f-4f0d-895c-a3b202e7839e.png"> |
