### PR TITLE
apply min-width to grow containers for overflows to work properly

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,7 +32,7 @@ onMounted(async () => {
         <TheSidebar />
       </div>
     </div>
-    <div class="grow flex flex-col">
+    <div class="grow flex flex-col min-w-0">
       <div
         id="navbar"
         class="sticky top-0 border-b border-skin-border bg-skin-bg z-40"


### PR DESCRIPTION
Fixes this layout issue:

![image](https://user-images.githubusercontent.com/6792578/159560201-295808e3-86ce-4365-b16f-6960dd0946ac.png)

Changes proposed in this pull request:
- apply min-width of 0 to content container for overflows to work properly.

Read more: https://css-tricks.com/flexbox-truncated-text/
