### PR TITLE
Hotfix safeSnap create form

### DIFF
--- a/src/plugins/safeSnap/Create.vue
+++ b/src/plugins/safeSnap/Create.vue
@@ -19,7 +19,7 @@ const update = form => {
     :proposal="proposal"
     :config="space.plugins.safeSnap"
     :network="space.network"
-    :preview="preview"
+    :preview="false"
     @update:modelValue="update"
     :modelValue="modelValue?.safeSnap || {}"
     :spaceId="space.id"


### PR DESCRIPTION
Fixes safesnap form not showing when preview mode is enabled in first step when creating a proposal.

Changes proposed in this pull request:
- hardcoded preview to false in safesnap's Create.vue

**Not to be merged yet. Wanna try some automation to create a PR to dev whenever we hotfix stable.**