### PR TITLE
export t() from useI18n compoable and moved setPageTitle to it

### DIFF
--- a/src/components/Block/ResultsError.vue
+++ b/src/components/Block/ResultsError.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 const { t } = useI18n();
 
 defineProps<{

--- a/src/components/Modal/Confirm.vue
+++ b/src/components/Modal/Confirm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, inject, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { shorten, getChoiceString, explorerUrl } from '@/helpers/utils';
 import { useClient } from '@/composables/useClient';
 import { useIntl } from '@/composables/useIntl';

--- a/src/components/Modal/RevokeDelegate.vue
+++ b/src/components/Modal/RevokeDelegate.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, watchEffect, inject } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { useUsername } from '@/composables/useUsername';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { sendTransaction, sleep } from '@snapshot-labs/snapshot.js/src/utils';

--- a/src/components/NoResults.vue
+++ b/src/components/NoResults.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 const { t } = useI18n();
 defineProps(['block']);
 const text = computed(() => t('noResultsFound'));

--- a/src/components/Plugin/CommentBox/Comment.vue
+++ b/src/components/Plugin/CommentBox/Comment.vue
@@ -6,7 +6,8 @@ import { useModal } from '@/composables/useModal';
 import { useWeb3 } from '@/composables/useWeb3';
 import { signMessage } from '@snapshot-labs/snapshot.js/src/utils/web3';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
+
 const { t } = useI18n();
 const auth = getInstance();
 const { modalOpen, modalAccountOpen } = useModal();

--- a/src/components/Plugin/CommentBox/CommentBlock.vue
+++ b/src/components/Plugin/CommentBox/CommentBlock.vue
@@ -5,7 +5,7 @@ import { useModal } from '@/composables/useModal';
 import { useWeb3 } from '@/composables/useWeb3';
 import { signMessage } from '@snapshot-labs/snapshot.js/src/utils/web3';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { useIntl } from '@/composables/useIntl';
 
 const { formatRelativeTime } = useIntl();

