### PR TITLE
added back timestamp for results block title

### DIFF
--- a/src/components/Block/Results.vue
+++ b/src/components/Block/Results.vue
@@ -29,8 +29,8 @@ const choices = computed(() =>
 );
 
 const getPercentage = (n, max) => (max ? ((100 / max) * n) / 1e2 : 0);
-
 const hideAbstain = props.space?.voting?.hideAbstain ?? false;
+const ts = (Date.now() / 1e3).toFixed();
 </script>
 
 <template>


### PR DESCRIPTION
I removed that timestamp var when I removed the block title. Then when adding back the title I forgot the timestamp.