### PR TITLE
add min scale und prevent zooming

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=no" />
     <title>Snapshot</title>
   </head>
   <body>


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/6792578/158785835-8b796b4e-8a40-4d0f-8b42-9865cfd236b2.png)

The other issue is that links like `https://medium.com/@MMFinance/29cbd0eaeddd` aren't broken up when adding tailwind's `break-words` class. It also needs an additional `word-break: break-word;` in chrome to work. Comes in next PR.
