### PR TITLE
[safesnap] Fix input amount & MultiSend address for Polygon

### DIFF
--- a/src/plugins/safeSnap/components/Form/TransferFunds.vue
+++ b/src/plugins/safeSnap/components/Form/TransferFunds.vue
@@ -124,6 +124,7 @@ export default {
     <SafeSnapInputAmount
       :label="$t('safeSnap.amount')"
       v-model="value"
+      :key="selectedToken?.decimals"
       :decimals="selectedToken?.decimals"
       :disabled="config.preview"
     />

--- a/src/plugins/safeSnap/components/SafeTransactions.vue
+++ b/src/plugins/safeSnap/components/SafeTransactions.vue
@@ -1,6 +1,7 @@
 <script>
 import Plugin, {
   createBatch,
+  EIP3770_PREFIXES,
   getGnosisSafeBalances,
   getGnosisSafeCollectibles
 } from '../index';
@@ -13,17 +14,6 @@ import SafeSnapFormImportTransactionsButton from './Form/ImportTransactionsButto
 import SafeSnapFormTransactionBatch from './Form/TransactionBatch.vue';
 
 const plugin = new Plugin();
-
-const EIP3770_PREFIXES = {
-  1: 'eth',
-  56: 'bnb',
-  4: 'rin',
-  100: 'gno',
-  246: 'ewt',
-  73799: 'vt',
-  42161: 'arb1',
-  137: 'matic'
-};
 
 async function fetchBalances(network, gnosisSafeAddress) {
   if (gnosisSafeAddress) {

--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -15,6 +15,17 @@ export const EIP712_TYPES = {
   ]
 };
 
+export const EIP3770_PREFIXES = {
+  1: 'eth',
+  4: 'rin',
+  56: 'bnb',
+  100: 'gno',
+  246: 'ewt',
+  73799: 'vt',
+  42161: 'arb1',
+  137: 'matic'
+};
+
 export const EXPLORER_API_URLS = {
   '1': 'https://api.etherscan.io/api',
   '4': 'https://api-rinkeby.etherscan.io/api',

--- a/src/plugins/safeSnap/utils/index.ts
+++ b/src/plugins/safeSnap/utils/index.ts
@@ -107,7 +107,8 @@ export function coerceConfig(config, network) {
         const txs = (safe.txs || []).map((batch, nonce) => {
           const oldMultiSendAddress =
             safe.multiSendAddress ||
-            getMultiSend(_network, MULTI_SEND_VERSION.V1_1_1);
+            getMultiSend(_network, MULTI_SEND_VERSION.V1_1_1) ||
+            getMultiSend(_network, MULTI_SEND_VERSION.V1_3_0);
           if (Array.isArray(batch)) {
             // Assume old config
             return createBatch(
@@ -150,7 +151,9 @@ export function coerceConfig(config, network) {
       {
         network,
         realityAddress: config.address,
-        multiSendAddress: getMultiSend(network, MULTI_SEND_VERSION.V1_1_1)
+        multiSendAddress:
+          getMultiSend(network, MULTI_SEND_VERSION.V1_1_1) ||
+          getMultiSend(network, MULTI_SEND_VERSION.V1_3_0)
       }
     ]
   };


### PR DESCRIPTION
### Summary
As reported in issue #1906, the input amount for tokens wasn't formatted correctly.

what really caught my attention was @ChaituVR 's [comment](https://github.com/snapshot-labs/snapshot/issues/1906#issuecomment-1061868087) saying:
> Something is wrong with transaction data and its hashes, the hash is null

Digging into what could have gone wrong, I found out that the default multi-send contract for an old configuration (`v1.1.1`) was not deployed to Polygon, returning `undefined` instead of the address. What caused **the hash to be null** is that the `to` field in the `main transaction` of the batch is `undefined` making the transaction invalid, so the hash could not be calculated.

### Solution
If the `v1.1.1` version of the multi-send contract is not available in the network, the `v1.3.0` is used instead which is deployed to several networks.


This PR closes #1906 