### PR TITLE
Update snapshot packages only once a week than every hour

### DIFF
--- a/.github/workflows/update-snapshot-packages.yml
+++ b/.github/workflows/update-snapshot-packages.yml
@@ -3,7 +3,7 @@ name: Update Snapshot packages
 on:
  workflow_dispatch:
  schedule:
-   - cron: 0 * * * *
+   - cron: 0 10 * * 1
 
 jobs:
   update-dep:


### PR DESCRIPTION
As we are using brovider now this will run every Monday, we can still trigger it manually anytime

