### PR TITLE
fix missing scrollbar after voting

### DIFF
--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -33,24 +33,24 @@ const id = route.params.id;
 
 const modalOpen = ref(false);
 const selectedChoices = ref(null);
-const loading = ref(true);
+const loadingProposal = ref(true);
 const loadedResults = ref(false);
 const loadingResultsFailed = ref(false);
 const loadedVotes = ref(false);
-const proposal = ref({});
+const proposal = ref(null);
 const votes = ref([]);
 const userVote = ref([]);
 const results = ref({});
 const modalStrategiesOpen = ref(false);
 
-const isCreator = computed(() => proposal.value.author === web3Account.value);
+const isCreator = computed(() => proposal.value?.author === web3Account.value);
 const isAdmin = computed(() => {
   const admins = (props.space.admins || []).map(admin => admin.toLowerCase());
   return admins.includes(web3Account.value?.toLowerCase());
 });
 const strategies = computed(
   // Needed for older proposal that are missing strategies
-  () => proposal.value.strategies ?? props.space?.strategies
+  () => proposal.value?.strategies ?? props.space?.strategies
 );
 
 const symbols = computed(() =>
@@ -77,7 +77,7 @@ function clickVote() {
 }
 
 async function loadProposal() {
-  loading.value = true;
+  loadingProposal.value = true;
   proposal.value = await getProposal(id);
   // Redirect to proposal space.id if it doesn't match route key
   if (
@@ -86,7 +86,7 @@ async function loadProposal() {
   ) {
     router.push({ name: 'error-404' });
   }
-  loading.value = false;
+  loadingProposal.value = false;
   loadResults();
 }
 
@@ -264,7 +264,7 @@ const truncateMarkdownBody = computed(() => {
         </a>
       </div>
       <div class="px-4 md:px-0">
-        <template v-if="!loading">
+        <template v-if="proposal">
           <h1 v-text="proposal.title" class="mb-3" />
 
           <div class="flex items-center justify-between mb-4">
@@ -378,7 +378,7 @@ const truncateMarkdownBody = computed(() => {
         <PageLoading v-else />
       </div>
       <BlockCastVote
-        v-if="!loading && proposal.state === 'active'"
+        v-if="proposal?.state === 'active'"
         :proposal="proposal"
         v-model="selectedChoices"
         @open="modalOpen = true"
@@ -386,7 +386,7 @@ const truncateMarkdownBody = computed(() => {
       />
       <BlockVotes
         @loadVotes="loadMore(loadMoreVotes)"
-        v-if="!loading && !loadingResultsFailed"
+        v-if="proposal && !loadingResultsFailed"
         :loaded="loadedVotes"
         :space="space"
         :proposal="proposal"
@@ -396,7 +396,7 @@ const truncateMarkdownBody = computed(() => {
         :loadingMore="loadingMore"
       />
       <PluginProposal
-        v-if="proposal.plugins && loadedResults"
+        v-if="proposal?.plugins && loadedResults"
         :id="id"
         :space="space"
         :proposal="proposal"
@@ -406,7 +406,7 @@ const truncateMarkdownBody = computed(() => {
         :strategies="strategies"
       />
     </template>
-    <template #sidebar-right v-if="!loading">
+    <template #sidebar-right v-if="proposal">
       <Block :title="$t('information')">
         <div class="space-y-1">
           <div>

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -503,7 +503,7 @@ const truncateMarkdownBody = computed(() => {
       />
     </template>
   </Layout>
-  <teleport to="#modal" v-if="!loading">
+  <teleport to="#modal" v-if="proposal && strategies">
     <ModalConfirm
       :open="modalOpen"
       @close="modalOpen = false"

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -503,7 +503,7 @@ const truncateMarkdownBody = computed(() => {
       />
     </template>
   </Layout>
-  <teleport to="#modal" v-if="proposal && strategies">
+  <teleport to="#modal" v-if="proposal">
     <ModalConfirm
       :open="modalOpen"
       @close="modalOpen = false"


### PR DESCRIPTION
**Bug:** When a modal opens the `body` has `overflow: hidden` so that the scrollbar doesn't show and you can't scroll the content in the background. After casting a vote, the confirmation modal disappears, the proposal reloads but you can't scroll because the `body` still has `overflow: hidden`.

**Cause:** [Here](https://github.com/snapshot-labs/snapshot/pull/1809/files#diff-db5facacb5eb9842e03054e4e4244ef5eb435893a4d180bca83b353d9c9d13fcR80) I set the `loading` prop back to true whenever we re-`loadProposal`. What I didn't deem harmful was that the modals on the proposal page aren't rendered while it's true. But since [here](https://github.com/snapshot-labs/snapshot/blob/08d12232edf2080bea3df6edf7100984a66f50df/src/components/Modal/Confirm.vue#L48-L49) the `reload` event is being triggered before the `close` event, it actually leads to [this](https://github.com/snapshot-labs/snapshot/blob/08d12232edf2080bea3df6edf7100984a66f50df/src/views/SpaceProposal.vue#L509) never being called, which in turn leads to [this](https://github.com/snapshot-labs/snapshot/blob/08d12232edf2080bea3df6edf7100984a66f50df/src/App.vue#L37-L40) never being called, thus not properly removing the `overflow-hidden` on the body.

**Solution:** Simply switching the order in which these events are called unfortunately doesn't fix the issue. The problem is, that as soon as the `reload` event is called, `loading` is set to true again, thus removing the modals from the dom. And it all happens so fast that calling `close` before `reload` doesn't help. Maybe the reason is actually the transition duration but I think it's better to not rely on that order anyway, if we can avoid it. So instead I adjusted the condition for rendering the modals (`proposal` instead of `!loading`). `proposal` is now initialed as `null` and other code adjusted accordingly.

And to be honest... I really could have anticipated/better checked that. My fault!