### PR TITLE
feat: image viewer for proposal markdown

### DIFF
--- a/src/components/BaseMarkdown.vue
+++ b/src/components/BaseMarkdown.vue
@@ -1,3 +1,9 @@
+<script lang="ts">
+export default {
+  inheritAttrs: true
+};
+</script>
+
 <script setup lang="ts">
 import { Remarkable } from 'remarkable';
 import { linkify } from 'remarkable/linkify';
@@ -16,6 +22,9 @@ const remarkable = new Remarkable({
   linkTarget: '_blank'
 }).use(linkify);
 
+const imgModalOpened = ref(false);
+const imgModalData = ref({ src: '', title: '' });
+
 const markdown = computed(() => {
   let body = props.body;
 
@@ -30,7 +39,7 @@ const markdown = computed(() => {
 
 onMounted(() => {
   const body = document.querySelector('.markdown-body');
-  if (body !== null)
+  if (body !== null) {
     body.querySelectorAll('pre>code').forEach(function (code) {
       const parent = code.parentElement;
       if (parent !== null) parent.classList.add('rounded-lg');
@@ -46,12 +55,45 @@ onMounted(() => {
       });
       code.appendChild(copyButton);
     });
+    body.querySelectorAll('img').forEach(function (img) {
+      img.addEventListener('click', function () {
+        imgModalOpened.value = true;
+        imgModalData.value = {
+          src: img.src,
+          title: img.alt
+        };
+      });
+    });
+  }
 });
 </script>
 
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <div class="markdown-body break-words" v-html="markdown" />
+  <div class="markdown-body break-words" v-bind="$attrs" v-html="markdown" />
+  <teleport to="#modal">
+    <BaseModal
+      :open="imgModalOpened"
+      max-width="1000px"
+      @close="imgModalOpened = false"
+    >
+      <template #header>
+        <div class="flex flex-row items-center justify-center">
+          <h3>{{ imgModalData.title }}</h3>
+        </div>
+      </template>
+      <div class="px-4 pb-4 pt-2">
+        <img
+          class="w-full"
+          :src="imgModalData.src"
+          :alt="imgModalData.title"
+          :style="{
+            minWidth: '100%'
+          }"
+        />
+      </div>
+    </BaseModal>
+  </teleport>
 </template>
 
 <style lang="scss">
@@ -322,6 +364,7 @@ onMounted(() => {
   max-width: 100%;
   box-sizing: content-box;
   background-color: #fff;
+  cursor: pointer;
 }
 
 .markdown-body img[align='right'] {

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -6,10 +6,12 @@ const props = withDefaults(
     open: boolean;
     hideClose?: boolean;
     maxHeight?: string;
+    maxWidth?: string;
   }>(),
   {
     hideClose: false,
-    maxHeight: '420px'
+    maxHeight: '420px',
+    maxWidth: '440px'
   }
 );
 
@@ -90,7 +92,7 @@ onBeforeUnmount(() => {
     background-color: var(--bg-color);
     padding-left: 0 !important;
     padding-right: 0 !important;
-    max-width: 440px;
+    max-width: v-bind(maxWidth);
     overflow-y: auto !important;
     max-height: calc(100vh - 120px);
     display: flex;


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/3279

### Changes 
1. Added img modal to BaseMarkdown
2. Added prop maxWidth to BaseModal

### How to test
1. Go to [proposal with images](https://snapshot.org/#/ens.eth/proposal/0x5c96e490f3e28d8269e8fc7e929491fb8fa5e4bd04d3379f0c4f4bb1a42dc23e)
2. Click images and open/close modals

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed