### PR TITLE
[safesnap] Chain provider reaches block limit

### DIFF
--- a/src/plugins/safeSnap/components/HandleOutcome.vue
+++ b/src/plugins/safeSnap/components/HandleOutcome.vue
@@ -183,7 +183,7 @@ const { notify } = useFlashNotification();
 
 const props = defineProps([
   'batches',
-  'proposalId',
+  'proposal',
   'network',
   'realityAddress',
   'multiSendAddress'
@@ -278,7 +278,7 @@ const updateDetails = async () => {
     questionDetails.value = await plugin.getExecutionDetailsWithHashes(
       props.network,
       props.realityAddress,
-      props.proposalId,
+      props.proposal.id,
       getTxHashes()
     );
     if (questionDetails.value.questionId && getInstance().web3) {
@@ -286,7 +286,8 @@ const updateDetails = async () => {
         getInstance().web3,
         props.network,
         questionDetails.value.questionId,
-        questionDetails.value.oracle
+        questionDetails.value.oracle,
+        props.proposal.snapshot
       );
     }
   } catch (e) {

--- a/src/plugins/safeSnap/components/SafeTransactions.vue
+++ b/src/plugins/safeSnap/components/SafeTransactions.vue
@@ -247,7 +247,7 @@ export default {
         <SafeSnapHandleOutcome
           v-if="preview && proposalResolved"
           :batches="input"
-          :proposalId="proposal.id"
+          :proposal="proposal"
           :realityAddress="realityAddress"
           :multiSendAddress="transactionConfig.multiSendAddress"
           :network="transactionConfig.network"

--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -1,10 +1,5 @@
 import { MULTI_SEND_VERSION } from './utils/multiSend';
 
-export const START_BLOCKS = {
-  1: 6531147,
-  4: 3175028
-};
-
 export const EIP712_TYPES = {
   Transaction: [
     { name: 'to', type: 'address' },

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -19,7 +19,6 @@ import {
   EIP712_TYPES,
   REALITY_MODULE_ABI,
   ORACLE_ABI,
-  START_BLOCKS,
   ERC20_ABI
 } from './constants';
 import {
@@ -211,8 +210,7 @@ export default class Plugin {
     }
 
     const answersFilter = contract.filters.LogNewAnswer(null, questionId);
-    const startBlock = Math.max(START_BLOCKS[network] || 0, parseInt(block));
-    const events = await contract.queryFilter(answersFilter, startBlock);
+    const events = await contract.queryFilter(answersFilter, parseInt(block));
 
     const users: Result[] = [];
     const historyHashes: Result[] = [];

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -29,6 +29,7 @@ import {
   getProposalDetails
 } from './utils/realityModule';
 import { retrieveInfoFromOracle } from './utils/realityETH';
+import { getNativeAsset } from '@/plugins/safeSnap/utils/coins';
 
 export * from './constants';
 export * from './models';
@@ -164,7 +165,8 @@ export default class Plugin {
     web3: any,
     network: string,
     questionId: string,
-    oracleAddress: string
+    oracleAddress: string,
+    block: string
   ) {
     const contract = new Contract(oracleAddress, ORACLE_ABI, web3);
     const provider: StaticJsonRpcProvider = getProvider(network);
@@ -178,11 +180,14 @@ export default class Plugin {
         [oracleAddress, 'isFinalized', [questionId]]
       ]);
 
-    let tokenSymbol = 'ETH';
-    let tokenDecimals = 18;
+    const nativeToken = getNativeAsset(network);
+    let token = {
+      symbol: nativeToken.symbol,
+      decimals: nativeToken.decimals
+    };
 
     try {
-      const token = await call(provider, ORACLE_ABI, [
+      const tokenCall = await call(provider, ORACLE_ABI, [
         oracleAddress,
         'token',
         []
@@ -192,22 +197,22 @@ export default class Plugin {
         provider,
         ERC20_ABI,
         [
-          [token, 'symbol', []],
-          [token, 'decimals', []]
+          [tokenCall, 'symbol', []],
+          [tokenCall, 'decimals', []]
         ]
       );
 
-      tokenSymbol = symbol;
-      tokenDecimals = decimals;
+      token = {
+        symbol,
+        decimals
+      };
     } catch (e) {
       console.log('[Realitio] Info: Oracle is not ERC20 based.');
     }
 
     const answersFilter = contract.filters.LogNewAnswer(null, questionId);
-    const events = await contract.queryFilter(
-      answersFilter,
-      START_BLOCKS[network]
-    );
+    const startBlock = Math.max(START_BLOCKS[network] || 0, parseInt(block));
+    const events = await contract.queryFilter(answersFilter, startBlock);
 
     const users: Result[] = [];
     const historyHashes: Result[] = [];
@@ -249,8 +254,8 @@ export default class Plugin {
     historyHashes.push(firstHash as Result);
 
     return {
-      tokenSymbol,
-      tokenDecimals,
+      tokenSymbol: token.symbol,
+      tokenDecimals: token.decimals,
       canClaim: (!alreadyClaimed && votedForCorrectQuestion) || hasBalance,
       data: {
         length: [bonds.length.toString()],


### PR DESCRIPTION
### Summary
To get the oracle's answers, we need to get the events emitted by the oracle. Chain providers tend to have a block limit, which only returns the events of the last X blocks. To avoid fetching from the genesis block, we set a block to start from per chain (usually the block in which the oracle was deployed).

### Issues
- As the chain grows, the block eventually will become too old, falling behind the limit.
- Some chains didn't have a block set, so the genesis block was being used, triggering the limit error.

### Solution
Since we're getting the answers of a question, and a question is created for every proposal. We could get the events dispatched after the proposal's snapshot block since it's a block older than the block in which the question is created.