--- a/src/components/Plugin/CommentBox/CustomBlock.vue
+++ b/src/components/Plugin/CommentBox/CustomBlock.vue
@@ -7,7 +7,7 @@ import { useProfiles } from '@/composables/useProfiles';
 import { useNotifications } from '@/composables/useNotifications';
 import { useScrollMonitor } from '@/composables/useScrollMonitor';
 import { signMessage } from '@snapshot-labs/snapshot.js/src/utils/web3';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 const { t } = useI18n();
 const props = defineProps({
   proposalId: String,

--- a/src/components/Plugin/CommentBox/ReplyBlock.vue
+++ b/src/components/Plugin/CommentBox/ReplyBlock.vue
@@ -5,7 +5,7 @@ import { useModal } from '@/composables/useModal';
 import { useWeb3 } from '@/composables/useWeb3';
 import { signMessage } from '@snapshot-labs/snapshot.js/src/utils/web3';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { useIntl } from '@/composables/useIntl';
 
 const { formatRelativeTime } = useIntl();

--- a/src/components/Plugin/SafeSnap/HandleOutcome.vue
+++ b/src/components/Plugin/SafeSnap/HandleOutcome.vue
@@ -166,7 +166,7 @@ import { useWeb3 } from '@/composables/useWeb3';
 import { useTxStatus } from '@/composables/useTxStatus';
 import { useNotifications } from '@/composables/useNotifications';
 import { useIntl } from '@/composables/useIntl';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 
 const { formatRelativeTime } = useIntl();
 const { t } = useI18n();

--- a/src/components/SearchWithFilters.vue
+++ b/src/components/SearchWithFilters.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 
 defineEmits(['update:modelValue']);
 

--- a/src/components/TimelineProposalPreview.vue
+++ b/src/components/TimelineProposalPreview.vue
@@ -4,7 +4,7 @@ import { shorten } from '@/helpers/utils';
 import { useUsername } from '@/composables/useUsername';
 import removeMd from 'remove-markdown';
 import { useIntl } from '@/composables/useIntl';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 
 const { t } = useI18n();
 

--- a/src/composables/useClient.ts
+++ b/src/composables/useClient.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import client from '@/helpers/client';
 import clientGnosisSafe from '@/helpers/clientGnosisSafe';
 import clientEIP712 from '@/helpers/clientEIP712';

--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -1,4 +1,4 @@
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { useClipboard } from '@vueuse/core';
 import { useNotifications } from '@/composables/useNotifications';
 

--- a/src/composables/useI18n.ts
+++ b/src/composables/useI18n.ts
@@ -9,6 +9,8 @@ import i18n, {
 const currentLocale = ref(lsGet('locale', defaultLocale));
 
 export function useI18n() {
+  const { t } = i18n.global;
+
   async function setLocale(locale) {
     currentLocale.value = locale;
     lsSet('locale', locale);
@@ -21,5 +23,9 @@ export function useI18n() {
     setI18nLanguage(i18n, currentLocale.value);
   }
 
-  return { setLocale, loadLocale, currentLocale };
+  function setPageTitle(message, params: any = {}) {
+    document.title = t(message, params);
+  }
+
+  return { t, setLocale, loadLocale, currentLocale, setPageTitle };
 }

--- a/src/composables/useSharing.ts
+++ b/src/composables/useSharing.ts
@@ -1,4 +1,4 @@
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { useCopy } from '@/composables/useCopy';
 import { useShare } from '@vueuse/core';
 

--- a/src/composables/useSpaceSubscription.ts
+++ b/src/composables/useSpaceSubscription.ts
@@ -5,7 +5,7 @@ import { SUBSCRIPTIONS_QUERY } from '@/helpers/queries';
 import { useAliasAction } from '@/composables/useAliasAction';
 import { beams } from '../helpers/beams';
 import { useNotifications } from './useNotifications';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import client from '@/helpers/clientEIP712';
 
 const subscriptions = ref<any[] | undefined>(undefined);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -4,7 +4,6 @@ import { BigNumber } from '@ethersproject/bignumber';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import voting from '@snapshot-labs/snapshot.js/src/voting';
 import { getUrl } from '@snapshot-labs/snapshot.js/src/utils';
-import i18n from '@/helpers/i18n';
 
 export function shortenAddress(str = '') {
   return `${str.slice(0, 6)}...${str.slice(str.length - 4)}`;
@@ -124,11 +123,6 @@ export function calcFromSeconds(value, unit) {
 export function calcToSeconds(value, unit) {
   if (unit === 'h') return value * 60 * 60;
   if (unit === 'd') return value * 60 * 60 * 24;
-}
-
-export function setPageTitle(message, params: any = {}) {
-  const { t } = i18n.global;
-  document.title = t(message, params);
 }
 
 export function getIpfsUrl(url) {

--- a/src/views/Delegate.vue
+++ b/src/views/Delegate.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, watchEffect, inject } from 'vue';
 import { useRoute } from 'vue-router';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { useProfiles } from '@/composables/useProfiles';
 import { isAddress } from '@ethersproject/address';
 import { formatBytes32String } from '@ethersproject/strings';
@@ -21,7 +21,7 @@ import {
 import { sleep } from '@snapshot-labs/snapshot.js/src/utils';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useTxStatus } from '@/composables/useTxStatus';
-import { shorten, setPageTitle } from '@/helpers/utils';
+import { shorten } from '@/helpers/utils';
 import { useIntl } from '@/composables/useIntl';
 import { debouncedWatch } from '@vueuse/core';
 import { SPACE_DELEGATE_QUERY } from '@/helpers/queries';
@@ -34,7 +34,7 @@ import { SNAPSHOT_SUBGRAPH_URL } from '@snapshot-labs/snapshot.js/src/utils';
 const abi = ['function setDelegate(bytes32 id, address delegate)'];
 
 const route = useRoute();
-const { t } = useI18n();
+const { t, setPageTitle } = useI18n();
 const auth = getInstance();
 const notify = inject('notify');
 const { web3, web3Account } = useWeb3();

--- a/src/views/Explore.vue
+++ b/src/views/Explore.vue
@@ -1,15 +1,14 @@
 <script setup>
 import { computed, ref, onMounted, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { useRoute } from 'vue-router';
 import { useScrollMonitor } from '@/composables/useScrollMonitor';
-import { setPageTitle } from '@/helpers/utils';
 import { useIntl } from '@/composables/useIntl';
 import { useNetworksFilter } from '@/composables/useNetworksFilter';
 import { useStrategies } from '@/composables/useStrategies';
 import { usePlugins } from '@/composables/usePlugins';
 
-const { t } = useI18n();
+const { t, setPageTitle } = useI18n();
 const { formatCompactNumber } = useIntl();
 const route = useRoute();
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -5,13 +5,15 @@ import { useScrollMonitor } from '@/composables/useScrollMonitor';
 import { useApp } from '@/composables/useApp';
 import { useFollowSpace } from '@/composables/useFollowSpace';
 import { useCategories } from '@/composables/useCategories';
-import { shorten, setPageTitle } from '@/helpers/utils';
+import { shorten } from '@/helpers/utils';
 import { useIntl } from '@/composables/useIntl';
+import { useI18n } from '@/composables/useI18n';
 
 const { selectedCategory, orderedSpaces, orderedSpacesByCategory } = useApp();
 const { followingSpaces } = useFollowSpace();
 const { spacesPerCategory, categoriesOrderedBySpaceCount } = useCategories();
 const { formatCompactNumber } = useIntl();
+const { setPageTitle } = useI18n();
 
 function selectCategory(c) {
   selectedCategory.value = c === selectedCategory.value ? '' : c;

--- a/src/views/Playground.vue
+++ b/src/views/Playground.vue
@@ -5,10 +5,9 @@ import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import getProvider from '@snapshot-labs/snapshot.js/src/utils/provider';
 import { getBlockNumber } from '@snapshot-labs/snapshot.js/src/utils/web3';
 import { getScores } from '@snapshot-labs/snapshot.js/src/utils';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { useCopy } from '@/composables/useCopy';
 import { decode, encode } from '@/helpers/b64';
-import { setPageTitle } from '@/helpers/utils';
 import { useIntl } from '@/composables/useIntl';
 import { useStrategies } from '@/composables/useStrategies';
 
@@ -22,7 +21,7 @@ const router = useRouter();
 const route = useRoute();
 const { query: queryParams } = useRoute();
 const { copyToClipboard } = useCopy();
-const { t } = useI18n();
+const { t, setPageTitle } = useI18n();
 const { formatCompactNumber } = useIntl();
 const {
   getExtendedStrategy,

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -3,13 +3,14 @@ import { ref, watch, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useModal } from '@/composables/useModal';
-import { setPageTitle } from '@/helpers/utils';
+import { useI18n } from '@/composables/useI18n';
 import { useEns } from '@/composables/useEns';
 
 const router = useRouter();
 const { web3, web3Account } = useWeb3();
 const { modalAccountOpen } = useModal();
 const { loadOwnedEnsDomains, ownedEnsDomains } = useEns();
+const { setPageTitle } = useI18n();
 
 onMounted(() => {
   setPageTitle('page.title.setup');

--- a/src/views/SpaceAbout.vue
+++ b/src/views/SpaceAbout.vue
@@ -3,7 +3,7 @@ import { computed, watchEffect } from 'vue';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { useProfiles } from '@/composables/useProfiles';
 import { getUrl } from '@snapshot-labs/snapshot.js/src/utils';
-import { setPageTitle } from '@/helpers/utils';
+import { useI18n } from '@/composables/useI18n';
 import { useIntl } from '@/composables/useIntl';
 
 const props = defineProps({
@@ -15,6 +15,7 @@ const props = defineProps({
 const network = computed(() => networks[props.space?.network]);
 
 const { formatCompactNumber } = useIntl();
+const { setPageTitle } = useI18n();
 const { profiles, loadProfiles } = useProfiles();
 
 watchEffect(() => {

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -2,7 +2,7 @@
 import { ref, watchEffect, computed, onMounted, inject } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import draggable from 'vuedraggable';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import getProvider from '@snapshot-labs/snapshot.js/src/utils/provider';
 import { getBlockNumber } from '@snapshot-labs/snapshot.js/src/utils/web3';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
@@ -16,7 +16,6 @@ import { useApolloQuery } from '@/composables/useApolloQuery';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useClient } from '@/composables/useClient';
 import { useStore } from '@/composables/useStore';
-import { setPageTitle } from '@/helpers/utils';
 import { useIntl } from '@/composables/useIntl';
 
 const props = defineProps({
@@ -26,7 +25,7 @@ const props = defineProps({
 });
 
 const router = useRouter();
-const { t } = useI18n();
+const { t, setPageTitle } = useI18n();
 const { formatCompactNumber } = useIntl();
 const auth = getInstance();
 const { domain } = useDomain();

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { ref, computed, watch, onMounted, inject, watchEffect } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { getProposal, getResults, getProposalVotes } from '@/helpers/snapshot';
-import { setPageTitle, explorerUrl, getIpfsUrl } from '@/helpers/utils';
+import { explorerUrl, getIpfsUrl } from '@/helpers/utils';
 import { useModal } from '@/composables/useModal';
 import { useTerms } from '@/composables/useTerms';
 import { useProfiles } from '@/composables/useProfiles';
@@ -24,7 +24,7 @@ const props = defineProps({
 const route = useRoute();
 const router = useRouter();
 const { domain } = useDomain();
-const { t } = useI18n();
+const { t, setPageTitle } = useI18n();
 const { web3, web3Account } = useWeb3();
 const { send, clientLoading } = useClient();
 const { store } = useStore();

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { watchEffect, computed, ref, watch } from 'vue';
 import { useStore } from '@/composables/useStore';
-import { setPageTitle } from '@/helpers/utils';
+import { useI18n } from '@/composables/useI18n';
 import { useInfiniteLoader } from '@/composables/useInfiniteLoader';
 import { useScrollMonitor } from '@/composables/useScrollMonitor';
 import { useApolloQuery } from '@/composables/useApolloQuery';
@@ -14,6 +14,7 @@ import { useWeb3 } from '@/composables/useWeb3';
 const props = defineProps({ space: Object, spaceId: String });
 
 const { store } = useStore();
+const { setPageTitle } = useI18n();
 
 const loading = ref(false);
 

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, ref, watchEffect, inject, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { useI18n } from '@/composables/useI18n';
 import { getAddress } from '@ethersproject/address';
 import {
   validateSchema,
@@ -14,7 +14,6 @@ import { useCopy } from '@/composables/useCopy';
 import { useWeb3 } from '@/composables/useWeb3';
 import { calcFromSeconds, calcToSeconds } from '@/helpers/utils';
 import { useClient } from '@/composables/useClient';
-import { setPageTitle } from '@/helpers/utils';
 import { usePlugins } from '@/composables/usePlugins';
 
 const props = defineProps({
@@ -29,7 +28,7 @@ const props = defineProps({
 const basicValidation = { name: 'basic', params: {} };
 
 const { pluginIndex } = usePlugins();
-const { t } = useI18n();
+const { t, setPageTitle } = useI18n();
 const { copyToClipboard } = useCopy();
 const { web3Account } = useWeb3();
 const { send, clientLoading } = useClient();

--- a/src/views/Strategy.vue
+++ b/src/views/Strategy.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import { setPageTitle } from '@/helpers/utils';
+import { useI18n } from '@/composables/useI18n';
 import { useStrategies } from '@/composables/useStrategies';
 
 const route = useRoute();
+const { setPageTitle } = useI18n();
 const { getExtendedStrategy, extendedStrategy: strategy } = useStrategies();
 
 onMounted(async () => {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -13,7 +13,7 @@ import { useWeb3 } from '@/composables/useWeb3';
 import verified from '@/../snapshot-spaces/spaces/verified.json';
 import zipObject from 'lodash/zipObject';
 import { useStore } from '@/composables/useStore';
-import { setPageTitle } from '@/helpers/utils';
+import { useI18n } from '@/composables/useI18n';
 
 const { store } = useStore();
 
@@ -22,6 +22,7 @@ const loading = ref(false);
 const route = useRoute();
 const { followingSpaces, loadingFollows } = useFollowSpace();
 const { web3, web3Account } = useWeb3();
+const { setPageTitle } = useI18n();
 
 const spaces = computed(() => {
   const verifiedSpaces = Object.entries(verified)


### PR DESCRIPTION
I'm currently trying [vitest](https://vitest.dev/) and that requires some cleanup work here and there it seems, or in other words... reveals the messy parts in our code. :-]

![image](https://user-images.githubusercontent.com/6792578/153686008-33aa5a1c-8ba8-4e9e-ad05-7b247c889768.png)

To avoid the naming conflict between the `useI18n` composable from the `i18n` plugin and our own `useI18n` composable, the `t` function is now exported from there, so we need only our own one in the components that use that function.

Then I moved the `setPageTitle` function over there too, because it depends on localization and therefore state and should be in a composable instead of utils. Later, when we implement more html meta info stuff, we might want to move it to a `useMetaInfo` composable. For now, this function must accept its new home. :D

So... lots of files but always the same change.