### PR TITLE
Show full number in results tooltip

### DIFF
--- a/src/components/Block/Results.vue
+++ b/src/components/Block/Results.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 import { shorten } from '@/helpers/utils';
 import { useIntl } from '@/composables/useIntl';
 
-const { formatCompactNumber, formatPercentNumber } = useIntl();
+const { formatCompactNumber, formatPercentNumber, formatNumber } = useIntl();
 
 const props = defineProps({
   id: String,
@@ -60,7 +60,7 @@ const ts = (Date.now() / 1e3).toFixed();
                   content: results.resultsByStrategyScore[choice.i]
                     .map(
                       (score, index) =>
-                        `${formatCompactNumber(score)} ${titles[index]}`
+                        `${formatNumber(score)} ${titles[index]}`
                     )
                     .join(' + ')
                 }"


### PR DESCRIPTION
Currently you can only see the results number in a compact format.

Changes:
- Show full number with rounded decimals in the results tooltip 
<img width="399" alt="image" src="https://user-images.githubusercontent.com/51686767/167355771-dfb36ca5-98ca-436f-a99a-e91d1ec7680b.png">
