### PR TITLE
Hide vote reason input and display when shutter enabled

### DIFF
--- a/src/components/ModalConfirm.vue
+++ b/src/components/ModalConfirm.vue
@@ -174,7 +174,7 @@ watch(
             <BaseIcon name="info" size="24" class="text-skin-text" />
           </BaseLink>
         </div>
-        <div class="mt-3 flex">
+        <div v-if="props.proposal.privacy !== 'shutter'" class="mt-3 flex">
           <TextareaAutosize
             v-model="reason"
             :max-length="140"

--- a/src/components/SpaceProposalVotesList.vue
+++ b/src/components/SpaceProposalVotesList.vue
@@ -125,7 +125,7 @@ watch(visibleVotes, () => {
           <BaseIcon name="signature" />
         </BaseButtonIcon>
         <BaseButtonIcon
-          v-if="vote.reason !== ''"
+          v-if="vote.reason !== '' && props.proposal.privacy !== 'shutter'"
           v-tippy="{
             content: vote.reason
           }"


### PR DESCRIPTION
Temporary fix for https://github.com/snapshot-labs/snapshot/issues/3228

This will hide the reason input inside the confirmation modal and also hide the reason icon on the vote if the proposal uses shutter.

We also need to make sure on the hub to not accept a reason for shutter proposals. @bonustrack 

