### PR TITLE
Show newly followed spaces at top of sidebar

### DIFF
--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -54,10 +54,8 @@ watch(followingSpaces, () => {
   );
   // Order side bar and add new spaces to the end of the sidebar
   draggableSpaces.value.sort((a, b) => {
-    if (!draggableSpaces.value.some(() => sidebarSpaceOrder.includes(a)))
-      return 1;
-    if (!draggableSpaces.value.some(() => sidebarSpaceOrder.includes(b)))
-      return -1;
+    if (!sidebarSpaceOrder.includes(a)) return -1;
+    if (!sidebarSpaceOrder.includes(b)) return 1;
     return sidebarSpaceOrder.indexOf(a) - sidebarSpaceOrder.indexOf(b);
   });
 


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/2581

- removed `draggableSpaces.value.some` because it didn't do anything
- switched ordering for new spaces (`-1` and `1`) so that they are at the top