### PR TITLE
overwrite tailwind class to add chrome fix

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -269,3 +269,12 @@ input[type='number'] {
 .s-indicator {
   @apply text-sm h-[12px] w-[12px] rounded-full inline-block bg-blue;
 }
+
+
+// Fix for chrome. Overwrites tailwinds break-words class.
+// For some reason chrome doesn't break links with just overflow-wrap.
+// It also needs word-break.
+.break-words {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}


### PR DESCRIPTION
Fixes:
![image](https://user-images.githubusercontent.com/6792578/158789684-f5c1e5ca-48a6-4408-aefd-9555f0e8d416.png)

The way it's added doesn't work with modifiers like `md:break-words` but I hope we are not going to need that anyway. This applies mostly to mobile only anyway.