### PR TITLE
Fix PR template to allow automatic issue closure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Fixes Issue #
+Fixes #
 
 Changes in this PR:
 


### PR DESCRIPTION
**Background**

The current PR template starting with:
```
Fixes Issue #
```

doesn't automatically close the linked issue. This PR solves that, more info [in the Github docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

**Handling related PRs**
Sometimes there are several PRs that need to be merged together in an order: `A -> B -> C` where `C` is the final PR closing the issue. To avoid automatic closure through the partial PRs AB we can ask contributors to use the below for their descriptions:

```Fixes partially #``` 

which will not close the linked issue but will show up as a linked PR in the issue thread.



