### PR TITLE
fix vue warning

### DIFF
--- a/src/components/SearchWithFilters.vue
+++ b/src/components/SearchWithFilters.vue
@@ -9,7 +9,7 @@ const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
 
-const routeQuery = computed(() => route.query.q);
+const routeQuery = computed(() => route.query.q || '');
 const searchOptions = computed(() => [
   {
     text: t('spaces'),


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/6792578/158644960-2c116287-aa8e-4523-8094-2619158b9844.png)

Changes proposed in this pull request:
- just made the `routeQuery` default to string
