### PR TITLE
workaround for bug in remove-markdown

### DIFF
--- a/src/components/TimelineProposal.vue
+++ b/src/components/TimelineProposal.vue
@@ -12,7 +12,10 @@ const props = defineProps({
   space: Object
 });
 
-const body = computed(() => removeMd(props.proposal.body));
+// shortening to twice the allowed character limit (140*2) before removing markdown
+// due to a bug in remove-markdown: https://github.com/stiang/remove-markdown/issues/52
+// until this is fixed we need to avoid applying that function to very long texts with a lot of markdown
+const body = computed(() => removeMd(shorten(props.proposal.body, 280)));
 
 const winningChoice = computed(() =>
   props.proposal.scores.indexOf(Math.max(...props.proposal.scores))

--- a/src/components/TimelineProposal.vue
+++ b/src/components/TimelineProposal.vue
@@ -15,6 +15,7 @@ const props = defineProps({
 // shortening to twice the allowed character limit (140*2) before removing markdown
 // due to a bug in remove-markdown: https://github.com/stiang/remove-markdown/issues/52
 // until this is fixed we need to avoid applying that function to very long texts with a lot of markdown
+// see also: TimelineProposalPreview.vue
 const body = computed(() => removeMd(shorten(props.proposal.body, 280)));
 
 const winningChoice = computed(() =>

--- a/src/components/TimelineProposalPreview.vue
+++ b/src/components/TimelineProposalPreview.vue
@@ -20,7 +20,11 @@ const props = defineProps({
   profiles: Object
 });
 
-const body = computed(() => removeMd(props.proposal.body));
+// shortening to twice the allowed character limit (140*2) before removing markdown
+// due to a bug in remove-markdown: https://github.com/stiang/remove-markdown/issues/52
+// until this is fixed we need to avoid applying that function to very long texts with a lot of markdown
+// see also: TimelineProposal.vue
+const body = computed(() => removeMd(shorten(props.proposal.body, 280)));
 
 const winningChoice = computed(() =>
   props.proposal.scores.indexOf(Math.max(...props.proposal.scores))


### PR DESCRIPTION
Fixes #1806.

There's a [bug in remove-markdown](https://github.com/stiang/remove-markdown/issues/52) causing this.

I couldn't find anything but in case someone complains now about too short preview texts or weirdly cut-off things, we can slightly increase the character count for shortening before calling `removeMd` (280).