### PR TITLE
dont refresh proposal after voting on spaces in pending.json

### DIFF
--- a/src/components/Modal/Confirm.vue
+++ b/src/components/Modal/Confirm.vue
@@ -6,6 +6,7 @@ import { useClient } from '@/composables/useClient';
 import { useIntl } from '@/composables/useIntl';
 import { getPower } from '../../helpers/snapshot';
 import { useWeb3 } from '../../composables/useWeb3';
+import pending from '@/helpers/pending.json';
 
 const { web3Account } = useWeb3();
 
@@ -45,7 +46,9 @@ async function handleSubmit() {
   console.log('Result', result);
   if (result.id) {
     notify(['green', t('notify.voteSuccessful')]);
-    emit('reload');
+    if (!pending.includes(props.space.id)) {
+      emit('reload');
+    }
     emit('close');
   }
 }


### PR DESCRIPTION
Fixes 0 VP issue after voting on cow space.

Simplest hot-fix is to just not refresh the proposal page after voting. It'll just show the "Your vote is in." confirmation message at the bottom.
Does that do the trick? Not sure if I understand the underlying issue and what's going on in the backend.
