### PR TITLE
add ens rinkeby subgraph support

### DIFF
--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -4,9 +4,12 @@ import {
   InMemoryCache
 } from '@apollo/client/core';
 
-const httpLink = createHttpLink({
-  uri: 'https://api.thegraph.com/subgraphs/name/ensdomains/ens'
-});
+const uri =
+  import.meta.env.VITE_DEFAULT_NETWORK === '4'
+    ? 'https://api.thegraph.com/subgraphs/name/ensdomains/ensrinkeby'
+    : 'https://api.thegraph.com/subgraphs/name/ensdomains/ens';
+
+const httpLink = createHttpLink({ uri });
 
 export const ensApolloClient = new ApolloClient({
   link: httpLink,


### PR DESCRIPTION
I still think the name `DEFAULT_NETWORK` isn't super appropriate but the space creation works now with Rinkeby ENS domains when set to `'4'`

https://github.com/ensdomains/ens-subgraph/issues/41#issuecomment-1048268488