### PR TITLE
feat: add settings saved notice

### DIFF
--- a/src/components/ModalNotice.vue
+++ b/src/components/ModalNotice.vue
@@ -8,7 +8,7 @@ defineEmits(['close']);
     <template #header>
       <h3>{{ title }}</h3>
     </template>
-    <div class="my-2 p-4 text-center">
+    <div class="my-2 flex h-full flex-col p-4 text-center">
       <slot />
     </div>
     <template #footer>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -293,9 +293,9 @@
     "confirmLeaveMessage": " Do you really want to leave? You have unsaved changes that will be lost.",
     "confirmDeleteSpace": " Do you really want to delete this space? This action cannot be undone.",
     "confirmInputDeleteSpace": "Enter {space} to continue:",
-    "noticeSettingsSavedTitle": "Settings saved",
-    "noticeSettingsSavedText": "New settings only affect future proposals, <br> not existing ones.",
-    "noticeSettingsSavedInputCheckboxLabel": "Don't show again",
+    "noticeSavedTitle": "Settings saved",
+    "noticeSavedText": "New settings only affect future proposals, not existing ones.",
+    "noticeSavedInputCheckboxLabel": "Don't show again",
     "navigation": {
       "general": "General",
       "strategies": "Strategies",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -293,6 +293,9 @@
     "confirmLeaveMessage": " Do you really want to leave? You have unsaved changes that will be lost.",
     "confirmDeleteSpace": " Do you really want to delete this space? This action cannot be undone.",
     "confirmInputDeleteSpace": "Enter {space} to continue:",
+    "noticeSettingsSavedTitle": "Settings saved",
+    "noticeSettingsSavedText": "New settings only affect future proposals, <br> not existing ones.",
+    "noticeSettingsSavedInputCheckboxLabel": "Don't show again",
     "navigation": {
       "general": "General",
       "strategies": "Strategies",

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -373,17 +373,16 @@ const isViewOnly = computed(() => {
     </ModalConfirmAction>
     <ModalNotice
       :open="modalSettingsSavedOpen"
-      :title="$t('settings.noticeSettingsSavedTitle')"
+      :title="$t('settings.noticeSavedTitle')"
       @close="modalSettingsSavedOpen = false"
     >
       <BaseMessageBlock level="info" class="mb-5">
-        <!-- eslint-disable-next-line vue/no-v-html -->
-        <p class="text-left" v-html="$t('settings.noticeSettingsSavedText')" />
+        <p class="text-left">{{ $t('settings.noticeSavedText') }}</p>
       </BaseMessageBlock>
       <InputCheckbox
         v-model="modalSettingsSavedIgnore"
         name="settings-saved-input-checkbox"
-        :label="$t('settings.noticeSettingsSavedInputCheckboxLabel')"
+        :label="$t('settings.noticeSavedInputCheckboxLabel')"
         class="ml-4 mt-auto max-w-min cursor-pointer self-start whitespace-nowrap"
         @click="modalSettingsSavedIgnore = !modalSettingsSavedIgnore"
       />

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -268,7 +268,10 @@ const isViewOnly = computed(() => {
               @delete-space="openConfirmDelete"
             />
           </template>
-          <div v-if="isSpaceAdmin || isSpaceController" class="flex gap-5 pt-2">
+          <div
+            v-if="isSpaceAdmin || isSpaceController"
+            class="flex gap-5 px-4 pt-2 md:px-0"
+          >
             <BaseButton class="mb-2 block w-full" @click="resetForm">
               {{ $t('reset') }}
             </BaseButton>
@@ -311,6 +314,7 @@ const isViewOnly = computed(() => {
       </BaseBlock>
     </template>
   </TheLayout>
+
   <teleport to="#modal">
     <ModalControllerEdit
       :open="modalControllerEditOpen"
@@ -372,13 +376,15 @@ const isViewOnly = computed(() => {
       :title="$t('settings.noticeSettingsSavedTitle')"
       @close="modalSettingsSavedOpen = false"
     >
-      <!-- eslint-disable-next-line vue/no-v-html -->
-      <p v-html="$t('settings.noticeSettingsSavedText')" />
+      <BaseMessageBlock level="info" class="mb-5">
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <p class="text-left" v-html="$t('settings.noticeSettingsSavedText')" />
+      </BaseMessageBlock>
       <InputCheckbox
         v-model="modalSettingsSavedIgnore"
         name="settings-saved-input-checkbox"
         :label="$t('settings.noticeSettingsSavedInputCheckboxLabel')"
-        class="mx-auto mt-4 max-w-min cursor-pointer whitespace-nowrap"
+        class="ml-4 mt-auto max-w-min cursor-pointer self-start whitespace-nowrap"
         @click="modalSettingsSavedIgnore = !modalSettingsSavedIgnore"
       />
     </ModalNotice>

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { shorten, clearStampCache } from '@/helpers/utils';
 import { ExtendedSpace } from '@/helpers/interfaces';
-import { useConfirmDialog } from '@vueuse/core';
+import { useConfirmDialog, useStorage } from '@vueuse/core';
 
 const props = defineProps<{
   space: ExtendedSpace;
@@ -64,6 +64,11 @@ const loaded = ref(false);
 const modalControllerEditOpen = ref(false);
 const currentPage = ref(Page.GENERAL);
 const modalDeleteSpaceConfirmation = ref('');
+const modalSettingsSavedOpen = ref(false);
+const modalSettingsSavedIgnore = useStorage(
+  'snapshot.settings.saved.ignore',
+  false
+);
 
 const isSpaceAdmin = computed(() => {
   if (!props.space) return false;
@@ -127,6 +132,7 @@ async function handleSubmit() {
   console.log('Result', result);
   if (result.id) {
     notify(['green', t('notify.saved')]);
+    if (!modalSettingsSavedIgnore.value) modalSettingsSavedOpen.value = true;
     resetTreasuryAssets();
     await clearStampCache(props.space.id);
     await reloadSpace(props.space.id);
@@ -361,5 +367,20 @@ const isViewOnly = computed(() => {
         </BaseInput>
       </div>
     </ModalConfirmAction>
+    <ModalNotice
+      :open="modalSettingsSavedOpen"
+      :title="$t('settings.noticeSettingsSavedTitle')"
+      @close="modalSettingsSavedOpen = false"
+    >
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <p v-html="$t('settings.noticeSettingsSavedText')" />
+      <InputCheckbox
+        v-model="modalSettingsSavedIgnore"
+        name=""
+        :label="$t('settings.noticeSettingsSavedInputCheckboxLabel')"
+        class="mx-auto mt-4 max-w-min cursor-pointer whitespace-nowrap"
+        @click="modalSettingsSavedIgnore = !modalSettingsSavedIgnore"
+      />
+    </ModalNotice>
   </teleport>
 </template>

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -376,7 +376,7 @@ const isViewOnly = computed(() => {
       <p v-html="$t('settings.noticeSettingsSavedText')" />
       <InputCheckbox
         v-model="modalSettingsSavedIgnore"
-        name=""
+        name="settings-saved-input-checkbox"
         :label="$t('settings.noticeSettingsSavedInputCheckboxLabel')"
         class="mx-auto mt-4 max-w-min cursor-pointer whitespace-nowrap"
         @click="modalSettingsSavedIgnore = !modalSettingsSavedIgnore"


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/3528

### Changes 
1. Added ModalNotice to SpaceSettings
2. Don't show again boolean saved to ls

### How to test
1. Go to Space setting and save some changes
2. Notice modal will be opened, if you click "Don't show again" it will not be shown again after space settings saved.

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed