### PR TITLE
fix: Show sub proposals on custom domain

### DIFF
--- a/src/components/LinkSpace.vue
+++ b/src/components/LinkSpace.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import domains from '@/../snapshot-spaces/spaces/domains.json';
+import { useApp } from '@/composables';
+
+const props = defineProps<{
+  spaceId: string;
+}>();
+
+const { domain } = useApp();
+
+const spaceLink = computed(() => {
+  // Check if proposal space id is a value in the domains.json file
+  if (domain && Object.values(domains).includes(props.spaceId)) {
+    // If so, find the key that matches the value
+    const key = Object.keys(domains).find(
+      key => domains[key] === props.spaceId
+    );
+    return `https://${key}`;
+  }
+
+  if (domain) return `https://snapshot.org/#/${props.spaceId}`;
+
+  return {
+    name: 'spaceProposals',
+    params: { key: props.spaceId }
+  };
+});
+</script>
+
+<template>
+  <BaseLink :link="spaceLink" hide-external-icon>
+    <slot />
+  </BaseLink>
+</template>

--- a/src/components/ProposalsItem.vue
+++ b/src/components/ProposalsItem.vue
@@ -27,12 +27,10 @@ const body = computed(() => removeMd(props.proposal.body));
         <div class="mb-2 flex items-center justify-between">
           <div class="flex items-center space-x-1">
             <template v-if="!hideSpaceAvatar">
-              <router-link
+              <LinkSpace
                 class="text-skin-text"
-                :to="{
-                  name: 'spaceProposals',
-                  params: { key: proposal.space.id }
-                }"
+                :space-id="proposal.space.id"
+                @click.stop
               >
                 <div class="flex items-center">
                   <AvatarSpace :space="proposal.space" size="28" />
@@ -41,7 +39,7 @@ const body = computed(() => removeMd(props.proposal.body));
                     v-text="proposal.space.name"
                   />
                 </div>
-              </router-link>
+              </LinkSpace>
               <span v-text="$tc('proposalBy')" />
             </template>
             <BaseUser

--- a/src/components/ProposalsItem.vue
+++ b/src/components/ProposalsItem.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   profiles: { [key: string]: Profile };
   space: ExtendedSpace;
   voted: boolean;
+  to: Record<string, unknown>;
   hideSpaceAvatar?: boolean;
 }>();
 
@@ -16,13 +17,7 @@ const body = computed(() => removeMd(props.proposal.body));
 
 <template>
   <div>
-    <router-link
-      class="block p-3 text-skin-text sm:p-4"
-      :to="{
-        name: 'spaceProposal',
-        params: { key: proposal.space.id, id: proposal.id }
-      }"
-    >
+    <router-link class="block p-3 text-skin-text sm:p-4" :to="to">
       <div>
         <div class="mb-2 flex items-center justify-between">
           <div class="flex items-center space-x-1">

--- a/src/components/SettingsSubSpacesBlock.vue
+++ b/src/components/SettingsSubSpacesBlock.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
 }>();
 
 const { form } = useSpaceForm(props.context);
-const { loadExtentedSpaces, extentedSpaces } = useExtendedSpaces();
+const { loadExtendedSpaces, extendedSpaces } = useExtendedSpaces();
 
 const lookingUpParent = ref(false);
 const foundParent = ref(false);
