### PR TITLE
fix: Improve date and time picker

### DIFF
--- a/src/components/BaseCalendar.vue
+++ b/src/components/BaseCalendar.vue
@@ -12,7 +12,7 @@ const { currentLocale: locale } = useI18n();
 
 const [
   yearNow = new Date().getFullYear(),
-  monthNow = new Date().getMonth() + 1
+  monthNow = new Date().getMonth()
   // dayNow = new Date().getDate()
 ] = props.modelValue ? props.modelValue.split('-') : [];
 
@@ -26,7 +26,6 @@ const fullYear = computed(() =>
 );
 const days = computed(() => new Date(year.value, month.value + 1, 0).getDate());
 const emptyDays = computed(() => new Date(year.value, month.value, 1).getDay());
-const isFutureMonth = computed(() => month.value > new Date().getMonth());
 
 const today = computed(() => {
   return formatDate(
@@ -77,7 +76,6 @@ function isSelectable(year, month, day) {
     <div class="mb-2 flex items-center">
       <div class="w-1/4 text-left">
         <a
-          v-show="isFutureMonth"
           class="iconfont iconback text-lg font-semibold text-skin-text"
           @click="month--"
         />
@@ -105,15 +103,22 @@ function isSelectable(year, month, day) {
       <div v-for="day in days" :key="day">
         <a
           v-if="isSelectable(year, month, day)"
-          class="day selectable border-b border-r"
+          class="day border-b border-r bg-transparent text-skin-link hover:bg-skin-link hover:text-skin-bg"
           :class="{
-            'bg-skin-header-bg': formatDate(year, month, day) === today,
-            selected: input.includes(formatDate(year, month, day))
+            'ring-1 ring-inset ring-primary':
+              formatDate(year, month, day) === today,
+            '!bg-skin-link text-skin-bg': input.includes(
+              formatDate(year, month, day)
+            )
           }"
           @click="toggleDay(year, month, day)"
           v-text="day"
         />
-        <div v-else class="day border-b border-r" v-text="day" />
+        <div
+          v-else
+          class="day cursor-not-allowed border-b border-r text-skin-border"
+          v-text="day"
+        />
       </div>
     </div>
   </div>
@@ -125,7 +130,6 @@ function isSelectable(year, month, day) {
   margin: 0 auto;
 
   .day {
-    color: var(--text-color);
     text-decoration: none;
     font-size: 17px !important;
     float: left;
@@ -133,21 +137,6 @@ function isSelectable(year, month, day) {
     line-height: 44px;
     width: 44px;
     height: 44px;
-
-    &.selectable {
-      color: var(--link-color);
-      background-color: transparent;
-
-      &:hover {
-        background-color: var(--link-color) !important;
-        color: var(--bg-color) !important;
-      }
-    }
-
-    &.selected {
-      background-color: var(--link-color) !important;
-      color: var(--bg-color) !important;
-    }
   }
 }
 </style>

--- a/src/components/InputDate.vue
+++ b/src/components/InputDate.vue
@@ -5,6 +5,7 @@ defineProps<{
   title?: string;
   information?: string;
   dateString?: string;
+  date: number;
   disabled?: boolean;
   type?: string;
   tooltip: string | null;
@@ -36,6 +37,7 @@ const modalDateSelectOpen = ref(false);
     <ModalSelectDate
       :type="type"
       :open="modalDateSelectOpen"
+      :value="date"
       @close="modalDateSelectOpen = false"
       @input="$emit('update:date', $event)"
     />

--- a/src/components/ModalSelectDate.vue
+++ b/src/components/ModalSelectDate.vue
@@ -58,8 +58,12 @@ watch(open, () => {
         <BaseCalendar v-model="input" class="mx-auto mb-2" />
       </div>
     </div>
-    <div v-else class="m-4 mx-auto flex max-w-[180px]">
-      <input v-model="time" type="time" class="s-input !pl-4 text-lg" />
+    <div v-else class="m-4 mx-auto max-w-[140px]">
+      <input
+        v-model="time"
+        type="time"
+        class="s-input form-input text-center text-lg"
+      />
     </div>
     <template #footer>
       <div class="float-left w-2/4 pr-2">

--- a/src/components/ModalSelectDate.vue
+++ b/src/components/ModalSelectDate.vue
@@ -12,10 +12,7 @@ const emit = defineEmits(['input', 'close']);
 const { open } = toRefs(props);
 const step = ref(0);
 const input = ref('');
-const time = ref({
-  h: '12',
-  m: '00'
-});
+const time = ref('12:00');
 
 function formatDate(date) {
   const output = { h: '12', m: '00', dateString: '' };
@@ -31,7 +28,7 @@ function formatDate(date) {
 
 function handleSubmit() {
   if (step.value === 0) return (step.value = 1);
-  const dateString = `${input.value} ${time.value.h}:${time.value.m}:00`;
+  const dateString = `${input.value} ${time.value}:00`;
   const timestamp = new Date(dateString).getTime() / 1000;
   emit('input', timestamp);
   emit('close');
@@ -41,7 +38,7 @@ watch(open, () => {
   step.value = 0;
   if (!props.value) return;
   const { dateString, h, m } = formatDate(props.value);
-  time.value = { h, m };
+  time.value = `${h}:${m}`;
   input.value = dateString;
 });
 </script>
@@ -61,12 +58,8 @@ watch(open, () => {
         <BaseCalendar v-model="input" class="mx-auto mb-2" />
       </div>
     </div>
-    <div v-else class="m-4 mx-auto flex" style="max-width: 160px">
-      <BaseButton class="w-max !px-0">
-        <input v-model="time.h" max="24" class="input w-5/12 text-center" />
-        <span class="w-2/12">:</span>
-        <input v-model="time.m" max="60" class="input w-5/12 text-center" />
-      </BaseButton>
+    <div v-else class="m-4 mx-auto flex max-w-[180px]">
+      <input v-model="time" type="time" class="s-input !pl-4 text-lg" />
     </div>
     <template #footer>
       <div class="float-left w-2/4 pr-2">

--- a/src/components/SpaceCreateVotingDateEnd.vue
+++ b/src/components/SpaceCreateVotingDateEnd.vue
@@ -24,6 +24,7 @@ const emit = defineEmits(['select']);
     type="end"
     :title="$t(`create.end`)"
     :disabled="!!period"
+    :date="date"
     :date-string="dateString"
     :tooltip="!!period ? $t('create.periodEnforced') : null"
     @update:date="emit('select', $event)"

--- a/src/components/SpaceCreateVotingDateStart.vue
+++ b/src/components/SpaceCreateVotingDateStart.vue
@@ -16,7 +16,7 @@ const props = withDefaults(
 
 const dateString = computed(() =>
   Math.round(props.date / 10) ===
-  Math.round(parseInt((Date.now() / 1e3).toFixed()) / 10)
+  Math.round(Number((Date.now() / 1e3).toFixed()) / 10)
     ? t('create.now')
     : d(props.date * 1e3, 'short', 'en-US')
 );
@@ -29,6 +29,7 @@ const emit = defineEmits(['select']);
     type="start"
     :title="$t(`create.start`)"
     :disabled="!!delay"
+    :date="date"
     :date-string="dateString"
     :tooltip="!!delay ? $t('create.delayEnforced') : null"
     @update:date="emit('select', $event)"

--- a/src/style.scss
+++ b/src/style.scss
@@ -161,6 +161,11 @@ input[type='number']::-webkit-outer-spin-button {
   margin: 0;
 }
 
+input[type='time']::-webkit-calendar-picker-indicator {
+  background: none;
+  display: none;
+}
+
 // Pointer cursor for file input buttons
 input[type=file], /* FF, IE7+, chrome (except button) */
 input[type=file]::-webkit-file-upload-button {


### PR DESCRIPTION
## Changes in this PR

### Calendar
1. There was a bug with the button for going backwards in months, I couldn't find a fix so I made it always visible now.
2. Fix for light theme. The disabled (past days) were not distinguishable from enabled (current and futures days). And I also added a not allowed cursor for disabled days.
3. The current day is now indicated by a `primary` ring
4. The The currently selected date in now pre-selected when you open the calendar

Before             |  After
:-------------------------:|:-------------------------:
<img width="393" alt="Screen Shot 2022-12-28 at 8 02 10 PM" src="https://user-images.githubusercontent.com/51686767/209816435-359b4a12-f0e8-4c15-82b5-320ba07493be.png">  | <img width="391" alt="image" src="https://user-images.githubusercontent.com/51686767/209817212-6014eef3-607a-425d-a2af-14f8ff694b83.png">


### Time

1. The time selector wasn't using the correct input so it was possible to enter invalid times. Fixed by using input with type `time`
2. The time input will now adjust to the browsers localization settings, f.e english is with `AM` `PM` and German is 24h
3. When clicking the clock icon it will open a dropdown with time sliders (great for mobile)
4. Time input is overall much easier 
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/51686767/209818316-1598a3d9-eaad-488a-83e3-e2321bb5ee43.png">


Before             |  After
:-------------------------:|:-------------------------:
<img width="501" alt="image" src="https://user-images.githubusercontent.com/51686767/209817613-37297e54-85b3-4c32-9dd7-77f3def985de.png">  | <img width="489" alt="image" src="https://user-images.githubusercontent.com/51686767/209817653-be284b85-b539-41d3-8f13-ab41491dff74.png">



## How to test and review this PR?

Go to https://bafybeicfdfu7bzkoii6gbp564hudaptmhv334yxha4mnoiokad4vmaqfbu.on.fleek.co/#/fabien.eth/create/1
