### PR TITLE
fix: fix keypress on button not triggering the ipfs hash fetching

### DIFF
--- a/src/components/SpaceProposalVotesListItem.vue
+++ b/src/components/SpaceProposalVotesListItem.vue
@@ -11,7 +11,6 @@ const props = defineProps<{
 
 defineEmits(['openReceiptModal']);
 
-const authorIpfsHash = ref('');
 const relayerIpfsHash = ref('');
 
 const titles = computed(() =>
@@ -54,7 +53,7 @@ const { formatCompactNumber } = useIntl();
       </span>
       <BasePopover>
         <template #button>
-          <BaseButtonIcon @click="authorIpfsHash = vote.ipfs">
+          <BaseButtonIcon>
             <BaseIcon name="signature" />
           </BaseButtonIcon>
         </template>
@@ -67,11 +66,8 @@ const { formatCompactNumber } = useIntl();
                   class="mr-1 flex-auto text-skin-text"
                   v-text="$t('author')"
                 />
-                <BaseLink
-                  :link="getIpfsUrl(authorIpfsHash)"
-                  class="text-skin-link"
-                >
-                  #{{ authorIpfsHash.slice(0, 7) }}
+                <BaseLink :link="getIpfsUrl(vote.ipfs)" class="text-skin-link">
+                  #{{ vote.ipfs.slice(0, 7) }}
                 </BaseLink>
               </div>
               <div v-if="relayerIpfsHash" class="flex">
@@ -88,7 +84,7 @@ const { formatCompactNumber } = useIntl();
               </div>
             </BaseBlock>
             <BaseLink
-              :link="`https://signator.io/view?ipfs=${authorIpfsHash}`"
+              :link="`https://signator.io/view?ipfs=${vote.ipfs}`"
               class="mb-2 block"
               hide-external-icon
             >


### PR DESCRIPTION
### Issues
When using the keyboard `ENTER` to trigger the vote receipt popover, it's crashing because it is unable to assign the IPFS hash url

Fixes #3714

### Changes 
Remove unneeded variable assignment on click event, just use the original variable

This function was probably inherited from another feature that does not exist anymore.

### How to test

1. Go to https://snapshot-git-fix-3714-snapshot.vercel.app/#/aave.eth/proposal/0xea8b9cc41076ba43c8a66dfd40ce539b3126af049639babce6c1fa3e62585b79
2. Scroll down to the votes list
3. Press anywhere with your mouse just before the RECEIPT modal link 
4. Use the keyboard `TAB` to navigate to the icon opening the RECEIPT popover
5. Press `ENTER` to open the popover
6. popover should open without any errors, and IFPS link should be set


### To-Do
Nothing

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
There still a leftover useless variable, 

```
const relayerIpfsHash = ref('');
```

which does not seem to do anything. Left here just in case, not in the scope of this ticket.