### PR TITLE
Fix ens address showing before spaces are loaded

### DIFF
--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -102,7 +102,7 @@ onUnmounted(() => clearInterval(waitingForRegistrationInterval));
           :web3Account="web3Account"
         />
         <BaseBlock v-else>
-          <div v-if="ownedEnsDomainsNoExistingSpace.length && spacesLoaded">
+          <div v-if="ownedEnsDomainsNoExistingSpace.length">
             <div class="mb-3">
               {{
                 $t(

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -14,7 +14,7 @@ const { web3, web3Account } = useWeb3();
 const { modalAccountOpen } = useModal();
 const { loadOwnedEnsDomains, ownedEnsDomains } = useEns();
 const { setPageTitle } = useI18n();
-const { spaces } = useSpaces();
+const { spaces, spacesLoaded } = useSpaces();
 const { ensAddress } = useSpaceController();
 
 onMounted(() => {
@@ -87,7 +87,7 @@ onUnmounted(() => clearInterval(waitingForRegistrationInterval));
         <h1 v-text="$t('setup.createASpace')" class="mb-4" />
       </div>
       <template v-if="web3Account">
-        <LoadingRow v-if="loadingOwnedEnsDomains" block />
+        <LoadingRow v-if="loadingOwnedEnsDomains || !spacesLoaded" block />
         <!-- Step two - setup space controller -->
         <SetupController
           v-else-if="route.params.step === 'controller' && ensAddress"
@@ -102,7 +102,7 @@ onUnmounted(() => clearInterval(waitingForRegistrationInterval));
           :web3Account="web3Account"
         />
         <BaseBlock v-else>
-          <div v-if="ownedEnsDomainsNoExistingSpace.length">
+          <div v-if="ownedEnsDomainsNoExistingSpace.length && spacesLoaded">
             <div class="mb-3">
               {{
                 $t(


### PR DESCRIPTION
If we show available ens addresses before spaces are loaded the `ownedEnsDomainsNoExistingSpace` will not work and all address that the wallet owns are shown. This also prevents the space setup flow from repeating.