@@ -22,9 +22,9 @@ watchDebounced(
     if (!form.value.parent) return;
 
     lookingUpParent.value = true;
-    await loadExtentedSpaces([form.value.parent]);
+    await loadExtendedSpaces([form.value.parent]);
 
-    const found = extentedSpaces.value?.some(
+    const found = extendedSpaces.value?.some(
       space => space.id === form.value.parent
     );
     if (found) {
@@ -50,9 +50,9 @@ watchDebounced(
     if (!childInput.value) return;
 
     lookingUpChild.value = true;
-    await loadExtentedSpaces([childInput.value]);
+    await loadExtendedSpaces([childInput.value]);
 
-    const found = extentedSpaces.value?.some(
+    const found = extendedSpaces.value?.some(
       space => space.id === childInput.value
     );
     if (found) {

--- a/src/components/SetupDomain.vue
+++ b/src/components/SetupDomain.vue
@@ -14,7 +14,7 @@ const defaultNetwork = import.meta.env.VITE_DEFAULT_NETWORK;
 
 const { web3Account } = useWeb3();
 const { loadOwnedEnsDomains, ownedEnsDomains } = useEns();
-const { loadExtentedSpaces, extentedSpaces, spaceLoading } =
+const { loadExtendedSpaces, extendedSpaces, spaceLoading } =
   useExtendedSpaces();
 
 const inputDomain = ref('');
@@ -28,19 +28,19 @@ watch(
     await loadOwnedEnsDomains(web3Account.value);
     loadingOwnedEnsDomains.value = false;
     if (ownedEnsDomains.value.map(d => d.name).length)
-      await loadExtentedSpaces(ownedEnsDomains.value.map(d => d.name));
+      await loadExtendedSpaces(ownedEnsDomains.value.map(d => d.name));
   },
   { immediate: true }
 );
 
 const domainsWithoutExistingSpace = computed(() => {
-  const spaces = clone(extentedSpaces.value.map(space => space.id));
+  const spaces = clone(extendedSpaces.value.map(space => space.id));
   return ownedEnsDomains.value.filter(d => !spaces.includes(d.name));
 });
 
 const domainsWithExistingSpace = computed(() => {
   const spaces = ownedEnsDomains.value.map(d => d.name);
-  return extentedSpaces.value.filter(d => spaces.includes(d.id));
+  return extendedSpaces.value.filter(d => spaces.includes(d.id));
 });
 
 const emit = defineEmits(['next']);

--- a/src/components/SpaceProposalHeader.vue
+++ b/src/components/SpaceProposalHeader.vue
@@ -105,18 +105,12 @@ watch(
   <div class="mb-4 flex flex-col sm:flex-row sm:space-x-1">
     <div class="mb-1 flex items-center sm:mb-0">
       <LabelProposalState :state="proposal.state" class="mr-2" />
-      <router-link
-        class="group text-skin-text"
-        :to="{
-          name: 'spaceProposals',
-          params: { key: space.id }
-        }"
-      >
+      <LinkSpace :space-id="space.id" class="group text-skin-text">
         <div class="flex items-center">
           <AvatarSpace :space="space" size="28" />
           <span class="ml-2 group-hover:text-skin-link" v-text="space.name" />
         </div>
-      </router-link>
+      </LinkSpace>
     </div>
     <div class="flex grow items-center space-x-1">
       <span v-text="$t('proposalBy')" />

--- a/src/components/SpaceProposalPage.vue
+++ b/src/components/SpaceProposalPage.vue
@@ -1,0 +1,254 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import voting from '@snapshot-labs/snapshot.js/src/voting';
+import { useRoute, useRouter } from 'vue-router';
+import { getProposalVotes } from '@/helpers/snapshot';
+import { ExtendedSpace, Proposal, Results, Vote } from '@/helpers/interfaces';
+import {
+  useI18n,
+  useModal,
+  useTerms,
+  useWeb3,
+  useInfiniteLoader
+} from '@/composables';
+
+const props = defineProps<{ space: ExtendedSpace; proposal: Proposal }>();
+const emit = defineEmits(['reload-proposal']);
+
+const route = useRoute();
+const router = useRouter();
+
+const { setPageTitle } = useI18n();
+const { web3, web3Account } = useWeb3();
+
+const proposalId: string = route.params.id as string;
+
+const modalOpen = ref(false);
+const isModalPostVoteOpen = ref(false);
+const selectedChoices = ref<any>(null);
+const loadedResults = ref(false);
+const loadedVotes = ref(false);
+const votes = ref([]);
+const userVote = ref<Vote | null>(null);
+const results = ref<Results | null>(null);
+
+const isAdmin = computed(() => {
+  const admins = (props.space.admins || []).map(admin => admin.toLowerCase());
+  return admins.includes(web3Account.value?.toLowerCase());
+});
+const strategies = computed(
+  // Needed for older proposal that are missing strategies
+  () => props.proposal?.strategies ?? props.space.strategies
+);
+
+const browserHasHistory = computed(() => window.history.state.back);
+
+const { modalAccountOpen } = useModal();
+const { modalTermsOpen, termsAccepted, acceptTerms } = useTerms(props.space.id);
+
+function clickVote() {
+  !web3.value.account
+    ? (modalAccountOpen.value = true)
+    : !termsAccepted.value && props.space.terms
+    ? (modalTermsOpen.value = true)
+    : (modalOpen.value = true);
+}
+
+function reloadProposal() {
+  emit('reload-proposal');
+}
+
+function formatProposalVotes(votes) {
+  if (!votes.length) return [];
+  return votes.map(vote => {
+    vote.balance = vote.vp;
+    vote.scores = vote.vp_by_strategy;
+    return vote;
+  });
+}
+
+async function loadResults() {
+  if (props.proposal.scores.length === 0) {
+    const votingClass = new voting[props.proposal.type](
+      props.proposal,
+      [],
+      strategies.value
+    );
+    results.value = {
+      scores: votingClass.getScores(),
+      scoresByStrategy: votingClass.getScoresByStrategy(),
+      scoresTotal: votingClass.getScoresTotal()
+    };
+  } else {
+    results.value = {
+      scores: props.proposal.scores,
+      scoresByStrategy: props.proposal.scores_by_strategy,
+      scoresTotal: props.proposal.scores_total
+    };
+  }
+  loadedResults.value = true;
+  const [userVotesRes, votesRes] = await Promise.all([
+    // Skip if user is not connected
+    web3Account.value
+      ? await getProposalVotes(proposalId, {
+          first: 1,
+          voter: web3Account.value,
+          space: props.proposal.space.id
+        })
+      : [],
+    await getProposalVotes(proposalId, {
+      first: 10,
+      space: props.proposal.space.id
+    })
+  ]);
+  userVote.value = formatProposalVotes(userVotesRes)?.[0] || null;
+  votes.value = formatProposalVotes(votesRes);
+  loadedVotes.value = true;
+}
+
+const { loadBy, loadingMore, loadMore } = useInfiniteLoader(10);
+
+async function loadMoreVotes() {
+  const votesObj = await getProposalVotes(proposalId, {
+    first: loadBy,
+    skip: votes.value.length
+  });
+  votes.value = votes.value.concat(formatProposalVotes(votesObj));
+}
+
+function handleBackClick() {
+  if (!browserHasHistory.value || browserHasHistory.value.includes('create'))
+    return router.push({ name: 'spaceProposals' });
+  return router.go(-1);
+}
+
+watch(web3Account, () => {
+  const choice = route.query.choice as string;
+  if (choice) {
+    selectedChoices.value = parseInt(choice);
+    clickVote();
+  }
+});
+
+onMounted(async () => {
+  setPageTitle('page.title.space.proposal', {
+    proposal: props.proposal.title,
+    space: props.space.name
+  });
+  const choice = route.query.choice as string;
+  if (props.proposal?.type === 'approval') selectedChoices.value = [];
+  if (web3Account.value && choice) {
+    selectedChoices.value = parseInt(choice);
+    clickVote();
+  }
+  loadResults();
+});
+</script>
+
+<template>
+  <TheLayout v-bind="$attrs">
+    <template #content-left>
+      <div class="mb-3 px-3 md:px-0">
+        <ButtonBack @click="handleBackClick" />
+      </div>
+
+      <div class="px-3 md:px-0">
+        <SpaceProposalHeader
+          :space="space"
+          :proposal="proposal"
+          :is-admin="isAdmin"
+        />
+        <SpaceProposalContent :space="space" :proposal="proposal" />
+      </div>
+      <div class="space-y-4">
+        <div v-if="proposal?.discussion" class="px-3 md:px-0">
+          <h3 v-text="$t('discussion')" />
+          <BlockLink :link="proposal.discussion" />
+        </div>
+        <SpaceProposalVote
+          v-if="proposal?.state === 'active' && loadedVotes"
+          v-model="selectedChoices"
+          :proposal="proposal"
+          :user-vote="userVote"
+          @open="modalOpen = true"
+          @clickVote="clickVote"
+        />
+        <SpaceProposalVotesList
+          :loaded="loadedVotes"
+          :space="space"
+          :proposal="proposal"
+          :votes="votes"
+          :strategies="strategies"
+          :user-vote="userVote"
+          :loading-more="loadingMore"
+          @loadVotes="loadMore(loadMoreVotes)"
+        />
+        <SpaceProposalPlugins
+          v-if="proposal?.plugins && loadedResults && results"
+          :id="proposalId"
+          :space="space"
+          :proposal="proposal"
+          :results="results"
+          :loaded-results="loadedResults"
+          :votes="votes"
+          :strategies="strategies"
+        />
+      </div>
+    </template>
+    <template #sidebar-right>
+      <div class="mt-4 space-y-4 lg:mt-0">
+        <SpaceProposalInformation
+          :space="space"
+          :proposal="proposal"
+          :strategies="strategies"
+        />
+        <SpaceProposalResults
+          :loaded="loadedResults"
+          :space="space"
+          :proposal="proposal"
+          :results="results"
+          :votes="votes"
+          :strategies="strategies"
+          :is-admin="isAdmin"
+          @reload="reloadProposal()"
+        />
+        <SpaceProposalPluginsSidebar
+          v-if="proposal.plugins && loadedResults && results"
+          :id="proposalId"
+          :space="space"
+          :proposal="proposal"
+          :results="results"
+          :loaded-results="loadedResults"
+          :votes="votes"
+          :strategies="strategies"
+        />
+      </div>
+    </template>
+  </TheLayout>
+  <teleport to="#modal">
+    <ModalVote
+      :open="modalOpen"
+      :space="space"
+      :proposal="proposal"
+      :selected-choices="selectedChoices"
+      :strategies="strategies"
+      @close="modalOpen = false"
+      @reload="reloadProposal()"
+      @openPostVoteModal="isModalPostVoteOpen = true"
+    />
+    <ModalTerms
+      :open="modalTermsOpen"
+      :space="space"
+      :action="$t('modalTerms.actionVote')"
+      @close="modalTermsOpen = false"
+      @accept="acceptTerms(), (modalOpen = true)"
+    />
+    <ModalPostVote
+      :open="isModalPostVoteOpen"
+      :space="space"
+      :proposal="proposal"
+      :selected-choices="selectedChoices"
+      @close="isModalPostVoteOpen = false"
+    />
+  </teleport>
+</template>

--- a/src/components/SpaceProposalsNoProposals.vue
+++ b/src/components/SpaceProposalsNoProposals.vue
@@ -11,9 +11,7 @@ defineProps<{
       <div class="mb-3">
         {{ $t('noResultsFound') }}
       </div>
-      <router-link
-        :to="{ name: 'spaceCreate', params: { key: space.id, step: 0 } }"
-      >
+      <router-link :to="{ name: 'spaceCreate', params: { step: 0 } }">
         <BaseButton>
           {{ $t('proposals.createProposal') }}
         </BaseButton>

--- a/src/components/SpaceSidebarSubspaces.vue
+++ b/src/components/SpaceSidebarSubspaces.vue
@@ -27,33 +27,21 @@ const subSpaces = computed(() => {
   <div v-if="mainSpace || subSpaces.length" class="my-3">
     <div v-if="mainSpace">
       <h5 class="px-4 font-normal text-skin-text">{{ $t('mainspace') }}</h5>
-      <BaseLink
-        :link="
-          domain
-            ? `https://snapshot.org/#/${mainSpace.id}`
-            : { name: 'spaceProposals', params: { key: mainSpace.id } }
-        "
-        hide-external-icon
-      >
+      <LinkSpace :space-id="mainSpace.id">
         <BaseSidebarNavigationItem class="flex items-center">
           <AvatarSpace :space="mainSpace" size="22" />
           <span class="mx-2 truncate">
             {{ mainSpace.name }}
           </span>
         </BaseSidebarNavigationItem>
-      </BaseLink>
+      </LinkSpace>
     </div>
     <div v-if="subSpaces?.length">
       <h5 class="px-4 font-normal text-skin-text">{{ $t('subspaces') }}</h5>
-      <BaseLink
+      <LinkSpace
         v-for="subSpace in subSpaces"
         :key="subSpace.id"
-        :link="
-          domain
-            ? `https://snapshot.org/#/${subSpace.id}`
-            : { name: 'spaceProposals', params: { key: subSpace.id } }
-        "
-        hide-external-icon
+        :space-id="subSpace.id"
       >
         <BaseSidebarNavigationItem class="flex items-center">
           <AvatarSpace :space="subSpace" size="22" />
@@ -61,7 +49,7 @@ const subSpaces = computed(() => {
             {{ subSpace.name }}
           </span>
         </BaseSidebarNavigationItem>
-      </BaseLink>
+      </LinkSpace>
     </div>
   </div>
 </template>

--- a/src/components/SpaceSidebarSubspaces.vue
+++ b/src/components/SpaceSidebarSubspaces.vue
@@ -2,10 +2,6 @@
 import { computed } from 'vue';
 import { ExtendedSpace } from '@/helpers/interfaces';
 
-import { useApp } from '@/composables';
-
-const { domain } = useApp();
-
 const props = defineProps<{
   space: ExtendedSpace;
 }>();

--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -20,15 +20,15 @@ const { web3Account } = useWeb3();
 const { loadFollows, followingSpaces, loadingFollows } = useFollowSpace();
 const { spaceHasUnseenProposals } = useUnseenProposals();
 const { domain, showSidebar } = useApp();
-const { loadExtentedSpaces, extentedSpaces, spaceLoading } =
+const { loadExtendedSpaces, extendedSpaces, spaceLoading } =
   useExtendedSpaces();
 const { spaces } = useSpaces();
 
 const draggableSpaces = ref<string[]>([]);
 
-const extentedSpacesObj = computed(() => {
+const extendedSpacesObj = computed(() => {
   return (
-    extentedSpaces.value?.reduce(
+    extendedSpaces.value?.reduce(
       (acc, space) => ({ ...acc, [space.id]: space }),
       {}
     ) ?? {}
@@ -60,7 +60,7 @@ watch(followingSpaces, () => {
 });
 
 watch(followingSpaces, () => {
-  loadExtentedSpaces(followingSpaces.value);
+  loadExtendedSpaces(followingSpaces.value);
 });
 
 watch(
@@ -100,7 +100,7 @@ watch(
       </router-link>
     </div>
     <SidebarSpacesSkeleton
-      v-if="extentedSpaces.length === 0 && (spaceLoading || loadingFollows)"
+      v-if="extendedSpaces.length === 0 && (spaceLoading || loadingFollows)"
     />
 
     <draggable
@@ -116,9 +116,9 @@ watch(
     >
       <template #item="{ element }">
         <div
-          v-if="extentedSpacesObj[element]"
+          v-if="extendedSpacesObj[element]"
           v-tippy="{
-            content: extentedSpacesObj[element].name,
+            content: extendedSpacesObj[element].name,
             placement: 'right',
             delay: [750, 0],
             touch: ['hold', 500]
@@ -140,7 +140,7 @@ watch(
           >
             <AvatarSpace
               :key="element"
-              :space="extentedSpacesObj[element]"
+              :space="extendedSpacesObj[element]"
               symbol-index="space"
               size="44"
               class="pointer-events-none"

--- a/src/composables/useApp.ts
+++ b/src/composables/useApp.ts
@@ -58,7 +58,6 @@ export function useApp() {
 
   return {
     domain,
-    domainName,
     domainAlias,
     env,
     isReady,

--- a/src/composables/useApp.ts
+++ b/src/composables/useApp.ts
@@ -58,6 +58,7 @@ export function useApp() {
 
   return {
     domain,
+    domainName,
     domainAlias,
     env,
     isReady,

--- a/src/composables/useExtendedSpaces.ts
+++ b/src/composables/useExtendedSpaces.ts
@@ -4,15 +4,15 @@ import { useApolloQuery } from '@/composables/useApolloQuery';
 import { ExtendedSpace } from '@/helpers/interfaces';
 import { mapOldPluginNames } from '@/helpers/utils';
 
-const extentedSpaces = ref<ExtendedSpace[]>([]);
+const extendedSpaces = ref<ExtendedSpace[]>([]);
 
 export function useExtendedSpaces() {
   const loading = ref(false);
 
   const { apolloQuery } = useApolloQuery();
-  async function loadExtentedSpaces(id_in: string[] = []) {
+  async function loadExtendedSpaces(id_in: string[] = []) {
     const filteredLoadedSpaces = id_in.filter(
-      id => !extentedSpaces.value?.find(space => space.id === id)
+      id => !extendedSpaces.value?.find(space => space.id === id)
     );
     if (!filteredLoadedSpaces.length) return;
 
@@ -29,10 +29,10 @@ export function useExtendedSpaces() {
       );
 
       const mappedSpaces = spaces.map(mapOldPluginNames);
-      extentedSpaces.value = [...extentedSpaces.value, ...mappedSpaces];
+      extendedSpaces.value = [...extendedSpaces.value, ...mappedSpaces];
 
       // Remove any duplicates incase two requests were made at the same time
-      extentedSpaces.value = extentedSpaces.value.filter(
+      extendedSpaces.value = extendedSpaces.value.filter(
         (space, index, self) => index === self.findIndex(t => t.id === space.id)
       );
 
@@ -45,19 +45,19 @@ export function useExtendedSpaces() {
   }
 
   const reloadSpace = (id: string) => {
-    const spaceToReload = extentedSpaces.value?.find(space => space.id === id);
+    const spaceToReload = extendedSpaces.value?.find(space => space.id === id);
     if (spaceToReload) {
-      extentedSpaces.value = extentedSpaces.value.filter(
+      extendedSpaces.value = extendedSpaces.value.filter(
         space => space.id !== id
       );
-      loadExtentedSpaces([id]);
+      loadExtendedSpaces([id]);
     }
   };
 
   return {
-    loadExtentedSpaces,
+    loadExtendedSpaces,
     reloadSpace,
-    extentedSpaces: computed(() => extentedSpaces.value),
+    extendedSpaces: computed(() => extendedSpaces.value),
     spaceLoading: computed(() => loading.value)
   };
 }

--- a/src/views/ProfileAbout.vue
+++ b/src/views/ProfileAbout.vue
@@ -34,11 +34,11 @@ async function loadSpacesFollowed() {
 onMounted(() => loadSpacesFollowed());
 
 const { loadOwnedEnsDomains, ownedEnsDomains } = useEns();
-const { loadExtentedSpaces, extentedSpaces } = useExtendedSpaces();
+const { loadExtendedSpaces, extendedSpaces } = useExtendedSpaces();
 
 const domainsWithExistingSpace = computed(() => {
   const spaces = ownedEnsDomains.value.map(d => d.name);
-  return extentedSpaces.value.filter(d => spaces.includes(d.id));
+  return extendedSpaces.value.filter(d => spaces.includes(d.id));
 });
 
 const loadingOwnedSpaces = ref(false);
@@ -46,7 +46,7 @@ const loadingOwnedSpaces = ref(false);
 onMounted(async () => {
   loadingOwnedSpaces.value = true;
   await loadOwnedEnsDomains(props.userAddress);
-  await loadExtentedSpaces(ownedEnsDomains.value.map(d => d.name));
+  await loadExtendedSpaces(ownedEnsDomains.value.map(d => d.name));
   loadingOwnedSpaces.value = false;
 });
 </script>

--- a/src/views/SetupView.vue
+++ b/src/views/SetupView.vue
@@ -36,13 +36,13 @@ const creatingSpace = ref(false);
 const { t } = useI18n();
 const { pendingENSRecord, uriAddress, loadUriAddress } = useSpaceController();
 const { send } = useClient();
-const { loadExtentedSpaces, extentedSpaces } = useExtendedSpaces();
+const { loadExtendedSpaces, extendedSpaces } = useExtendedSpaces();
 
 const currentStep = computed(() => Number(route.query.step));
 
 async function checkIfSpaceExists() {
-  await loadExtentedSpaces([route.params.ens as string]);
-  if (extentedSpaces.value?.some(space => space.id === route.params.ens)) {
+  await loadExtendedSpaces([route.params.ens as string]);
+  if (extendedSpaces.value?.some(space => space.id === route.params.ens)) {
     return;
   } else {
     await sleep(5000);

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -39,10 +39,7 @@ async function loadProposal() {
     extendedSpaces.value.find(
       space => space.id.toLowerCase() === proposal.value?.space.id.toLowerCase()
     ) ?? null;
-  console.log(
-    space.value?.parent?.children.map(c => c.id),
-    proposal.value.space.id
-  );
+
   if (!isSpaceRelatedProposal.value) return router.push({ name: 'error-404' });
 
   loadingProposal.value = false;

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -1,279 +1,72 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, watchEffect } from 'vue';
-import voting from '@snapshot-labs/snapshot.js/src/voting';
+import { ref, onMounted, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { getProposal, getProposalVotes } from '@/helpers/snapshot';
-import { ExtendedSpace, Proposal, Results, Vote } from '@/helpers/interfaces';
-import {
-  useI18n,
-  useModal,
-  useTerms,
-  useWeb3,
-  useInfiniteLoader
-} from '@/composables';
+import { getProposal } from '@/helpers/snapshot';
+import { ExtendedSpace, Proposal } from '@/helpers/interfaces';
 
-const props = defineProps<{ space: ExtendedSpace }>();
+import { useExtendedSpaces } from '@/composables';
+
+const props = defineProps<{ spaceKey: string }>();
+
+const loadingProposal = ref(false);
+const proposal = ref<Proposal | null>(null);
+const space = ref<ExtendedSpace | null>(null);
 
 const route = useRoute();
 const router = useRouter();
 
-const { setPageTitle } = useI18n();
-const { web3, web3Account } = useWeb3();
+const { loadExtendedSpaces, extendedSpaces } = useExtendedSpaces();
 
-const id: string = route.params.id as string;
+const proposalId: string = route.params.id as string;
 
-const modalOpen = ref(false);
-const isModalPostVoteOpen = ref(false);
-const selectedChoices = ref<any>(null);
-const loadingProposal = ref(true);
-const loadedResults = ref(false);
-const loadedVotes = ref(false);
-const proposal = ref<Proposal | null>(null);
-const votes = ref([]);
-const userVote = ref<Vote | null>(null);
-const results = ref<Results | null>(null);
-
-const isAdmin = computed(() => {
-  const admins = (props.space.admins || []).map(admin => admin.toLowerCase());
-  return admins.includes(web3Account.value?.toLowerCase());
+const isSpaceRelatedProposal = computed(() => {
+  if (!space.value || !proposal.value) return false;
+  return (
+    props.spaceKey === proposal.value.space.id ||
+    space.value?.parent?.children
+      .map(c => c.id)
+      .includes(proposal.value.space.id)
+  );
 });
-const strategies = computed(
-  // Needed for older proposal that are missing strategies
-  () => proposal.value?.strategies ?? props.space.strategies
-);
-
-const browserHasHistory = computed(() => window.history.state.back);
-
-const { modalAccountOpen } = useModal();
-const { modalTermsOpen, termsAccepted, acceptTerms } = useTerms(props.space.id);
-
-function clickVote() {
-  !web3.value.account
-    ? (modalAccountOpen.value = true)
-    : !termsAccepted.value && props.space.terms
-    ? (modalTermsOpen.value = true)
-    : (modalOpen.value = true);
-}
 
 async function loadProposal() {
   loadingProposal.value = true;
-  proposal.value = await getProposal(id);
-  // Redirect to 404 page if proposal doesn't belong to current space
-  if (
-    !proposal.value ||
-    props.space.id.toLowerCase() !== proposal.value.space.id.toLowerCase()
-  ) {
-    router.push({ name: 'error-404' });
-  }
+  proposal.value = await getProposal(proposalId);
+  if (!proposal.value) return router.push({ name: 'error-404' });
+
+  await loadExtendedSpaces([proposal.value.space.id]);
+  space.value =
+    extendedSpaces.value.find(
+      space => space.id.toLowerCase() === proposal.value?.space.id.toLowerCase()
+    ) ?? null;
+  console.log(
+    space.value?.parent?.children.map(c => c.id),
+    proposal.value.space.id
+  );
+  if (!isSpaceRelatedProposal.value) return router.push({ name: 'error-404' });
+
   loadingProposal.value = false;
-  loadResults();
 }
 
-function reloadProposal() {
+onMounted(() => {
   loadProposal();
-}
-
-function formatProposalVotes(votes) {
-  if (!votes.length) return [];
-  return votes.map(vote => {
-    vote.balance = vote.vp;
-    vote.scores = vote.vp_by_strategy;
-    return vote;
-  });
-}
-
-async function loadResults() {
-  if (!proposal.value) return;
-
-  if (proposal.value.scores.length === 0) {
-    const votingClass = new voting[proposal.value.type](
-      proposal.value,
-      [],
-      strategies.value
-    );
-    results.value = {
-      scores: votingClass.getScores(),
-      scoresByStrategy: votingClass.getScoresByStrategy(),
-      scoresTotal: votingClass.getScoresTotal()
-    };
-  } else {
-    results.value = {
-      scores: proposal.value.scores,
-      scoresByStrategy: proposal.value.scores_by_strategy,
-      scoresTotal: proposal.value.scores_total
-    };
-  }
-  loadedResults.value = true;
-  const [userVotesRes, votesRes] = await Promise.all([
-    // Skip if user is not connected
-    web3Account.value
-      ? await getProposalVotes(id, {
-          first: 1,
-          voter: web3Account.value,
-          space: proposal.value.space.id
-        })
-      : [],
-    await getProposalVotes(id, {
-      first: 10,
-      space: proposal.value.space.id
-    })
-  ]);
-  userVote.value = formatProposalVotes(userVotesRes)?.[0] || null;
-  votes.value = formatProposalVotes(votesRes);
-  loadedVotes.value = true;
-}
-
-const { loadBy, loadingMore, loadMore } = useInfiniteLoader(10);
-
-async function loadMoreVotes() {
-  const votesObj = await getProposalVotes(id, {
-    first: loadBy,
-    skip: votes.value.length
-  });
-  votes.value = votes.value.concat(formatProposalVotes(votesObj));
-}
-
-function handleBackClick() {
-  if (!browserHasHistory.value || browserHasHistory.value.includes('create'))
-    return router.push({ name: 'spaceProposals' });
-  return router.go(-1);
-}
-
-watch(web3Account, () => {
-  const choice = route.query.choice as string;
-  if (proposal.value && choice) {
-    selectedChoices.value = parseInt(choice);
-    clickVote();
-  }
-});
-
-watchEffect(() => {
-  if (props.space?.name && proposal.value?.title)
-    setPageTitle('page.title.space.proposal', {
-      proposal: proposal.value.title,
-      space: props.space.name
-    });
-});
-
-onMounted(async () => {
-  await loadProposal();
-  const choice = route.query.choice as string;
-  if (proposal.value?.type === 'approval') selectedChoices.value = [];
-  if (web3Account.value && choice) {
-    selectedChoices.value = parseInt(choice);
-    clickVote();
-  }
 });
 </script>
 
 <template>
-  <TheLayout v-bind="$attrs">
-    <template #content-left>
-      <div class="mb-3 px-3 md:px-0">
-        <ButtonBack @click="handleBackClick" />
-      </div>
+  <div>
+    <TheLayout v-if="loadingProposal">
+      <template #content-left>
+        <LoadingPage />
+      </template>
+    </TheLayout>
 
-      <div class="px-3 md:px-0">
-        <template v-if="proposal">
-          <SpaceProposalHeader
-            :space="space"
-            :proposal="proposal"
-            :is-admin="isAdmin"
-          />
-          <SpaceProposalContent :space="space" :proposal="proposal" />
-        </template>
-        <LoadingPage v-else />
-      </div>
-      <div class="space-y-4">
-        <div v-if="proposal?.discussion" class="px-3 md:px-0">
-          <h3 v-text="$t('discussion')" />
-          <BlockLink :link="proposal.discussion" />
-        </div>
-        <SpaceProposalVote
-          v-if="proposal?.state === 'active' && loadedVotes"
-          v-model="selectedChoices"
-          :proposal="proposal"
-          :user-vote="userVote"
-          @open="modalOpen = true"
-          @clickVote="clickVote"
-        />
-        <SpaceProposalVotesList
-          v-if="proposal"
-          :loaded="loadedVotes"
-          :space="space"
-          :proposal="proposal"
-          :votes="votes"
-          :strategies="strategies"
-          :user-vote="userVote"
-          :loading-more="loadingMore"
-          @loadVotes="loadMore(loadMoreVotes)"
-        />
-        <SpaceProposalPlugins
-          v-if="proposal?.plugins && loadedResults && results"
-          :id="id"
-          :space="space"
-          :proposal="proposal"
-          :results="results"
-          :loaded-results="loadedResults"
-          :votes="votes"
-          :strategies="strategies"
-        />
-      </div>
-    </template>
-    <template #sidebar-right>
-      <div v-if="proposal" class="mt-4 space-y-4 lg:mt-0">
-        <SpaceProposalInformation
-          :space="space"
-          :proposal="proposal"
-          :strategies="strategies"
-        />
-        <SpaceProposalResults
-          :loaded="loadedResults"
-          :space="space"
-          :proposal="proposal"
-          :results="results"
-          :votes="votes"
-          :strategies="strategies"
-          :is-admin="isAdmin"
-          @reload="reloadProposal()"
-        />
-        <SpaceProposalPluginsSidebar
-          v-if="proposal.plugins && loadedResults && results"
-          :id="id"
-          :space="space"
-          :proposal="proposal"
-          :results="results"
-          :loaded-results="loadedResults"
-          :votes="votes"
-          :strategies="strategies"
-        />
-      </div>
-    </template>
-  </TheLayout>
-  <teleport v-if="proposal" to="#modal">
-    <ModalVote
-      :open="modalOpen"
+    <SpaceProposalPage
+      v-else-if="proposal && space"
       :space="space"
       :proposal="proposal"
-      :selected-choices="selectedChoices"
-      :strategies="strategies"
-      @close="modalOpen = false"
-      @reload="reloadProposal()"
-      @openPostVoteModal="isModalPostVoteOpen = true"
+      :loading="loadingProposal"
+      @reload-proposal="loadProposal"
     />
-    <ModalTerms
-      :open="modalTermsOpen"
-      :space="space"
-      :action="$t('modalTerms.actionVote')"
-      @close="modalTermsOpen = false"
-      @accept="acceptTerms(), (modalOpen = true)"
-    />
-    <ModalPostVote
-      :open="isModalPostVoteOpen"
-      :space="space"
-      :proposal="proposal"
-      :selected-choices="selectedChoices"
-      @close="isModalPostVoteOpen = false"
-    />
-  </teleport>
+  </div>
 </template>

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -146,6 +146,10 @@ onMounted(() => {
             :space="space"
             :voted="userVotedProposalIds.includes(proposal.id)"
             :hide-space-avatar="proposal.space.id === space.id"
+            :to="{
+              name: 'spaceProposal',
+              params: { id: proposal.id }
+            }"
           />
         </BaseBlock>
       </div>

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -13,8 +13,7 @@ import {
   useApolloQuery,
   useProfiles,
   useI18n,
-  useWeb3,
-  useApp
+  useWeb3
 } from '@/composables';
 
 const props = defineProps<{
@@ -24,7 +23,6 @@ const props = defineProps<{
 const { store, userVotedProposalIds, addSpaceProposals, setSpaceProposals } =
   useProposals();
 const { setPageTitle } = useI18n();
-const { domain } = useApp();
 
 const loading = ref(false);
 
@@ -40,12 +38,6 @@ const subSpaces = computed(
 );
 
 const spaceProposals = computed(() => {
-  if (domain)
-    return clone(store.space.proposals).filter(
-      proposal =>
-        proposal.space.id.toLowerCase() === props.space.id.toLowerCase()
-    );
-
   return clone(store.space.proposals).filter(proposal =>
     [props.space.id.toLowerCase(), ...subSpaces.value].includes(
       proposal.space.id.toLowerCase()

--- a/src/views/SpaceView.vue
+++ b/src/views/SpaceView.vue
@@ -9,7 +9,7 @@ const route = useRoute();
 const router = useRouter();
 const { domain } = useApp();
 const aliasedSpace = aliases[domain] || aliases[route.params.key as string];
-const { loadExtentedSpaces, extentedSpaces } = useExtendedSpaces();
+const { loadExtendedSpaces, extendedSpaces } = useExtendedSpaces();
 
 // Redirect the user to the ENS address if the space is aliased.
 if (aliasedSpace) {
@@ -22,11 +22,11 @@ if (aliasedSpace) {
 
 const spaceKey = computed(() => aliasedSpace || domain || route.params.key);
 const space = computed(() =>
-  extentedSpaces.value?.find(s => s.id === spaceKey.value.toLowerCase())
+  extendedSpaces.value?.find(s => s.id === spaceKey.value.toLowerCase())
 );
 
 onMounted(async () => {
-  await loadExtentedSpaces([spaceKey.value.toLowerCase()]);
+  await loadExtendedSpaces([spaceKey.value.toLowerCase()]);
   if (!space.value) {
     router.push('/');
   }
@@ -36,7 +36,7 @@ onMounted(async () => {
 <template>
   <SpaceWarningFlagged :space-key="spaceKey" />
 
-  <router-view v-if="space" :space="space" />
+  <router-view v-if="space" :space="space" :space-key="spaceKey" />
   <div v-else>
     <!-- Lazy loading skeleton for space page with left sidebar layout -->
     <TheLayout

--- a/src/views/TimelineView.vue
+++ b/src/views/TimelineView.vue
@@ -202,6 +202,10 @@ const { endElement } = useScrollMonitor(() => {
             :space="proposal.space"
             :profiles="profiles"
             :voted="userVotedProposalIds.includes(proposal.id)"
+            :to="{
+              name: 'spaceProposal',
+              params: { key: proposal.space.id, id: proposal.id }
+            }"
             class="border-b border-skin-border transition-colors first:border-t last:border-b-0 md:border-b md:first:border-t-0"
           />
         </div>


### PR DESCRIPTION
Fixes #3455

## Changes 

- Show proposals from sub-spaces on custom domains
- Add checks to make sure that the proposal is related to the space using `isSpaceRelatedProposal`
- Fix links to sub-spaces on custom domains
  - If sub-space also has a custom domain, then link to that
  - If sub-space doesn't have a custom domain then link to snapshot.org
- Fix bugs and `extented` -> `extended` typo

## How to test

1. Run deployment locally and add `"localhost": "SPACENAME.eth"` to domains.json inside `snapshot-spaces` sub-module.
