### PR TITLE
Remove edit controller from setup flow

### DIFF
--- a/src/components/Modal/UnsupportedNetwork.vue
+++ b/src/components/Modal/UnsupportedNetwork.vue
@@ -3,11 +3,12 @@ import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { computed, ref } from 'vue';
 import { useI18n } from '../../composables/useI18n';
 import { useFlashNotification } from '../../composables/useFlashNotification';
+import { sleep } from '@snapshot-labs/snapshot.js/src/utils';
 
 defineProps<{
   open: boolean;
 }>();
-const emit = defineEmits(['close', 'setTextrecord']);
+const emit = defineEmits(['close', 'networkChanged']);
 
 const { notify } = useFlashNotification();
 const { t } = useI18n();
@@ -29,9 +30,10 @@ const switchToMainnet = async () => {
         }
       ]
     });
+    await sleep(1000);
     switchingChain.value = false;
     emit('close');
-    emit('setTextrecord');
+    emit('networkChanged');
   } catch (e) {
     notify(['red', t('notify.somethingWentWrong')]);
     console.error(e);

--- a/src/components/ModalControllerEdit.vue
+++ b/src/components/ModalControllerEdit.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useSpaceController } from '@/composables/useSpaceController';
+import { shorten } from '@/helpers/utils';
+
+const { spaceControllerInput, controllerInputIsValid, settingENSRecord } =
+  useSpaceController();
+
+const props = defineProps<{
+  open: boolean;
+  currentTextRecord: string;
+  ensAddress: string;
+}>();
+
+const currentSpaceController = computed(() => {
+  return props.currentTextRecord?.split('/')[4] ?? '';
+});
+
+defineEmits(['close', 'set']);
+</script>
+
+<template>
+  <UiModal :open="open" @close="$emit('close')">
+    <template v-slot:header>
+      <div class="flex flex-row justify-center items-center">
+        <h3>{{ $t('settings.editController') }}</h3>
+      </div>
+    </template>
+
+    <div class="p-4">
+      <BaseMessageBlock level="info">
+        {{
+          $tc('settings.currentSpaceControllerIs', {
+            address: shorten(currentSpaceController)
+          })
+        }}
+        <div>
+          <BaseLink :link="`https://app.ens.domains/name/${ensAddress}`">
+            {{ $t('setup.seeOnEns') }}
+          </BaseLink>
+        </div>
+      </BaseMessageBlock>
+
+      {{ $t('settings.newController') }}
+
+      <UiInput
+        v-model.trim="spaceControllerInput"
+        :placeholder="$t('setup.spaceOwnerAddressPlaceHolder')"
+        class="mt-1"
+        focus-on-mount
+      >
+      </UiInput>
+    </div>
+    <template v-slot:footer>
+      <UiButton
+        class="button-outline w-full my-2"
+        primary
+        :disabled="!controllerInputIsValid"
+        @click="$emit('set'), $emit('close')"
+        :loading="settingENSRecord"
+      >
+        {{ $t('settings.set') }}
+      </UiButton>
+    </template>
+  </UiModal>
+</template>

--- a/src/components/SetupController.vue
+++ b/src/components/SetupController.vue
@@ -1,209 +1,63 @@
 <script setup lang="ts">
-import { computed, ref, inject, onMounted } from 'vue';
-import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
-import namehash from '@ensdomains/eth-ens-namehash';
-import { useTxStatus } from '../composables/useTxStatus';
-import { useWeb3 } from '@/composables/useWeb3';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
-import { getAddress } from '@ethersproject/address';
-import { useI18n } from '@/composables/useI18n';
-import { isAddress } from '@ethersproject/address';
 import { shorten } from '@/helpers/utils';
+import { useSpaceController } from '@/composables/useSpaceController';
 import { useRouter } from 'vue-router';
-import {
-  getSpaceUri,
-  sendTransaction
-} from '@snapshot-labs/snapshot.js/src/utils';
 
