### PR TITLE
[safeSnap] Fix matic network prefix

### DIFF
--- a/src/plugins/safeSnap/components/SafeTransactions.vue
+++ b/src/plugins/safeSnap/components/SafeTransactions.vue
@@ -22,7 +22,7 @@ const EIP3770_PREFIXES = {
   246: 'ewt',
   73799: 'vt',
   42161: 'arb1',
-  137: 'MATIC'
+  137: 'matic'
 };
 
 async function fetchBalances(network, gnosisSafeAddress) {


### PR DESCRIPTION
UI is suggesting URL https://gnosis-safe.io/app/MATIC:0x56322a77E3fD213fA0aB3165C5078a9f197204C4 but we get nothing when we go there,

It works if we go to https://gnosis-safe.io/app/matic:0x56322a77E3fD213fA0aB3165C5078a9f197204C4