### PR TITLE
fix: reset proposal search input

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,7 @@ onMounted(async () => init());
           <TheNavbar />
         </div>
         <div id="content" class="pb-6 pt-4">
-          <router-view />
+          <router-view :key="route.path" />
         </div>
         <footer v-if="route.name === 'home'" class="mt-auto">
           <TheFooter />

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,7 @@ onMounted(async () => init());
           <TheNavbar />
         </div>
         <div id="content" class="pb-6 pt-4">
-          <router-view :key="route.path" />
+          <router-view />
         </div>
         <footer v-if="route.name === 'home'" class="mt-auto">
           <TheFooter />

--- a/src/components/BaseSearch.vue
+++ b/src/components/BaseSearch.vue
@@ -13,7 +13,6 @@ const emit = defineEmits(['update:modelValue']);
 const router = useRouter();
 
 const input = ref(props.modelValue || '');
-
 const BaseInputEL = ref<HTMLDivElement | undefined>(undefined);
 
 function updateRouteQuery() {

--- a/src/components/BaseSearch.vue
+++ b/src/components/BaseSearch.vue
@@ -12,7 +12,13 @@ const emit = defineEmits(['update:modelValue']);
 
 const router = useRouter();
 
-const input = ref(props.modelValue || '');
+const input = ref('');
+watch(
+  () => props.modelValue,
+  val => (input.value = val),
+  { immediate: true }
+);
+
 const BaseInputEL = ref<HTMLDivElement | undefined>(undefined);
 
 function updateRouteQuery() {

--- a/src/components/BaseSearch.vue
+++ b/src/components/BaseSearch.vue
@@ -12,12 +12,7 @@ const emit = defineEmits(['update:modelValue']);
 
 const router = useRouter();
 
-const input = ref('');
-watch(
-  () => props.modelValue,
-  val => (input.value = val),
-  { immediate: true }
-);
+const input = ref(props.modelValue || '');
 
 const BaseInputEL = ref<HTMLDivElement | undefined>(undefined);
 

--- a/src/components/SpaceCreateContent.vue
+++ b/src/components/SpaceCreateContent.vue
@@ -8,15 +8,25 @@ defineProps<{
 }>();
 
 const { formatNumber } = useIntl();
-const { form, isBodySet, getValidation } = useFormSpaceProposal();
+const { form, formDraft, getValidation } = useFormSpaceProposal();
 
 const imageDragging = ref(false);
 const textAreaEl = ref<HTMLTextAreaElement | null>(null);
-const input = computed({
+
+const inputName = computed({
+  get: () => form.value.name,
+  set: value => {
+    form.value.name = value;
+    formDraft.value.name = value;
+  }
+});
+
+const inputBody = computed({
   get: () => form.value.body,
   set: value => {
     form.value.body = value;
-    isBodySet.value = true;
+    formDraft.value.body = value;
+    formDraft.value.isBodySet = true;
   }
 });
 
@@ -68,7 +78,7 @@ const handleDrop = e => {
       />
       <BaseInput
         v-else
-        v-model="form.name"
+        v-model="inputName"
         :title="$t('create.proposalTitle')"
         :max-length="128"
         :error="getValidation('name')"
@@ -96,7 +106,7 @@ const handleDrop = e => {
           >
             <textarea
               ref="textAreaEl"
-              v-model="input"
+              v-model="inputBody"
               class="s-input mt-0 h-full min-h-[240px] w-full !rounded-xl border-none pt-0 text-base"
               :maxlength="bodyLimit"
               data-testid="input-proposal-body"

--- a/src/components/SpaceCreateContent.vue
+++ b/src/components/SpaceCreateContent.vue
@@ -8,10 +8,17 @@ defineProps<{
 }>();
 
 const { formatNumber } = useIntl();
-const { form, getValidation } = useFormSpaceProposal();
+const { form, isBodySet, getValidation } = useFormSpaceProposal();
 
 const imageDragging = ref(false);
 const textAreaEl = ref<HTMLTextAreaElement | null>(null);
+const input = computed({
+  get: () => form.value.body,
+  set: value => {
+    form.value.body = value;
+    isBodySet.value = true;
+  }
+});
 
 const injectImageToBody = image => {
   const cursorPosition = textAreaEl.value?.selectionStart;
@@ -89,7 +96,7 @@ const handleDrop = e => {
           >
             <textarea
               ref="textAreaEl"
-              v-model="form.body"
+              v-model="input"
               class="s-input mt-0 h-full min-h-[240px] w-full !rounded-xl border-none pt-0 text-base"
               :maxlength="bodyLimit"
               data-testid="input-proposal-body"

--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -12,7 +12,8 @@ const {
   form,
   sourceProposalLoaded,
   userSelectedDateStart,
-  userSelectedDateEnd
+  userSelectedDateEnd,
+  formDraft
 } = useFormSpaceProposal();
 
 const disableChoiceEdit = computed(() => form.value.type === 'basic');
@@ -20,6 +21,7 @@ const disableChoiceEdit = computed(() => form.value.type === 'basic');
 function addChoices(num) {
   for (let i = 1; i <= num; i++) {
     form.value.choices.push({ key: form.value.choices.length, text: '' });
+    formDraft.value.choices.push({ key: form.value.choices.length, text: '' });
   }
 }
 
@@ -95,6 +97,7 @@ onMounted(async () => {
                 class="group"
                 :focus-on-mount="index === 0"
                 :data-testid="`input-proposal-choice-${index}`"
+                @update:model-value="formDraft.choices[index].text = $event"
               >
                 <template #label>
                   <div

--- a/src/composables/useFormSpaceProposal.ts
+++ b/src/composables/useFormSpaceProposal.ts
@@ -39,6 +39,7 @@ const form = ref<ProposalForm>(clone(EMPTY_PROPOSAL));
 const userSelectedDateStart = ref(false);
 const userSelectedDateEnd = ref(false);
 const sourceProposalLoaded = ref(false);
+const isBodySet = ref(false);
 
 export function useFormSpaceProposal() {
   const route = useRoute();
@@ -75,6 +76,7 @@ export function useFormSpaceProposal() {
     sourceProposalLoaded.value = false;
     userSelectedDateEnd.value = false;
     userSelectedDateStart.value = false;
+    isBodySet.value = false;
   }
 
   const { getValidationMessage } = useFormValidation(schemas.proposal, form);
@@ -94,6 +96,7 @@ export function useFormSpaceProposal() {
     userSelectedDateEnd,
     sourceProposalLoaded,
     sourceProposal,
+    isBodySet,
     resetForm,
     getValidation
   };

--- a/src/composables/useFormSpaceProposal.ts
+++ b/src/composables/useFormSpaceProposal.ts
@@ -35,11 +35,20 @@ const EMPTY_PROPOSAL: ProposalForm = {
   type: 'single-choice'
 };
 
+const EMPTY_PROPOSAL_DRAFT = {
+  name: '',
+  body: '',
+  choices: [
+    { key: 0, text: '' },
+    { key: 1, text: '' }
+  ],
+  isBodySet: false
+};
+
 const form = ref<ProposalForm>(clone(EMPTY_PROPOSAL));
 const userSelectedDateStart = ref(false);
 const userSelectedDateEnd = ref(false);
 const sourceProposalLoaded = ref(false);
-const isBodySet = ref(false);
 
 export function useFormSpaceProposal() {
   const route = useRoute();
@@ -48,35 +57,17 @@ export function useFormSpaceProposal() {
     name: string;
     body: string;
     choices: { key: number; text: string }[];
-  }>(`snapshot.proposal.${route.params.key}`, {
-    name: '',
-    body: '',
-    choices: [
-      { key: 0, text: '' },
-      { key: 1, text: '' }
-    ]
-  });
+    isBodySet: boolean;
+  }>(`snapshot.proposal.${route.params.key}`, clone(EMPTY_PROPOSAL_DRAFT));
 
   const sourceProposal = computed(() => route.params.sourceProposal);
 
-  watch(
-    form,
-    () => {
-      formDraft.value = {
-        name: form.value.name,
-        body: form.value.body,
-        choices: form.value.choices
-      };
-    },
-    { deep: true }
-  );
-
   function resetForm() {
+    formDraft.value = clone(EMPTY_PROPOSAL_DRAFT);
     form.value = clone(EMPTY_PROPOSAL);
     sourceProposalLoaded.value = false;
     userSelectedDateEnd.value = false;
     userSelectedDateStart.value = false;
-    isBodySet.value = false;
   }
 
   const { getValidationMessage } = useFormValidation(schemas.proposal, form);
@@ -96,7 +87,6 @@ export function useFormSpaceProposal() {
     userSelectedDateEnd,
     sourceProposalLoaded,
     sourceProposal,
-    isBodySet,
     resetForm,
     getValidation
   };

--- a/src/composables/useInfiniteLoader.ts
+++ b/src/composables/useInfiniteLoader.ts
@@ -3,6 +3,7 @@ export function useInfiniteLoader(loadBy = 6) {
   const stopLoadingMore = ref(false);
 
   async function loadMore(loadFn) {
+    if (loadingMore.value) return;
     if (!stopLoadingMore.value) {
       loadingMore.value = true;
       await loadFn();

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -50,6 +50,7 @@ const {
   userSelectedDateEnd,
   sourceProposalLoaded,
   sourceProposal,
+  isBodySet,
   resetForm,
   getValidation
 } = useFormSpaceProposal();
@@ -297,7 +298,7 @@ onMounted(async () => {
     form.value.choices = formDraft.value.choices;
   }
 
-  if (!!props.space?.template && !sourceProposal.value && !form.value.body) {
+  if (!!props.space?.template && !sourceProposal.value && !isBodySet.value) {
     form.value.body = props.space.template;
   }
 });

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -50,7 +50,6 @@ const {
   userSelectedDateEnd,
   sourceProposalLoaded,
   sourceProposal,
-  isBodySet,
   resetForm,
   getValidation
 } = useFormSpaceProposal();
@@ -298,7 +297,11 @@ onMounted(async () => {
     form.value.choices = formDraft.value.choices;
   }
 
-  if (!!props.space?.template && !sourceProposal.value && !isBodySet.value) {
+  if (
+    !!props.space?.template &&
+    !sourceProposal.value &&
+    !formDraft.value.isBodySet
+  ) {
     form.value.body = props.space.template;
   }
 });

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -22,7 +22,7 @@ useMeta({
   }
 });
 
-const { store, userVotedProposalIds, addSpaceProposals, setSpaceProposals } =
+const { store, userVotedProposalIds, addSpaceProposals, resetSpaceProposals } =
   useProposals();
 
 const loading = ref(false);
@@ -96,7 +96,10 @@ watch(spaceProposals, () => {
   loadProfiles(spaceProposals.value.map((proposal: any) => proposal.author));
 });
 
-watch([stateFilter, titleFilter], loadProposals);
+watch([stateFilter, titleFilter], () => {
+  resetSpaceProposals();
+  loadProposals();
+});
 
 watch(
   () => props.space.id,

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -147,7 +147,7 @@ onMounted(() => loadProposals());
         class="mt-2"
         :space="space"
       />
-      <div v-else class="my-4 space-y-4">
+      <div v-else class="mb-4 space-y-4">
         <BaseBlock
           v-for="(proposal, i) in spaceProposals"
           :key="i"

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -84,11 +84,11 @@ watch(web3Account, () => emitUpdateLastSeenProposal(props.space.id));
 
 async function loadProposals() {
   loading.value = true;
-  const proposals = await getProposals();
+  const proposals = await getProposals(spaceProposals.value.length);
   emitUpdateLastSeenProposal(props.space.id);
   stopLoadingMore.value = proposals?.length < loadBy;
   loading.value = false;
-  setSpaceProposals(proposals);
+  addSpaceProposals(proposals);
 }
 
 const { profiles, loadProfiles } = useProfiles();

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -108,17 +108,11 @@ watch([stateFilter, titleFilter], () => {
   loadProposals();
 });
 
-watch(
-  () => props.space.id,
-  () => {
-    loadProposals();
-  },
-  { immediate: true }
-);
-
 watch(spaceProposals, () => {
   loadProfiles(spaceProposals.value.map((proposal: any) => proposal.author));
 });
+
+onMounted(() => loadProposals());
 </script>
 
 <template>

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -124,7 +124,7 @@ watch(
             </h2>
           </div>
         </div>
-        <SpaceProposalsMenuFilter />
+        <SpaceProposalsMenuFilter :key="space.id" />
 
         <SpaceProposalsNotice
           v-if="spaceProposals.length < 1 && !loading"

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -89,7 +89,7 @@ useInfiniteScroll(
     if (loadingMore.value) return;
     loadMore(() => loadMoreProposals(spaceProposals.value.length));
   },
-  { distance: 300 }
+  { distance: 400 }
 );
 
 watch(web3Account, () => emitUpdateLastSeenProposal(props.space.id));

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -124,7 +124,7 @@ watch(
             </h2>
           </div>
         </div>
-        <SpaceProposalsMenuFilter :key="space.id" />
+        <SpaceProposalsMenuFilter />
 
         <SpaceProposalsNotice
           v-if="spaceProposals.length < 1 && !loading"


### PR DESCRIPTION
### Issues
Fixes https://github.com/snapshot-labs/snapshot/issues/3664

### Changes 
1. Added key prop to SpaceProposalsMenuFilter

### How to test
1. Go to space page and try to search
2. Click another space from sidebar
3. Search input should be reset

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed