### PR TITLE
Fix space creation with not matching controller

### DIFF
--- a/src/components/SetupProfile.vue
+++ b/src/components/SetupProfile.vue
@@ -30,9 +30,7 @@ const form = ref({
   name: '',
   symbol: '',
   network: '',
-  // Adds connected wallet as admin so that the settings will show
-  // in the sidebar after space creation
-  admins: [props.web3Account],
+  admins: [] as string[],
   // Adds "ticket" strategy with VOTE symbol as default/placeholder strategy
   strategies: [
     {
@@ -101,6 +99,9 @@ async function handleSubmit() {
       await sleep(3000);
       await handleSubmit();
     } else {
+      // Adds connected wallet as admin so that the settings will show
+      // in the sidebar after space creation
+      form.value.admins = [props.web3Account];
       // Create the space
       const result = await send(
         { id: props.ensAddress },

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -67,6 +67,9 @@ watch(ownedEnsDomains, (newVal, oldVal) => {
 const loadingOwnedEnsDomains = ref(true);
 loadOwnedEnsDomains().finally(() => (loadingOwnedEnsDomains.value = false));
 watch(web3Account, async () => {
+  // Prevent the page from reloading on account change (e.g. when switching to the controller account set on the previos step)
+  if (route.params.step === 'profile') return;
+
   // Reset ensAddress to empty string
   ensAddress.value = '';
 


### PR DESCRIPTION
Fixes https://discord.com/channels/707079246388133940/831512954435534898/963343919553327114

Steps to create space with not matching controller:

1. Connect with wallet that owns the ENS domain (Account 1)
2. Select the ENS domain on Setup page
3. Paste address (of Account 2) and sign tx to set the space controller 
4. On the `setup/profile` step switch to the controller wallet and create the space

Changes proposed in this pull request:
- Prevent page from reloading on account change
- Fix admin not matching controller
