### PR TITLE
Fix wallets connecting when they don't emit events

### DIFF
--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -40,7 +40,10 @@ export function useWeb3() {
 
   async function loadProvider() {
     try {
-      if (auth.provider.value.removeAllListeners)
+      if (
+        auth.provider.value.removeAllListeners &&
+        !auth.provider.value.isTorus
+        )
         auth.provider.value.removeAllListeners();
       if (auth.provider.value.on) {
         try {

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -40,25 +40,23 @@ export function useWeb3() {
 
   async function loadProvider() {
     try {
-      if (
-        auth.provider.value.removeAllListeners &&
-        !auth.provider.value.isTorus
-      )
+      if (auth.provider.value.removeAllListeners)
         auth.provider.value.removeAllListeners();
-      if (
-        auth.provider.value.on &&
-        auth.provider._value['_events'] !== undefined
-      ) {
-        auth.provider.value.on('chainChanged', async chainId => {
-          handleChainChanged(parseInt(formatUnits(chainId, 0)));
-        });
-        auth.provider.value.on('accountsChanged', async accounts => {
-          if (accounts.length !== 0) {
-            state.account = accounts[0];
-            await login();
-          }
-        });
-        // auth.provider.on('disconnect', async () => {});
+      if (auth.provider.value.on) {
+        try {
+          auth.provider.value.on('chainChanged', async chainId => {
+            handleChainChanged(parseInt(formatUnits(chainId, 0)));
+          });
+          auth.provider.value.on('accountsChanged', async accounts => {
+            if (accounts.length !== 0) {
+              state.account = accounts[0];
+              await login();
+            }
+          });
+          // auth.provider.on('disconnect', async () => {});
+        } catch (e) {
+          console.log(`failed to subscribe to events for provider: ${e}`);
+        }
       }
       console.log('Provider', auth.provider.value);
       let network, accounts;

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -45,7 +45,10 @@ export function useWeb3() {
         !auth.provider.value.isTorus
       )
         auth.provider.value.removeAllListeners();
-      if (auth.provider.value.on) {
+      if (
+        auth.provider.value.on &&
+        auth.provider._value['_events'] !== undefined
+      ) {
         auth.provider.value.on('chainChanged', async chainId => {
           handleChainChanged(parseInt(formatUnits(chainId, 0)));
         });

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -43,7 +43,7 @@ export function useWeb3() {
       if (
         auth.provider.value.removeAllListeners &&
         !auth.provider.value.isTorus
-        )
+      )
         auth.provider.value.removeAllListeners();
       if (auth.provider.value.on) {
         try {


### PR DESCRIPTION
Fixes #
N/A

Changes in this PR:
The GameStop wallet currently cannot connect. When comparing the differences between GameStop and MetaMask on connecting, I found the problem is the GameStop wallet has no events to emit. When Snapshot then tries to subscribe to events, exceptions and thrown and this throws off the users ability to connect to the site. Adding a check for events in the condition check resolves this.


It seems chrome prompts for the 'Injected' option while Brave does not. This will only solve it for users in Chrome. Not sure how to get the 'Injected' option when connecting in Brave.

How to test and review this PR?
I connected to the dev instance without issue using the GameStop wallet. Then I went into the 'fabien.eth' space and cast a vote successfully. I also connected with MetaMask and casted a vote successfully. Changing a network in MetaMask seemed to work, though I'm not entirely sure what UX should appear differently when a user does this.
