### PR TITLE
Filter by network using strategies networks

### DIFF
--- a/src/composables/useSpaces.ts
+++ b/src/composables/useSpaces.ts
@@ -68,7 +68,7 @@ export function useSpaces() {
         };
       })
       .filter(space => !space.private && verified[space.id] !== -1)
-      .filter(space => space.network === network || !network)
+      .filter(space => space.networks.includes(network) || !network)
       .filter(space =>
         JSON.stringify(space).toLowerCase().includes(q.toLowerCase())
       );


### PR DESCRIPTION
With this change instead of using space network to filter it use strategies network, which bring more interesting list example:
On https://snapshot.org/#/?network=100
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/16245250/173153725-3357c799-d0fc-495d-a6fe-c2e99aa807e4.png">

On http://localhost:3000/#/?network=100
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/16245250/173153741-a0b9f802-402f-402f-9fd5-1539efd3107f.png">
