### PR TITLE
moved footer back to App.vue and made rendering depend on route

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,11 +4,13 @@ import { useApp } from '@/composables/useApp';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useFlashNotification } from '@/composables/useFlashNotification';
 import { useDomain } from '@/composables/useDomain';
+import { useRoute } from 'vue-router';
 
 const { domain } = useDomain();
 const { init, ready } = useApp();
 const { web3 } = useWeb3();
 const { notify } = useFlashNotification();
+const route = useRoute();
 
 provide('web3', web3);
 provide('notify', notify);
@@ -26,13 +28,16 @@ onMounted(async () => {
         <TheSidebar />
       </div>
     </div>
-    <div class="grow">
+    <div class="grow flex flex-col">
       <div id="navbar" class="sticky top-0 border-b border-skin-border bg-skin-bg z-40">
         <TheNavbar />
       </div>
       <div id="content" class="py-4">
         <router-view :key="$route.path" />
       </div>
+      <footer class="mt-auto" v-if="route.name === 'home'">
+        <TheFooter />
+      </footer>
     </div>
   </div>
   <FlashNotification />

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -176,9 +176,6 @@ onMounted(() => {
           {{ $t('homeLoadmore') }}
         </UiButton>
       </div>
-      <footer class="mt-auto">
-        <TheFooter />
-      </footer>
     </BaseContainer>
     <div ref="endElement" />
   </div>


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/6792578/158641877-feb08d39-d1c2-40b2-9ac0-91b9d17b69cb.png)

Changes proposed in this pull request:
- moved `TheFooter` component back to `App.vue` to keep it in it's proper position in the layout
- made rendering depend on route (could become `showFooter` composable if we decide to show it on more than just the home page)
