### PR TITLE
Improve space setup

### DIFF
--- a/src/components/SetupController.vue
+++ b/src/components/SetupController.vue
@@ -169,6 +169,20 @@ onMounted(async () => {
             >
               {{ $t('setup.updateController') }}
             </UiButton>
+            <div class="w-full text-center mb-2">{{ $t('or') }}</div>
+
+            <UiButton
+              class="button-outline w-full mb-2"
+              @click="
+                $router.push({
+                  name: 'spaceSettings',
+                  params: { key: ensAddress }
+                })
+              "
+              :loading="settingENSRecord"
+            >
+              {{ $t('setup.goToSettings') }}
+            </UiButton>
           </div>
           <div v-else-if="!currentTextRecord && ensOwner">
             <UiButton

--- a/src/components/SetupController.vue
+++ b/src/components/SetupController.vue
@@ -179,7 +179,7 @@ onMounted(async () => {
                   params: { key: ensAddress }
                 })
               "
-              :loading="settingENSRecord"
+              :disabled="settingENSRecord"
             >
               {{ $t('setup.goToSettings') }}
             </UiButton>

--- a/src/components/SetupController.vue
+++ b/src/components/SetupController.vue
@@ -155,7 +155,6 @@ onMounted(async () => {
         class="mt-2"
         focus-on-mount
       >
-        <template v-slot:label>{{ $t('setup.controllerAddress') }}</template>
       </UiInput>
 
       <div>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -277,7 +277,6 @@
     "controllerHasAuthority": "The controller has full authority over the space settings",
     "controller": "Controller",
     "selectEnsForSpace": "Choose ENS address",
-    "spaceNeedsEnsAddress": "To setup a space on snapshot you need a ENS address on the Ethereum Mainnet",
     "textRecordExists": "Currently the space controller is {address}. You can update the space controller by using the form below.",
     "spaceOwnerAddressPlaceHolder": "e.g. 0xF78108c9BBaF466dd96BE41be728Fe3220b37119",
     "controllerAddress": "Controller address",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -125,6 +125,7 @@
   "optional": "(optional)",
   "homeLoadmore": "Load more",
   "confirmAction": "Confirm action",
+  "or": "or",
   "errors": {
     "required": "Field is required",
     "minLength": "Minimum length is {0}",
@@ -282,7 +283,8 @@
     "controllerAddress": "Controller address",
     "updateController": "Update controller",
     "connectWithEnsController": "To modify the space controller you need to connect with the wallet that owns {ens}",
-    "seeOnEns": "See on ENS"
+    "seeOnEns": "See on ENS",
+    "goToSettings": "Go to settings"
   },
   "notify": {
     "youDidIt": "You did it!",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -269,7 +269,7 @@
     "registerEnsButton": "Register",
     "supportedEnsTLDs": "Supported domain endings",
     "helpDocsAndDiscordLinks": "Not sure how to create a space? Learn more in the <a target='_blank' href='https://docs.snapshot.org/spaces/create'> documentation </a> or join Snapshot <a target='_blank' href='https://discord.gg/snapshot'>Discord</a>.",
-    "setSpaceController": "Set controller on ENS",
+    "setSpaceController": "Set space controller address on ENS",
     "editSpaceController": "Edit controller on ENS",
     "setController": "Set controller",
     "explainControllerAndEns": "This action requires a transaction on the Ethereum Mainnet which will add a \"snapshot\" TEXT record to your ENS domain.",

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -106,7 +106,7 @@ onUnmounted(() => clearInterval(waitingForRegistrationInterval));
           v-else
           :title="$t('setup.selectEnsForSpace')"
           icon="info"
-          :iconTooltip="$t('setup.spaceNeedsEnsAddress')"
+          iconHref="https://docs.snapshot.org/spaces/before-creating-your-space"
         >
           <div v-if="ownedEnsDomainsNoExistingSpace.length">
             <div class="mb-3">


### PR DESCRIPTION
Issue https://github.com/snapshot-labs/snapshot/issues/1801

- Add back "or, Go to settings" button incase user gets stuck like we have the case linked in https://github.com/snapshot-labs/snapshot/issues/1801. This isn't optimal, but seems like an acceptable fix until we have reworked some more of our setup flow. I also want to note that this will only show if the text-record has already been set. <img width="1217" alt="image" src="https://user-images.githubusercontent.com/51686767/155102915-4e0d71d3-daf4-48bb-86ac-f4899f55f89e.png">
- Remove not really needed tooltip. About the same text is shown when there are no registered ENS domains for the connected wallet.
- Remove input label that wasn't really needed and was using a lot of space and instead made it more clear in the block title 