### PR TITLE
feat: make demo banner removable

### DIFF
--- a/src/components/TheNavbar.vue
+++ b/src/components/TheNavbar.vue
@@ -2,15 +2,22 @@
 const { pendingCount } = useTxStatus();
 const { env, showSidebar, domain } = useApp();
 const { web3Account } = useWeb3();
+const showDemoBanner = ref(true);
 </script>
 
 <template>
   <div
-    v-if="env === 'demo'"
-    class="bg-primary p-3 text-center"
+    v-if="env === 'demo' && showDemoBanner"
+    class="relative bg-primary p-3 text-center"
     style="color: white; font-size: 20px"
   >
     {{ $t('demoSite') }}
+    <BaseButtonIcon
+      class="absolute right-3 top-[10px]"
+      @click="showDemoBanner = false"
+    >
+      <i-ho-x />
+    </BaseButtonIcon>
   </div>
   <div>
     <BaseContainer class="pl-0 pr-3 sm:!px-4">


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/3254

### Changes 
1. Made demo banner removable in TheNavbar.vue

### How to test
1. Go to demo site and close the banner with "x"
2. Refresh the page the banner will appear again

### To-Do
- [ ] Add demo tag to the snapshot logo (visible only on desktop)?

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed