### PR TITLE
add pilot extension to known hosts array

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import { createHead } from '@vueuse/head';
 
 const head = createHead();
 
-const knownHosts = ['app.safe.global'];
+const knownHosts = ['app.safe.global', 'pilot.gnosisguild.org'];
 const parentUrl =
   window.location != window.parent.location
     ? document.referrer ||


### PR DESCRIPTION
### Issues
Fixes #3701 

### Changes 
1. Adds  `pilot.gnosisguild.org` to known hosts list

### How to test
Visit snapshot.org with the Pilot extension, site should load.

### To-Do
*_(List any outstanding tasks be addressed before or after this PR is merged)_*

- [ ] Item 1


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
More info about Pilot can be found here: https://pilot.gnosisguild.org/

