### PR TITLE
Remove length check for showing tooltip

### DIFF
--- a/src/components/Block/Results.vue
+++ b/src/components/Block/Results.vue
@@ -47,7 +47,7 @@ const ts = (Date.now() / 1e3).toFixed();
             <div class="flex overflow-hidden">
               <span
                 v-tippy="{
-                  content: choice.choice.length > 24 ? choice.choice : null
+                  content: choice.choice
                 }"
                 class="mr-1 truncate"
                 v-text="choice.choice"
@@ -123,7 +123,10 @@ const ts = (Date.now() / 1e3).toFixed();
           />
         </template>
       </div>
-      <div v-if="proposal.quorum || space.voting?.quorum" class="text-skin-link">
+      <div
+        v-if="proposal.quorum || space.voting?.quorum"
+        class="text-skin-link"
+      >
         {{ $t('settings.quorum') }}
         <span class="float-right">
           {{ formatCompactNumber(results.sumOfResultsBalance) }} /


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/2147

Length for the symbol can vary a lot so the length check for choice string doesn't make sense under some circumstances. (This is just a quick fix)
