### PR TITLE
fix: fix downloaded CSV votes file not containing all votes

### DIFF
--- a/src/components/BaseProgressRadial.vue
+++ b/src/components/BaseProgressRadial.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+defineProps<{ value: number }>();
+</script>
+
+<template>
+  <div
+    :style="{
+      backgroundImage: `conic-gradient(var(--text-color) ${value}%, transparent 0)`
+    }"
+    class="circle"
+  ></div>
+</template>
+
+<style scoped>
+.circle {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--text-color);
+}
+</style>

--- a/src/components/SpaceProposalVotesList.vue
+++ b/src/components/SpaceProposalVotesList.vue
@@ -39,7 +39,7 @@ onMounted(async () => {
     <template v-if="props.proposal.state === 'closed'" #button>
       <BaseButtonIcon
         v-if="!isDownloadingVotes"
-        v-tippy="{ content: 'Download as CSV' }"
+        v-tippy="{ content: $t('proposal.downloadCsvVotes') }"
         @click="downloadVotes(proposal.id, proposal.space.id)"
       >
         <i-ho-download />
@@ -49,7 +49,7 @@ onMounted(async () => {
         :loading="downloadProgress < 1"
         :is-disabled="true"
       >
-        Preparing your file ...
+        {{ $t('proposal.preparingCsvVotes') }}…
         <BaseProgressRadial class="ml-2" :value="downloadProgress" />
       </BaseButtonIcon>
     </template>

--- a/src/components/SpaceProposalVotesList.vue
+++ b/src/components/SpaceProposalVotesList.vue
@@ -44,14 +44,15 @@ onMounted(async () => {
       >
         <i-ho-download />
       </BaseButtonIcon>
-      <BaseButtonIcon
+      <div
         v-else
         :loading="downloadProgress < 1"
         :is-disabled="true"
+        class="flex"
       >
         {{ $t('proposal.preparingCsvVotes') }}…
-        <BaseProgressRadial class="ml-2" :value="downloadProgress" />
-      </BaseButtonIcon>
+        <BaseProgressRadial class="my-1 ml-2" :value="downloadProgress" />
+      </div>
     </template>
     <SpaceProposalVotesListItem
       v-for="(vote, i) in sortedVotes"

--- a/src/components/SpaceProposalVotesList.vue
+++ b/src/components/SpaceProposalVotesList.vue
@@ -44,14 +44,12 @@ onMounted(async () => {
       >
         <i-ho-download />
       </BaseButtonIcon>
-      <div
-        v-else
-        :loading="downloadProgress < 1"
-        :is-disabled="true"
-        class="flex"
-      >
-        {{ $t('proposal.preparingCsvVotes') }}…
-        <BaseProgressRadial class="my-1 ml-2" :value="downloadProgress" />
+      <div v-else class="flex">
+        <LoadingSpinner v-if="downloadProgress < 1" :small="true" />
+        <template v-else>
+          {{ $t('proposal.preparingCsvVotes') }}…
+          <BaseProgressRadial class="my-1 ml-2" :value="downloadProgress" />
+        </template>
       </div>
     </template>
     <SpaceProposalVotesListItem

--- a/src/components/SpaceProposalVotesList.vue
+++ b/src/components/SpaceProposalVotesList.vue
@@ -20,7 +20,8 @@ const modalVotesmOpen = ref(false);
 
 const voteCount = computed(() => props.proposal.votes);
 
-const { downloadVotes, isDownloadingVotes } = useReportDownload();
+const { downloadVotes, isDownloadingVotes, downloadProgress } =
+  useReportDownload();
 
 onMounted(async () => {
   await loadVotes();
@@ -37,15 +38,19 @@ onMounted(async () => {
   >
     <template v-if="props.proposal.state === 'closed'" #button>
       <BaseButtonIcon
+        v-if="!isDownloadingVotes"
         v-tippy="{ content: 'Download as CSV' }"
-        :loading="isDownloadingVotes"
-        @click="
-          isDownloadingVotes
-            ? null
-            : downloadVotes(proposal.id, proposal.space.id)
-        "
+        @click="downloadVotes(proposal.id, proposal.space.id)"
       >
         <i-ho-download />
+      </BaseButtonIcon>
+      <BaseButtonIcon
+        v-else
+        :loading="downloadProgress < 1"
+        :is-disabled="true"
+      >
+        Preparing your file ...
+        <BaseProgressRadial class="ml-2" :value="downloadProgress" />
       </BaseButtonIcon>
     </template>
     <SpaceProposalVotesListItem

--- a/src/components/TheNavbar.vue
+++ b/src/components/TheNavbar.vue
@@ -2,15 +2,22 @@
 const { pendingCount } = useTxStatus();
 const { env, showSidebar, domain } = useApp();
 const { web3Account } = useWeb3();
+const showDemoBanner = ref(true);
 </script>
 
 <template>
   <div
-    v-if="env === 'demo'"
-    class="bg-primary p-3 text-center"
+    v-if="env === 'demo' && showDemoBanner"
+    class="relative bg-primary p-3 text-center"
     style="color: white; font-size: 20px"
   >
     {{ $t('demoSite') }}
+    <BaseButtonIcon
+      class="absolute right-3 top-[10px]"
+      @click="showDemoBanner = false"
+    >
+      <i-ho-x />
+    </BaseButtonIcon>
   </div>
   <div>
     <BaseContainer class="pl-0 pr-3 sm:!px-4">

--- a/src/composables/useReportDownload.ts
+++ b/src/composables/useReportDownload.ts
@@ -24,7 +24,7 @@ export function useReportDownload() {
     let resultsSize = 0;
     const maxPage = 5;
     do {
-      const newVotes = await getProposalVotes(proposalId, {
+      let newVotes = await getProposalVotes(proposalId, {
         first: pageSize,
         skip: page * pageSize,
         space: space,
@@ -32,8 +32,15 @@ export function useReportDownload() {
         orderBy: 'created',
         orderDirection: 'asc'
       });
-      votes = [...votes, ...newVotes];
       resultsSize = newVotes.length;
+
+      if (page === 0 && createdPivot > 0) {
+        const existingIpfs = votes.slice(-pageSize).map(vote => vote.ipfs);
+
+        newVotes = newVotes.filter(vote => {
+          return !existingIpfs.includes(vote.ipfs);
+        });
+      }
 
       if (page === maxPage) {
         page = 0;
@@ -41,6 +48,8 @@ export function useReportDownload() {
       } else {
         page++;
       }
+
+      votes = [...votes, ...newVotes];
     } while (resultsSize === pageSize);
     return votes;
   }

--- a/src/composables/useReportDownload.ts
+++ b/src/composables/useReportDownload.ts
@@ -1,14 +1,15 @@
 import jsonexport from 'jsonexport/dist';
 import pkg from '@/../package.json';
-import { getProposalVotes } from '@/helpers/snapshot';
+import { getProposalVotes, getProposal } from '@/helpers/snapshot';
 import { Vote } from '@/helpers/interfaces';
 
 export function useReportDownload() {
   async function getCsvFile(
     data: any[] | Record<string, any>,
+    headers: string[],
     fileName: string
   ) {
-    const csv = await jsonexport(data);
+    const csv = await jsonexport(data, { headers });
     const link = document.createElement('a');
     link.setAttribute('href', `data:text/csv;charset=utf-8,${csv}`);
     link.setAttribute('download', `${fileName}.csv`);
@@ -71,7 +72,19 @@ export function useReportDownload() {
       };
     });
     try {
-      getCsvFile(data, `${pkg.name}-report-${proposalId}`);
+      const proposal = await getProposal(proposalId);
+      getCsvFile(
+        data,
+        [
+          'address',
+          ...proposal.choices.map((choice, index) => `choice.${index + 1}`),
+          'voting_power',
+          'timestamp',
+          'date_utc',
+          'author_ipfs_hash'
+        ],
+        `${pkg.name}-report-${proposalId}`
+      );
     } catch (e) {
       console.error(e);
       isDownloadingVotes.value = false;

--- a/src/composables/useReportDownload.ts
+++ b/src/composables/useReportDownload.ts
@@ -21,8 +21,9 @@ export function useReportDownload() {
     let page = 0;
     let createdPivot = 0;
     const pageSize = 1000;
+    let resultsSize = 0;
     const maxPage = 5;
-    while (votes.length === pageSize * page) {
+    do {
       const newVotes = await getProposalVotes(proposalId, {
         first: pageSize,
         skip: page * pageSize,
@@ -32,14 +33,15 @@ export function useReportDownload() {
         orderDirection: 'asc'
       });
       votes = [...votes, ...newVotes];
+      resultsSize = newVotes.length;
 
       if (page === maxPage) {
         page = 0;
-        createdPivot = newVotes[-1].created;
+        createdPivot = newVotes[newVotes.length - 1].created;
       } else {
         page++;
       }
-    }
+    } while (resultsSize === pageSize);
     return votes;
   }
 

--- a/src/composables/useReportDownload.ts
+++ b/src/composables/useReportDownload.ts
@@ -19,15 +19,26 @@ export function useReportDownload() {
   async function getAllVotes(proposalId: string, space: string) {
     let votes: Vote[] = [];
     let page = 0;
+    let createdPivot = 0;
     const pageSize = 1000;
+    const maxPage = 5;
     while (votes.length === pageSize * page) {
       const newVotes = await getProposalVotes(proposalId, {
         first: pageSize,
         skip: page * pageSize,
-        space: space
+        space: space,
+        created_gte: createdPivot,
+        orderBy: 'created',
+        orderDirection: 'asc'
       });
       votes = [...votes, ...newVotes];
-      page++;
+
+      if (page === maxPage) {
+        page = 0;
+        createdPivot = newVotes[-1].created;
+      } else {
+        page++;
+      }
     }
     return votes;
   }

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -9,11 +9,18 @@ export const VOTES_QUERY = gql`
     $orderDirection: OrderDirection
     $voter: String
     $space: String
+    $created_gte: Int
   ) {
     votes(
       first: $first
       skip: $skip
-      where: { proposal: $id, vp_gt: 0, voter: $voter, space: $space }
+      where: {
+        proposal: $id
+        vp_gt: 0
+        voter: $voter
+        space: $space
+        created_gte: $created_gte
+      }
       orderBy: $orderBy
       orderDirection: $orderDirection
     ) {

--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -6,13 +6,14 @@ import cloneDeep from 'lodash/cloneDeep';
 
 export async function getProposalVotes(
   proposalId: string,
-  { first, voter, skip, space, orderBy, orderDirection }: any = {
+  { first, voter, skip, space, orderBy, orderDirection, created_gte }: any = {
     first: 1000,
     voter: '',
     skip: 0,
     space: '',
     orderBy: 'vp',
-    orderDirection: 'desc'
+    orderDirection: 'desc',
+    created_gte: 0
   }
 ): Promise<Vote[] | []> {
   try {
@@ -26,7 +27,8 @@ export async function getProposalVotes(
         first,
         voter,
         skip,
-        space
+        space,
+        created_gte
       }
     });
     console.timeEnd('getProposalVotes');

--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -6,11 +6,13 @@ import cloneDeep from 'lodash/cloneDeep';
 
 export async function getProposalVotes(
   proposalId: string,
-  { first, voter, skip, space }: any = {
+  { first, voter, skip, space, orderBy, orderDirection }: any = {
     first: 1000,
     voter: '',
     skip: 0,
-    space: ''
+    space: '',
+    orderBy: 'vp',
+    orderDirection: 'desc'
   }
 ): Promise<Vote[] | []> {
   try {
@@ -19,8 +21,8 @@ export async function getProposalVotes(
       query: VOTES_QUERY,
       variables: {
         id: proposalId,
-        orderBy: 'vp',
-        orderDirection: 'desc',
+        orderBy,
+        orderDirection,
         first,
         voter,
         skip,

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -250,7 +250,9 @@
       "tips": {
         "1": "Votes can be changed while the proposal is active"
       }
-    }
+    },
+    "downloadCsvVotes": "Download as CSV",
+    "preparingCsvVotes": "Preparing the CSV file"
   },
   "proposals": {
     "header": "Proposals",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -254,7 +254,9 @@
       "tips": {
         "1": "Les votes peuvent être modifiés tant que la proposition est active"
       }
-    }
+    },
+    "downloadCsvVotes": "Télécharger en tant que CSV",
+    "preparingCsvVotes": "Préparation du fichier CSV"
   },
   "proposals": {
     "header": "Propositions",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -256,7 +256,7 @@
       }
     },
     "downloadCsvVotes": "Télécharger en tant que CSV",
-    "preparingCsvVotes": "Préparation du fichier CSV"
+    "preparingCsvVotes": "Préparation du fichier"
   },
   "proposals": {
     "header": "Propositions",


### PR DESCRIPTION
### Issues
When downloading the CSV files for a proposal votes, the file is capped at 6000 rows due to implementation of the new limit on the API side.

Fixes #1626

### Changes 
Implement the changes, as described in https://discord.com/channels/707079246388133940/1061540232769577061/1061540232769577061

1. the proposal query is now using the created_gte condition to get over the 6000 rows limit
2. the data in the CSV file is now ordered by created, instead of voting power
3. A progress icon is shown while the CSV file is being built

### How to test

1. Go to a proposal with more than 6k votes (such as https://snapshot-git-fix-1626-snapshot.vercel.app/#/aave.eth/proposal/0xf6da417983653f7e7f5560a8e16ad77d5e25533bba9157abfd222347b40d09d0?app=senate)
4. Download all the votes as CSV file
5. A progress icon should be shown in lieu of the button, to track the progress
6. The file should contains as many rows as the votes count
7. The columns for the choices are adjacent, and order asc

### To-Do

- [x] Handle duplicate votes
- [x] missing comma before address, and missing line break
- [x] vote choice column is not ordered

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations

Data are now sorted by created. We could also revert back to `voting power` if desired, but it may be computation heavy, as the sorting is done on the browser side.
