### PR TITLE
Fixed plugin data not loaded when duplicating a proposal

### DIFF
--- a/src/plugins/gnosis/CreateSidebar.vue
+++ b/src/plugins/gnosis/CreateSidebar.vue
@@ -22,7 +22,7 @@ const update = form => {
       v-if="space.plugins.gnosis"
       :proposal="proposal"
       :network="space.network"
-      :modelValue="modelValue"
+      :modelValue="modelValue?.gnosis || {}"
       @update:modelValue="update"
     />
   </Block>

--- a/src/plugins/safeSnap/Create.vue
+++ b/src/plugins/safeSnap/Create.vue
@@ -19,6 +19,6 @@ const update = form => {
     :network="space.network"
     :preview="preview"
     @update:modelValue="update"
-    :modelValue="modelValue"
+    :modelValue="modelValue?.safeSnap || {}"
   />
 </template>

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -173,6 +173,7 @@ function clickSubmit() {
 
 const { apolloQuery, queryLoading } = useApolloQuery();
 
+const sourceProposalLoaded = ref(false);
 async function loadProposal() {
   const proposal = await apolloQuery(
     {
@@ -201,6 +202,8 @@ async function loadProposal() {
     key,
     text
   }));
+
+  sourceProposalLoaded.value = true;
 }
 
 onMounted(async () => {
@@ -358,7 +361,7 @@ watchEffect(() => {
         </UiButton>
       </Block>
       <PluginCreate
-        v-if="space?.plugins"
+        v-if="space?.plugins && (!from || sourceProposalLoaded)"
         :proposal="proposal"
         :space="space"
         :preview="preview"
@@ -415,7 +418,7 @@ watchEffect(() => {
         </UiButton>
       </Block>
       <PluginCreateSidebar
-        v-if="space?.plugins"
+        v-if="space?.plugins && (!from || sourceProposalLoaded)"
         :proposal="proposal"
         :space="space"
         :preview="preview"


### PR DESCRIPTION
If you duplicate a proposal, the plugin form components must wait for that proposal data to be loaded. I simply wasn't aware (enough) of that feature. 🙈