-const props = defineProps<{
-  ensAddress: string;
+const router = useRouter();
+
+defineProps<{
   ownedEnsDomains: { name: string }[];
 }>();
 
-const router = useRouter();
-const { web3 } = useWeb3();
-const { pendingCount } = useTxStatus();
-const auth = getInstance();
-const { t } = useI18n();
-
-const notify: any = inject('notify');
-
-const ensAbi = ['function setText(bytes32 node, string key, string value)'];
-
-const spaceOwnerInput = ref('');
-const settingENSRecord = ref(false);
-const modalUnsupportedNetworkOpen = ref(false);
-const currentTextRecord = ref('');
-const loaded = ref(false);
-const modalConfirmSetTextRecordOpen = ref(false);
-
-const networkKey = computed(() => web3.value.network.key);
-
-const ensOwner = computed(() => {
-  return props.ownedEnsDomains.map(d => d.name).includes(props.ensAddress);
-});
-
-const textRecord = computed(() => {
-  const keyURI = encodeURIComponent(props.ensAddress);
-  const address = spaceOwnerInput.value
-    ? getAddress(spaceOwnerInput.value)
-    : null;
-  return `ipns://storage.snapshot.page/registry/${address}/${keyURI}`;
-});
-
-const spaceOwnerAddress = computed(() => {
-  return currentTextRecord.value?.split('/')[4] ?? '';
-});
-
-const spaceOwnerInputIsValid = computed(
-  () =>
-    spaceOwnerInput.value === '' ||
-    spaceOwnerInput.value === spaceOwnerAddress.value ||
-    !isAddress(spaceOwnerInput.value)
-);
-
-async function loadSpaceUri() {
-  try {
-    const uri = await getSpaceUri(
-      props.ensAddress,
-      import.meta.env.VITE_DEFAULT_NETWORK
-    );
-    console.log('URI', uri);
-    currentTextRecord.value = uri;
-  } catch (e) {
-    console.log(e);
-  }
-}
+const {
+  spaceControllerInput,
+  controllerInputIsValid,
+  settingENSRecord,
+  modalUnsupportedNetworkOpen,
+  modalConfirmSetTextRecordOpen,
+  ensAddress,
+  setRecord,
+  confirmSetRecord
+} = useSpaceController();
 
 async function handleSetRecord() {
-  settingENSRecord.value = true;
-  try {
-    const ensPublicResolverAddress = networks[networkKey.value].ensResolver;
-    if (!ensPublicResolverAddress) {
-      throw new Error('No ENS resolver address for this network');
-    }
-    const ensname = props.ensAddress;
-    const node = namehash.hash(ensname);
-    const tx = await sendTransaction(
-      auth.web3,
-      ensPublicResolverAddress,
-      ensAbi,
-      'setText',
-      [node, 'snapshot', textRecord.value]
-    );
-    settingENSRecord.value = false;
-    pendingCount.value++;
-    const receipt = await tx.wait();
-    console.log('Receipt', receipt);
+  const receipt = await setRecord();
+  if (receipt) {
     router.push({
       name: 'spaceSettings',
       params: {
-        key: props.ensAddress
+        key: ensAddress.value
       }
     });
-    notify(t('notify.ensSet'));
-  } catch (e) {
-    notify(['red', t('notify.somethingWentWrong')]);
-    console.log(e);
-  } finally {
-    pendingCount.value--;
-    settingENSRecord.value = false;
   }
 }
-
-function clickSetRecord() {
-  if (networkKey.value !== import.meta.env.VITE_DEFAULT_NETWORK)
-    modalUnsupportedNetworkOpen.value = true;
-  else modalConfirmSetTextRecordOpen.value = true;
-}
-
-onMounted(async () => {
-  await loadSpaceUri();
-  loaded.value = true;
-});
 </script>
 
 <template>
-  <Block v-if="!loaded" slim>
-    <RowLoading class="my-2" />
-  </Block>
-  <BaseMessageBlock level="warning" v-else-if="!ensOwner" class="mb-0">
-    {{ $t('setup.connectWithEnsController', { ens: ensAddress }) }}
-  </BaseMessageBlock>
-  <template v-else>
-    <BaseMessageBlock v-if="spaceOwnerAddress && ensOwner" level="info">
-      {{
-        $t('setup.textRecordExists', { address: shorten(spaceOwnerAddress) })
-      }}
-      <div>
-        <BaseLink :link="`https://app.ens.domains/name/${ensAddress}`">
-          {{ $t('setup.seeOnEns') }}
-        </BaseLink>
-      </div>
-    </BaseMessageBlock>
-    <Block
-      :title="
-        currentTextRecord
-          ? $t('setup.editSpaceController')
-          : $t('setup.setSpaceController')
-      "
+  <Block :title="$t('setup.setSpaceController')">
+    <UiInput
+      v-model.trim="spaceControllerInput"
+      :placeholder="$t('setup.spaceOwnerAddressPlaceHolder')"
+      class="mt-2"
+      focus-on-mount
     >
-      <UiInput
-        v-if="ensOwner"
-        v-model.trim="spaceOwnerInput"
-        :placeholder="$t('setup.spaceOwnerAddressPlaceHolder')"
-        class="mt-2"
-        focus-on-mount
-      >
-      </UiInput>
+    </UiInput>
+    <UiButton
+      class="button-outline w-full my-2"
+      primary
+      :disabled="!controllerInputIsValid"
+      @click="confirmSetRecord"
+      :loading="settingENSRecord"
+    >
+      {{ $t('setup.setController') }}
+    </UiButton>
+  </Block>
 
-      <div>
-        <div>
-          <div v-if="currentTextRecord && ensOwner">
-            <UiButton
-              class="button-outline w-full mb-2"
-              primary
-              :disabled="spaceOwnerInputIsValid"
-              @click="clickSetRecord"
-              :loading="settingENSRecord"
-            >
-              {{ $t('setup.updateController') }}
-            </UiButton>
-            <div class="w-full text-center mb-2">{{ $t('or') }}</div>
-
-            <UiButton
-              class="button-outline w-full mb-2"
-              @click="
-                $router.push({
-                  name: 'spaceSettings',
-                  params: { key: ensAddress }
-                })
-              "
-              :disabled="settingENSRecord"
-            >
-              {{ $t('setup.goToSettings') }}
-            </UiButton>
-          </div>
-          <div v-else-if="!currentTextRecord && ensOwner">
-            <UiButton
-              class="button-outline w-full my-2"
-              primary
-              :disabled="spaceOwnerInputIsValid"
-              @click="clickSetRecord"
-              :loading="settingENSRecord"
-            >
-              {{ $t('setup.setController') }}
-            </UiButton>
-          </div>
-        </div>
-      </div>
-    </Block>
-  </template>
   <teleport to="#modal">
     <ModalUnsupportedNetwork
       :open="modalUnsupportedNetworkOpen"
       @close="modalUnsupportedNetworkOpen = false"
-      @setTextrecord="modalConfirmSetTextRecordOpen = true"
+      @networkChanged="modalConfirmSetTextRecordOpen = true"
     />
     <ModalConfirmAction
       :open="modalConfirmSetTextRecordOpen"
@@ -217,7 +71,7 @@ onMounted(async () => {
         <p>
           {{
             $t('setup.confirmToSetAddress', {
-              address: shorten(spaceOwnerInput)
+              address: shorten(spaceControllerInput)
             })
           }}
           {{ $t('setup.controllerHasAuthority') + '.' }}

--- a/src/composables/useSpaceController.ts
+++ b/src/composables/useSpaceController.ts
@@ -1,0 +1,89 @@
+import { computed, ref, inject } from 'vue';
+import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
+import namehash from '@ensdomains/eth-ens-namehash';
+import { useTxStatus } from '../composables/useTxStatus';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { getAddress } from '@ethersproject/address';
+import { useI18n } from '@/composables/useI18n';
+import { useWeb3 } from '@/composables/useWeb3';
+import { isAddress } from '@ethersproject/address';
+import { sendTransaction } from '@snapshot-labs/snapshot.js/src/utils';
+
+const ensAddress = ref('');
+const spaceControllerInput = ref('');
+const modalUnsupportedNetworkOpen = ref(false);
+const modalConfirmSetTextRecordOpen = ref(false);
+const settingENSRecord = ref(false);
+
+export function useSpaceController() {
+  const { web3 } = useWeb3();
+  const { pendingCount } = useTxStatus();
+  const auth = getInstance();
+  const { t } = useI18n();
+
+  const notify: any = inject('notify');
+
+  const ensAbi = ['function setText(bytes32 node, string key, string value)'];
+
+  const controllerInputIsValid = computed(() =>
+    isAddress(spaceControllerInput.value)
+  );
+
+  const networkKey = computed(() => web3.value.network.key);
+
+  const textRecord = computed(() => {
+    const keyURI = encodeURIComponent(ensAddress.value);
+    const address = spaceControllerInput.value
+      ? getAddress(spaceControllerInput.value)
+      : null;
+    return `ipns://storage.snapshot.page/registry/${address}/${keyURI}`;
+  });
+
+  async function setRecord() {
+    settingENSRecord.value = true;
+    try {
+      const ensPublicResolverAddress = networks[networkKey.value].ensResolver;
+      if (!ensPublicResolverAddress) {
+        throw new Error('No ENS resolver address for this network');
+      }
+      const ensname = ensAddress.value;
+      const node = namehash.hash(ensname);
+      const tx = await sendTransaction(
+        auth.web3,
+        ensPublicResolverAddress,
+        ensAbi,
+        'setText',
+        [node, 'snapshot', textRecord.value]
+      );
+      settingENSRecord.value = false;
+      pendingCount.value++;
+      const receipt = await tx.wait();
+      notify(t('notify.ensSet'));
+      console.log('Receipt', receipt);
+      return receipt;
+    } catch (e) {
+      notify(['red', t('notify.somethingWentWrong')]);
+      console.log(e);
+    } finally {
+      pendingCount.value--;
+      settingENSRecord.value = false;
+    }
+  }
+
+  function confirmSetRecord() {
+    if (networkKey.value !== import.meta.env.VITE_DEFAULT_NETWORK)
+      modalUnsupportedNetworkOpen.value = true;
+    else modalConfirmSetTextRecordOpen.value = true;
+  }
+
+  return {
+    spaceControllerInput,
+    controllerInputIsValid,
+    settingENSRecord,
+    ensAddress,
+    modalUnsupportedNetworkOpen,
+    modalConfirmSetTextRecordOpen,
+    setRecord,
+    confirmSetRecord
+  };
+}

--- a/src/composables/useSpaceController.ts
+++ b/src/composables/useSpaceController.ts
@@ -58,6 +58,7 @@ export function useSpaceController() {
       settingENSRecord.value = false;
       pendingCount.value++;
       const receipt = await tx.wait();
+      pendingCount.value--;
       notify(t('notify.ensSet'));
       console.log('Receipt', receipt);
       return receipt;
@@ -65,7 +66,6 @@ export function useSpaceController() {
       notify(['red', t('notify.somethingWentWrong')]);
       console.log(e);
     } finally {
-      pendingCount.value--;
       settingENSRecord.value = false;
     }
   }

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -11,7 +11,7 @@ const defaultNetwork: any =
 
 const state = reactive<{
   account: string;
-  network: string;
+  network: Record<string, any>;
   authLoading: boolean;
   profile: { name: string; ens: string } | null;
   walletConnectType: string | null;

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -272,7 +272,10 @@
     "type": "Type",
     "anyType": "Any",
     "hideAbstain": "Ignore abstain votes in basic voting results",
-    "connectWithSpaceOwner": "To modify space settings, connect with a controller or admin wallet."
+    "connectWithSpaceOwner": "To modify space settings, connect with a controller or admin wallet.",
+    "currentSpaceControllerIs": "The current space controller is {address}",
+    "newController": "New controller",
+    "set": "Set"
   },
   "setup": {
     "example": "e.g. yam.eth",
@@ -292,11 +295,9 @@
     "controllerHasAuthority": "The controller has full authority over the space settings",
     "controller": "Controller",
     "selectEnsForSpace": "Choose ENS address",
-    "textRecordExists": "Currently the space controller is {address}. You can update the space controller by using the form below.",
     "spaceOwnerAddressPlaceHolder": "e.g. 0xF78108c9BBaF466dd96BE41be728Fe3220b37119",
     "controllerAddress": "Controller address",
     "updateController": "Update controller",
-    "connectWithEnsController": "To modify the space controller you need to connect with the wallet that owns {ens}",
     "seeOnEns": "See on ENS",
     "goToSettings": "Go to settings"
   },

--- a/src/router.ts
+++ b/src/router.ts
@@ -76,7 +76,7 @@ if (domain) {
   // prefix space routes with space domain (/:key).
   routes.push(
     { path: '/', name: 'home', component: Home },
-    { path: '/setup/:ensAddress?', name: 'setup', component: Setup },
+    { path: '/setup/:step?', name: 'setup', component: Setup },
     { path: '/networks', name: 'networks', component: Explore },
     { path: '/strategies', name: 'strategies', component: Explore },
     { path: '/plugins', name: 'plugins', component: Explore },

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -9,7 +9,9 @@ import { useWeb3 } from '@/composables/useWeb3';
 import { calcFromSeconds, calcToSeconds } from '@/helpers/utils';
 import { useClient } from '@/composables/useClient';
 import { usePlugins } from '@/composables/usePlugins';
+import { useSpaceController } from '@/composables/useSpaceController';
 import { useEns } from '@/composables/useEns';
+import { shorten } from '@/helpers/utils';
 import {
   validateSchema,
   getSpaceUri,
@@ -299,6 +301,18 @@ onMounted(() => {
     ? setPageTitle('page.title.space.settings', { space: props.space.name })
     : setPageTitle('page.title.setup');
 });
+
+const {
+  settingENSRecord,
+  ensAddress,
+  modalUnsupportedNetworkOpen,
+  modalConfirmSetTextRecordOpen,
+  spaceControllerInput,
+  setRecord,
+  confirmSetRecord
+} = useSpaceController();
+
+const modalControllerEditOpen = ref(false);
 </script>
 
 <template>
@@ -318,11 +332,15 @@ onMounted(() => {
         <BaseMessageBlock level="warning">
           {{ $t('settings.needToSetEnsText') }}
         </BaseMessageBlock>
-        <router-link :to="{ name: 'setup', params: { ensAddress: spaceKey } }">
-          <UiButton no-focus primary class="w-full">
-            {{ $t('settings.setEnsTextRecord') }}
-          </UiButton>
-        </router-link>
+        <UiButton
+          @click="modalControllerEditOpen = true"
+          :loading="settingENSRecord"
+          no-focus
+          primary
+          class="w-full"
+        >
+          {{ $t('settings.setEnsTextRecord') }}
+        </UiButton>
       </Block>
       <template v-else-if="currentTextRecord">
         <Block :title="$t('settings.profile')">
@@ -646,14 +664,14 @@ onMounted(() => {
         class="lg:fixed lg:w-[300px]"
       >
         <Block :title="$t('actions')">
-          <router-link
+          <UiButton
             v-if="ensOwner"
-            :to="{ name: 'setup', params: { ensAddress: spaceKey } }"
+            @click="modalControllerEditOpen = true"
+            :loading="settingENSRecord"
+            class="block w-full mb-2"
           >
-            <UiButton class="block w-full mb-2">
-              {{ $t('settings.editController') }}
-            </UiButton>
-          </router-link>
+            {{ $t('settings.editController') }}
+          </UiButton>
           <UiButton @click="handleReset" class="block w-full mb-2">
             {{ $t('reset') }}
           </UiButton>
@@ -718,5 +736,33 @@ onMounted(() => {
       v-model:selected="form.voting.type"
       allowAny
     />
+    <ModalControllerEdit
+      :open="modalControllerEditOpen"
+      @close="modalControllerEditOpen = false"
+      :currentTextRecord="currentTextRecord"
+      :ensAddress="spaceKey"
+      @set="(ensAddress = spaceKey), confirmSetRecord()"
+    />
+    <ModalUnsupportedNetwork
+      :open="modalUnsupportedNetworkOpen"
+      @close="modalUnsupportedNetworkOpen = false"
+      @networkChanged="modalConfirmSetTextRecordOpen = true"
+    />
+    <ModalConfirmAction
+      :open="modalConfirmSetTextRecordOpen"
+      @close="modalConfirmSetTextRecordOpen = false"
+      @confirm="setRecord"
+    >
+      <div class="space-y-4 m-4 text-skin-link">
+        <p>
+          {{
+            $t('setup.confirmToSetAddress', {
+              address: shorten(spaceControllerInput)
+            })
+          }}
+          {{ $t('setup.controllerHasAuthority') + '.' }}
+        </p>
+      </div>
+    </ModalConfirmAction>
   </teleport>
 </template>

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -313,6 +313,13 @@ const {
 } = useSpaceController();
 
 const modalControllerEditOpen = ref(false);
+
+async function handleSetRecord() {
+  const receipt = await setRecord();
+  if (receipt) {
+    props.loadExtentedSpaces([props.spaceKey]);
+  }
+}
 </script>
 
 <template>
@@ -751,7 +758,7 @@ const modalControllerEditOpen = ref(false);
     <ModalConfirmAction
       :open="modalConfirmSetTextRecordOpen"
       @close="modalConfirmSetTextRecordOpen = false"
-      @confirm="setRecord"
+      @confirm="handleSetRecord"
     >
       <div class="space-y-4 m-4 text-skin-link">
         <p>


### PR DESCRIPTION
This is the first step in decoupling the space settings from the setup flow  https://github.com/snapshot-labs/snapshot/issues/1902

Changes proposed in this pull request:
- Move controller logic into composable and create an edit controller modal for settings page
- Prepair setup flow for step 3 (space profile)
- Remove redundant warning and conditional text
