### PR TITLE
Fix revoking global delegation

### DIFF
--- a/src/components/Modal/RevokeDelegate.vue
+++ b/src/components/Modal/RevokeDelegate.vue
@@ -40,7 +40,7 @@ async function handleSubmit() {
       contractAddress,
       abi,
       'clearDelegate',
-      [formatBytes32String(props.id)]
+      [formatBytes32String(props.id || '')]
     );
     pendingCount.value++;
     emit('close');


### PR DESCRIPTION
The new decentralized subgraph returns `null` instead of `''` for global delegations, causing `formatBytes32String` to fail.
It is passed either the space id or empty string now.
