### PR TITLE
feat: Added Kaikas wallet support

### DIFF
--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -5,6 +5,7 @@ import connectors from '@/helpers/connectors.json';
 import walletlink from '@snapshot-labs/lock/connectors/walletlink';
 import gnosis from '@snapshot-labs/lock/connectors/gnosis';
 import stargazer from '@snapshot-labs/lock/connectors/stargazer';
+import kaikas from '@snapshot-labs/lock/connectors/kaikas';
 
 const options: any = { connectors: [] };
 const lockConnectors = {
@@ -13,7 +14,8 @@ const lockConnectors = {
   walletlink,
   portis,
   stargazer,
-  gnosis
+  gnosis,
+  kaikas
 };
 
 Object.entries(connectors).forEach((connector: any) => {

--- a/src/helpers/connectors.json
+++ b/src/helpers/connectors.json
@@ -49,5 +49,10 @@
     "name": "Gnosis Safe",
     "icon": "ipfs://QmfJUHZLtRvadM7fvEJUWWxhS869KXXCMxPCr7TUqkwvUc",
     "hidden": true
+  },
+  "kaikas": {
+    "id": "kaikas",
+    "name": "Kaikas",
+    "icon": "ipfs://QmXD4kkxKzXKbbBu3zAzZ279Sm91JhxCDAwSypyzxwe2Hj"
   }
 }


### PR DESCRIPTION
Fixes #
Added Kaikas wallet support to the connectors list. Kaikas is a global digital wallet functioning as a [web browser extension](https://chrome.google.com/webstore/detail/kaikas/jblndlipeogpafnldhgmapagcccfchpi?hl=en).

Changes in this PR:
- Added kaikas wallet to connectors list

How to test and review this PR?

1. The "kaikas" wallet option should be shown when "connect wallet" is clicked.
2. User should be able to perform the snapshot operations with the connected wallet address from kaikas.

![image](https://user-images.githubusercontent.com/112046567/221835396-ed5ff3e7-fec0-4daa-b240-ff5cbc14ce72.png)
