### PR TITLE
Fix content from behind showing on space notice

### DIFF
--- a/src/components/SpaceProposalsNotice.vue
+++ b/src/components/SpaceProposalsNotice.vue
@@ -16,7 +16,7 @@ const createdSpaces = useStorage(
 <template>
   <Block
     v-if="createdSpaces?.[spaceId]?.showMessage"
-    class="absolute z-10 left-0"
+    class="absolute z-10 left-0 !bg-skin-bg"
   >
     <div>
       <div>


### PR DESCRIPTION
Issue:
<img width="757" alt="image" src="https://user-images.githubusercontent.com/51686767/158390466-15a3c4d1-d2bf-470b-979f-5f92550095ec.png">


Changes proposed in this pull request:
- Add background to notice
