### PR TITLE
fix: Remove playground from custom domain

### DIFF
--- a/src/components/ButtonPlayground.vue
+++ b/src/components/ButtonPlayground.vue
@@ -2,24 +2,39 @@
 import { encodeJson } from '@/helpers/b64';
 import { useRouter } from 'vue-router';
 
+import { useApp } from '@/composables';
+
 const props = withDefaults(
   defineProps<{
     name: string;
     network?: string;
     params?: any;
     snapshot?: string;
+    big?: boolean;
   }>(),
   {
     name: '',
     network: '',
     params: {},
-    snapshot: ''
+    snapshot: '',
+    big: false
   }
 );
 
 const router = useRouter();
+const { domain } = useApp();
 
 function clickPlayground() {
+  if (domain) {
+    return window.open(
+      `https://snapshot.org/#/playground/${props.name}?query=${encodeJson({
+        params: props.params,
+        network: props.network,
+        snapshot: props.snapshot
+      })}`,
+      '_blank'
+    );
+  }
   const playgroundRoute = router.resolve({
     name: 'playground',
     query: {
@@ -36,7 +51,13 @@ function clickPlayground() {
 </script>
 
 <template>
+  <BaseButton v-if="big" class="w-full" @click="clickPlayground">
+    {{ $t('settings.testInPlayground') }}
+    <i-ho-external-link class="mb-[2px] inline-block text-xs" />
+  </BaseButton>
+
   <BaseButtonIcon
+    v-else
     v-tippy="{ content: $t('playground') }"
     @click="clickPlayground"
   >

--- a/src/components/ModalStrategy.vue
+++ b/src/components/ModalStrategy.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, toRefs, watch } from 'vue';
-import { useRouter } from 'vue-router';
 import { clone, validateSchema } from '@snapshot-labs/snapshot.js/src/utils';
-import { encodeJson } from '@/helpers/b64';
 import { useNetworksFilter, useStrategies } from '@/composables';
 
 const defaultParams = {
@@ -47,25 +45,6 @@ const { getNetworksSpacesCount } = useNetworksFilter();
 const isValid = computed(
   () => validateSchema(strategyDefinition.value, input.value.params) === true
 );
-
-const router = useRouter();
-
-const playgroundLink = computed(() => {
-  const route = router.resolve({
-    name: 'playground',
-    query: {
-      query: encodeJson({
-        params: input.value.params,
-        network: input.value.network,
-        snapshot: '',
-        addresses: extendedStrategy.value?.examples?.[0].addresses || []
-      })
-    },
-    params: { name: input.value.name }
-  });
-
-  return new URL(route.href, window.location.origin).href;
-});
 
 function handleSubmit() {
   const strategyObj = clone(input.value);
@@ -157,17 +136,17 @@ watch(open, () => {
       </div>
     </div>
     <template v-if="input.name" #footer>
-      <BaseLink :link="playgroundLink" hide-external-icon class="mb-2 block">
-        <BaseButton class="w-full">
-          {{ $t('settings.testInPlayground') }}
-          <i-ho-external-link class="mb-[2px] inline-block text-xs" />
-        </BaseButton>
-      </BaseLink>
+      <ButtonPlayground
+        big
+        :name="strategy.name"
+        :network="strategy.network"
+        :params="strategy.params"
+      />
       <BaseButton
         :disabled="
           !textAreaJsonIsValid || (strategyDefinition && !isValid) || loading
         "
-        class="w-full"
+        class="mt-2 w-full"
         primary
         @click="handleSubmit"
       >

--- a/src/router.ts
+++ b/src/router.ts
@@ -90,11 +90,6 @@ if (domain) {
     { path: '/', name: 'home', component: SpaceView, children: spaceRoutes },
     { path: '/delegate/:key?/:to?', name: 'delegate', component: DelegateView },
     {
-      path: '/playground/:name',
-      name: 'playground',
-      component: PlaygroundView
-    },
-    {
       path: `/${domain}`,
       alias: `/${domainAlias ?? domain}`,
       name: 'home-redirect',

--- a/src/views/PlaygroundView.vue
+++ b/src/views/PlaygroundView.vue
@@ -23,7 +23,7 @@ const { t, setPageTitle } = useI18n();
 const { formatCompactNumber } = useIntl();
 const {
   getExtendedStrategy,
-  extendedStrategy: strategy,
+  extendedStrategy,
   strategyDefinition,
   getStrategies,
   isLoadingStrategies,
@@ -71,25 +71,22 @@ const scoresWithZeroBalanceAddresses = computed(() => {
 const strategyExample = computed(() => {
   if (queryParams.query) {
     try {
-      const { params, network, snapshot, addresses } = decodeJson(
-        queryParams.query
-      );
+      const { params, network, snapshot } = decodeJson(queryParams.query);
       return {
-        ...strategy.value?.examples?.[0],
-        addresses,
+        ...extendedStrategy.value?.examples?.[0],
         network,
         snapshot,
         strategy: { params }
       };
     } catch (e) {
-      return strategy.value?.examples?.[0];
+      return extendedStrategy.value?.examples?.[0];
     }
   }
-  return strategy.value?.examples?.[0];
+  return extendedStrategy.value?.examples?.[0];
 });
 
 async function loadScores() {
-  if (!strategy.value) return;
+  if (!extendedStrategy.value) return;
 
   scores.value = null;
   strategyError.value = null;
@@ -97,7 +94,7 @@ async function loadScores() {
 
   try {
     const strategyParams = {
-      name: strategy.value.id,
+      name: extendedStrategy.value.id,
       params: form.value.params
     };
     scores.value = await getScores(
@@ -208,7 +205,7 @@ function handleNetworkSelect(value) {
             @search="value => (searchInput = value)"
           />
         </BaseBlock>
-        <LoadingPage v-if="!strategy" />
+        <LoadingPage v-if="!extendedStrategy" />
         <div v-else class="space-y-3">
           <BaseBlock :title="$t('settings.header')">
             <div class="space-y-2">
@@ -268,7 +265,7 @@ function handleNetworkSelect(value) {
         <BaseBlock :title="$t('actions')">
           <BaseButton
             :loading="loading"
-            :disabled="loading || !strategy"
+            :disabled="loading || !extendedStrategy"
             class="flex w-full items-center justify-center"
             primary
             @click="loadScores"

--- a/src/views/PlaygroundView.vue
+++ b/src/views/PlaygroundView.vue
@@ -71,9 +71,12 @@ const scoresWithZeroBalanceAddresses = computed(() => {
 const strategyExample = computed(() => {
   if (queryParams.query) {
     try {
-      const { params, network, snapshot } = decodeJson(queryParams.query);
+      const { params, network, snapshot, addresses } = decodeJson(
+        queryParams.query
+      );
       return {
         ...extendedStrategy.value?.examples?.[0],
+        addresses: addresses || extendedStrategy.value?.examples?.[0].addresses,
         network,
         snapshot,
         strategy: { params }


### PR DESCRIPTION
Fixes #3508

## Changes

- Remove `playground` route for custom domain and redirect to `snapshot.org` instead
- Refactor all playground router.push logic into `ButtonPlayground.vue`
- Fix bug where example `addresses` wouldn't be filled 
