### PR TITLE
Use stable branch for dependabot and snapshot packages update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    target-branch: "stable"
     commit-message:
       prefix: '⬆️ subs:'
     rebase-strategy: auto

--- a/.github/workflows/update-snapshot-packages.yml
+++ b/.github/workflows/update-snapshot-packages.yml
@@ -9,7 +9,9 @@ jobs:
   update-dep:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: stable
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'


### PR DESCRIPTION
Right now it is hard to create a new PR every time something changes in spaces or snapshot.js 