### PR TITLE
fix: proposal link in space without custom domain

### DIFF
--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -166,7 +166,9 @@ watch(
             :voted="userVotedProposalIds.includes(proposal.id)"
             :hide-space-avatar="proposal.space.id === space.id"
             :to="{
-              path: `${domain ? '' : proposal.space.id}/proposal/${proposal.id}`
+              path: domain
+                ? `proposal/${proposal.id}`
+                : `/${proposal.space.id}/proposal/${proposal.id}`
             }"
           />
         </BaseBlock>

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -13,8 +13,7 @@ import {
   useApolloQuery,
   useProfiles,
   useWeb3,
-  useMeta,
-  useApp
+  useMeta
 } from '@/composables';
 
 const props = defineProps<{
@@ -43,7 +42,6 @@ const loading = ref(false);
 
 const { loadBy, loadingMore, stopLoadingMore, loadMore } = useInfiniteLoader();
 const { apolloQuery } = useApolloQuery();
-const { domain } = useApp();
 
 const spaceMembers = computed(() =>
   props.space.members.length < 1 ? ['none'] : props.space.members

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -166,9 +166,8 @@ watch(
             :voted="userVotedProposalIds.includes(proposal.id)"
             :hide-space-avatar="proposal.space.id === space.id"
             :to="{
-              path: domain
-                ? `proposal/${proposal.id}`
-                : `/${proposal.space.id}/proposal/${proposal.id}`
+              name: 'spaceProposal',
+              params: { id: proposal.id, key: proposal.space.id }
             }"
           />
         </BaseBlock>


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/snapshot/issues/3564
As it was discussed here https://github.com/snapshot-labs/snapshot/pull/3543#discussion_r1125183478 but there was no "/" in a path to proposal from space without of custom domain.

Changes in this PR:
Prop "to" in SpaceProposals => ProposalsItem

How to test and review this PR?
1. Go to space with custom domain and check proposal link
2. Go to space without custom domain and check proposal link 
