### PR TITLE
dont show metamask on browsers that have not installed it

### DIFF
--- a/src/components/Modal/Account.vue
+++ b/src/components/Modal/Account.vue
@@ -54,7 +54,7 @@ watch(open, () => (step.value = null));
             {{ injected.name }}
           </BaseButton>
           <BaseButton
-            v-else-if="id !== 'gnosis'"
+            v-else-if="id !== 'gnosis' && id !== 'injected'"
             class="button-outline w-full flex justify-center items-center gap-2"
           >
             <img


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/6792578/159567304-3aa4e192-df71-4b72-9def-6f7daf2555d1.png)

This happens in browses that don't have Metamask installed.

If there wasn't any `injected`, it just went into the `v-else-if`.