### PR TITLE
Show warning for invalid ENS names on setup

### DIFF
--- a/src/composables/useEns.ts
+++ b/src/composables/useEns.ts
@@ -44,6 +44,10 @@ export function useEns() {
                 )
               };
             }
+            return {
+              ...domain,
+              isInvalid: true
+            };
           }
 
           return domain;

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -451,7 +451,8 @@
       "ensMessage": " One thing you need before you can create your own space, is an ENS domain on Ethereum mainnet.",
       "ensMessageTestnet": "You can also {link} on the Goerli testnet and mess with things there first.",
       "tryDemo": "try the demo",
-      "yourExistingSpaces": "Your existing spaces"
+      "yourExistingSpaces": "Your existing spaces",
+      "invalidEns": "This ENS name is invalid. Usually this is due the use of invalid characters during registration."
     },
     "strategy": {
       "title": "How would you like to setup your voting strategy?",


### PR DESCRIPTION
Fixes #2088

## Changes

1. Shorten the displayed hash when `labelName` isn't available
2. Show a warning icon and tooltip with an explanation when `labelName` isn't available <img width="881" alt="image" src="https://user-images.githubusercontent.com/51686767/216083568-ea89b9f9-58e4-49dd-bde5-fafe66c2d9d3.png">

4. When user clicks the button with an invalid domain, it will open the ENS app in a new tab `https://app.ens.domains/address/<CONNECTED_ADDRESS>/controller` so that the user can further investigate the issue <img width="1421" alt="image" src="https://user-images.githubusercontent.com/51686767/216083404-2b01766c-7afb-4d9b-ba3d-fdf9d3313565.png">

## How to test

1. Go to https://guest.on.fleek.co/#/0xa2e81c205e38324bf7432aecbd2c7e20c717e1d3 and connect to a deployment from this PR using WalletConnect
2. Go to Create space
3. You will see the invalid address in the list


@zzuziak Please check text for warning message.