### PR TITLE
Mobile fixes

### DIFF
--- a/src/components/BaseBlock.vue
+++ b/src/components/BaseBlock.vue
@@ -46,7 +46,7 @@ defineProps<{
       />
       <div class="rounded-md lazy-loading" style="width: 50%; height: 20px" />
     </div>
-    <div v-else :class="!slim && 'p-4'" class="leading-6">
+    <div v-else :class="!slim && 'p-4'" class="leading-5 sm:leading-6">
       <slot />
     </div>
   </div>

--- a/src/components/Block/Votes.vue
+++ b/src/components/Block/Votes.vue
@@ -93,7 +93,7 @@ watch(visibleVotes, () => {
       v-for="(vote, i) in visibleVotes"
       :key="i"
       :style="i === 0 && 'border: 0 !important;'"
-      class="px-4 py-3 border-t flex"
+      class="px-3 py-3 border-t flex"
     >
       <AvatarUser
         :profile="profiles[vote.voter]"
@@ -103,7 +103,7 @@ watch(visibleVotes, () => {
         :proposal="proposal"
         class="w-[110px] xs:w-[130px] min-w-[110px] xs:min-w-[130px]"
       />
-      <div class="flex-auto text-center text-skin-link truncate px-3">
+      <div class="flex-auto text-center text-skin-link truncate px-2">
         <div
           class="text-center text-skin-link truncate"
           v-tippy="{

--- a/src/components/TheLayout.vue
+++ b/src/components/TheLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <BaseContainer :slim="true" class="mt-4">
+  <BaseContainer :slim="true" class="sm:mt-4">
     <slot />
     <div
       v-if="$slots['sidebar-left']"

--- a/src/components/TimelineProposal.vue
+++ b/src/components/TimelineProposal.vue
@@ -26,7 +26,7 @@ const winningChoice = computed(() =>
 <template>
   <BaseBlock slim class="transition-colors hover:border-skin-text">
     <router-link
-      class="p-4 block text-skin-text"
+      class="p-3 py-0 sm:p-4 block text-skin-text"
       :to="{
         name: 'spaceProposal',
         params: { key: proposal.space.id, id: proposal.id }
@@ -53,8 +53,8 @@ const winningChoice = computed(() =>
           </div>
           <LabelProposalState :state="proposal.state" />
         </div>
-        <h3 v-text="proposal.title" class="my-1 break-words" />
-        <p v-text="shorten(body, 140)" class="break-words mb-2 text-md" />
+        <h3 v-text="proposal.title" class="my-1 leading-7 break-words" />
+        <p v-text="shorten(body, 140)" class="break-words mb-2 sm:text-md" />
         <div>
           <span
             v-if="proposal.scores_state !== 'final'"

--- a/src/components/TimelineProposalPreview.vue
+++ b/src/components/TimelineProposalPreview.vue
@@ -28,7 +28,7 @@ const winningChoice = computed(() =>
 </script>
 
 <template>
-  <div class="transition-colors md:border-b last:border-b-0">
+  <div class="transition-colors md:border-b last:border-b-0 border-skin-border">
     <router-link
       class="p-4 block text-skin-text"
       :to="{

--- a/src/components/TimelineProposalPreview.vue
+++ b/src/components/TimelineProposalPreview.vue
@@ -28,7 +28,7 @@ const winningChoice = computed(() =>
 </script>
 
 <template>
-  <div class="transition-colors border-b last:border-b-0">
+  <div class="transition-colors md:border-b last:border-b-0">
     <router-link
       class="p-4 block text-skin-text"
       :to="{

--- a/src/components/Ui/Markdown.vue
+++ b/src/components/Ui/Markdown.vue
@@ -51,8 +51,8 @@ onMounted(() => {
 
 <style lang="scss">
 .markdown-body {
-  font-size: 22px;
-  line-height: 1.4;
+  font-size: 19px;
+  line-height: 1.3;
   word-wrap: break-word;
 }
 
@@ -204,27 +204,27 @@ onMounted(() => {
 }
 
 .markdown-body h1 {
-  font-size: 2em;
-}
-
-.markdown-body h2 {
   font-size: 1.5em;
 }
 
-.markdown-body h3 {
+.markdown-body h2 {
   font-size: 1.25em;
 }
 
-.markdown-body h4 {
+.markdown-body h3 {
   font-size: 1em;
 }
 
-.markdown-body h5 {
+.markdown-body h4 {
   font-size: 0.875em;
 }
 
-.markdown-body h6 {
+.markdown-body h5 {
   font-size: 0.85em;
+}
+
+.markdown-body h6 {
+  font-size: 0.8em;
 }
 
 .markdown-body ul,
@@ -522,5 +522,36 @@ onMounted(() => {
   font-weight: 600;
   background: #f6f8fa;
   border-top: 0;
+}
+
+@media (min-width: 544px) {
+  .markdown-body {
+    font-size: 22px;
+    line-height: 1.4;
+}
+
+  .markdown-body h1 {
+    font-size: 2em;
+  }
+
+  .markdown-body h2 {
+    font-size: 1.5em;
+  }
+
+  .markdown-body h3 {
+    font-size: 1.25em;
+  }
+
+  .markdown-body h4 {
+    font-size: 1em;
+  }
+
+  .markdown-body h5 {
+    font-size: 0.875em;
+  }
+
+  .markdown-body h6 {
+    font-size: 0.85em;
+  }
 }
 </style>

--- a/src/style.scss
+++ b/src/style.scss
@@ -145,6 +145,8 @@ textarea {
   line-height: 1.4em;
 }
 
+// TODO: Remove this and use border-skin-border in the templates. Tailwind has
+// dozens of modifiers (md:, sm:, hover: etc.) which would all need to be listed here.
 .border,
 .border-md,
 .border-lg,

--- a/src/style.scss
+++ b/src/style.scss
@@ -65,7 +65,9 @@
   h1,
   h2,
   h3,
-  h4 {
+  h4,
+  h5,
+  h6 {
     @apply font-semibold text-skin-heading;
   }
 

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -267,8 +267,8 @@ const truncateMarkdownBody = computed(() => {
         <template v-if="proposal">
           <h1 v-text="proposal.title" class="mb-3 break-words" />
 
-          <div class="flex items-center justify-between mb-4">
-            <div class="flex space-x-1 items-center">
+          <div class="flex flex-col sm:flex-row sm:space-x-1 mb-4">
+            <div class="flex items-center mb-1 sm:mb-0">
               <LabelProposalState :state="proposal.state" class="mr-1" />
               <router-link
                 class="text-skin-text group"
@@ -280,12 +280,13 @@ const truncateMarkdownBody = computed(() => {
                 <div class="flex items-center">
                   <AvatarSpace :space="space" size="28" />
                   <span
-                    class="ml-2 group-hover:text-skin-link hidden sm:block"
+                    class="ml-2 group-hover:text-skin-link"
                     v-text="space.name"
                   />
                 </div>
               </router-link>
-
+            </div>
+            <div class="flex grow items-center space-x-1">
               <span v-text="$t('proposalBy')" />
               <AvatarUser
                 :address="proposal.author"
@@ -295,15 +296,13 @@ const truncateMarkdownBody = computed(() => {
                 only-username
               />
               <BaseBadge :address="proposal.author" :members="space.members" />
-            </div>
-            <div class="flex justify-end">
               <ShareButton
                 v-if="sharingIsSupported"
                 @click="startShare(space, proposal)"
               />
               <BaseDropdown
                 v-else
-                class="ml-3"
+                class="pl-3 !ml-auto"
                 @select="selectFromShareDropdown"
                 :items="sharingItems"
               >

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -248,7 +248,7 @@ const truncateMarkdownBody = computed(() => {
 <template>
   <TheLayout v-bind="$attrs">
     <template #content-left>
-      <div class="px-4 md:px-0 mb-3">
+      <div class="px-3 md:px-0 mb-3">
         <a
           class="text-skin-text"
           @click="
@@ -263,9 +263,9 @@ const truncateMarkdownBody = computed(() => {
           {{ $t('back') }}
         </a>
       </div>
-      <div class="px-4 md:px-0">
+      <div class="px-3 md:px-0">
         <template v-if="proposal">
-          <h1 v-text="proposal.title" class="mb-3 break-words" />
+          <h1 v-text="proposal.title" class="mb-3 break-words text-xl leading-8 sm:text-2xl" />
 
           <div class="flex flex-col sm:flex-row sm:space-x-1 mb-4">
             <div class="flex items-center mb-1 sm:mb-0">

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -112,7 +112,7 @@ onMounted(() => {
       <SpaceSidebar :space="space" />
     </template>
     <template #content-right>
-      <div class="px-4 md:px-0 mb-3 flex relative">
+      <div class="px-3 md:px-0 mb-3 flex relative">
         <div class="flex-auto">
           <div class="flex items-center flex-auto">
             <h2>{{ $t('proposals.header') }}</h2>
@@ -167,7 +167,7 @@ onMounted(() => {
         class="mt-2"
         :space="space"
       />
-      <div v-else class="space-y-4 mb-4">
+      <div v-else class="space-y-6 my-4">
         <TimelineProposal
           v-for="(proposal, i) in store.space.proposals"
           :key="i"

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -176,7 +176,7 @@ function selectState(e) {
           </template>
         </BaseDropdown>
       </div>
-      <div class="md:rounded-lg bg-skin-block-bg border">
+      <div class="md:rounded-lg bg-skin-block-bg md:border">
         <LoadingRow
           v-if="
             loading ||

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -176,7 +176,7 @@ function selectState(e) {
           </template>
         </BaseDropdown>
       </div>
-      <div class="md:rounded-lg bg-skin-block-bg md:border">
+      <div class="md:rounded-lg bg-skin-block-bg md:border border-skin-border">
         <LoadingRow
           v-if="
             loading ||


### PR DESCRIPTION
Proposal page:
- put author/dropdowns in new line
- reduced text size/line height
- reduced paddings in votes block

Proposal list:
- reduced text size/line height
- reduced paddings

Timeline:
- removed borders
- (no other adjustments for now because I will try to merge those two components TimelineProposal.vue and TimelineProposalPreview.vue)

Looks good to me now all the way down to 360px width, which is still the most common according to [some statistic](https://gs.statcounter.com/screen-resolution-stats/mobile/worldwide) I found.

Share/dropdown menus would look better if they were on the same line as proposal state and space but that's a bit tricky if author is meant to be in the middle on large screens. Some other day...

![image](https://user-images.githubusercontent.com/6792578/159497166-36e7881c-333d-4026-9d71-a2c730e9a435.png)

![image](https://user-images.githubusercontent.com/6792578/159497184-025dcd71-7032-4a9e-a77d-a2b6825db087.png)

