### PR TITLE
Make FlashNotification appear above Modal backdrop

### DIFF
--- a/src/components/FlashNotification.vue
+++ b/src/components/FlashNotification.vue
@@ -6,7 +6,7 @@ const { items } = useFlashNotification();
 
 <template>
   <div
-    class="fixed left-0 right-0 bottom-0 z-50 flex flex-col items-center mb-4 space-y-2 pointer-events-none"
+    class="flash-notification fixed left-0 right-0 bottom-0 flex flex-col items-center mb-4 space-y-2 pointer-events-none"
   >
     <TransitionGroup name="fade">
       <div v-for="item in items" :key="item.id" class="pointer-events-auto">
@@ -33,3 +33,9 @@ const { items } = useFlashNotification();
     </TransitionGroup>
   </div>
 </template>
+
+<style lang="scss">
+  .flash-notification {
+    z-index: 100;
+  }
+</style>


### PR DESCRIPTION
Fixes #2188.

Increases the z-index of `FlashNotification` component so it's slightly above the `Modal` backdrop's z-index.

![fix](https://user-images.githubusercontent.com/81343175/163661864-a5c303a9-479c-4506-b067-12ac10725a7d.png)

