### PR TITLE
fix: use <a> to create links to spaces in sidebar

### DIFF
--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -3,8 +3,6 @@ import draggable from 'vuedraggable';
 
 import { lsSet, lsGet } from '@/helpers/utils';
 
-const router = useRouter();
-
 const { web3Account } = useWeb3();
 const { loadFollows, followingSpaces, loadingFollows } = useFollowSpace();
 const { spaceHasUnseenProposals } = useUnseenProposals();
@@ -118,14 +116,11 @@ watch(
             :space="element"
             :has-unseen="spaceHasUnseenProposals(element)"
           />
-          <div
-            class="cursor-pointer"
-            @click="
-              router.push({
-                name: 'spaceProposals',
-                params: { key: element }
-              })
-            "
+          <router-link
+            :to="{
+              name: 'spaceProposals',
+              params: { key: extendedSpacesObj[element].id }
+            }"
           >
             <AvatarSpace
               :key="element"
@@ -139,7 +134,7 @@ watch(
               :counter="spaces[element].proposals_active"
               class="absolute -top-[1px] right-[9px] !h-[16px] !min-w-[16px] !bg-green !leading-[16px]"
             />
-          </div>
+          </router-link>
         </div>
       </template>
     </draggable>


### PR DESCRIPTION
Prefer `<a>` instead of `<div>` with an onClick event, to not break keyboard navigation

### Issues
Current link to spaces in the sidebar are created using a `<div>` + `onClick` event. These are not considered as native links by the browser, and are skipped when navigating the page using the keyboard.

Fix some part of #3707 

### Changes 
Use `<router-link>` to create link to spaces in the sidebar, instead of `<div>` + onClick event

### How to test
Sidebar links should behave as before. They are just now focusable when using keyboard navigation

1. Open any page
2. Click on `TAB` key, and navigate through the sidebar
3. You should see that spaces link are now focusable
4. Focus any space, and click `ENTER`
5. You should navigate to the space page

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [x] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
I am not aware of why the div/onClick event choice has been made, over the `<router-link>` one. Is there any reason, or edge case explaining this choice ?
