### PR TITLE
Use earlier block to avoid bug with Blockfinder

### DIFF
--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -74,9 +74,8 @@ onMounted(async () => {
   if (props.space?.voting?.type) form.value.type = props.space.voting.type;
   // Initialize the snapshot block number
   if (props.space?.network) {
-    form.value.snapshot = await getBlockNumber(
-      getProvider(props.space.network, 'brovider')
-    );
+    form.value.snapshot =
+      (await getBlockNumber(getProvider(props.space.network, 'brovider'))) - 4;
   }
 });
 </script>


### PR DESCRIPTION
Blockfinder can only resolve a block based on a timestamp if that block is not the latest, this cause issue currently if you try to create a proposal on a space with multichain (you can try on fabien.eth), cuz Blockfinder wont find corresponding block based on timestamp unless the block is 2 block past already. This PR should fix it