### PR TITLE
🗑️ Make pagination strategy not selectable in UI

### DIFF
--- a/src/composables/useStrategies.ts
+++ b/src/composables/useStrategies.ts
@@ -41,6 +41,11 @@ export function useStrategies() {
       'strategies'
     );
 
+    const index = strategies.value.findIndex(
+      elem => elem['id'] === 'pagination'
+    );
+    if (index) strategies.value.splice(index, 1);
+
     loadingStrategies.value = false;
   }
 

--- a/src/composables/useStrategies.ts
+++ b/src/composables/useStrategies.ts
@@ -41,10 +41,9 @@ export function useStrategies() {
       'strategies'
     );
 
-    const index = strategies.value.findIndex(
-      elem => elem['id'] === 'pagination'
+    strategies.value = strategies.value.filter(
+      strategy => strategy.id !== 'pagination'
     );
-    if (index) strategies.value.splice(index, 1);
 
     loadingStrategies.value = false;
   }


### PR DESCRIPTION
Changes in this PR: Removes the "pagination" strategy from the list available strategies to select in the UI.

How to test and review this PR? Run snapshot locally, go to fabien.eth space, and try to change the space strategy to pagination. It should not appear.
