### PR TITLE
fix: add missing time reference to closed proposal

### DIFF
--- a/src/components/ProposalsItem.vue
+++ b/src/components/ProposalsItem.vue
@@ -65,10 +65,7 @@ const body = computed(() => removeMd(props.proposal.body));
           :proposal="proposal"
         />
 
-        <ProposalsItemActive
-          v-if="proposal.scores_state !== 'final'"
-          :proposal="proposal"
-        />
+        <ProposalsItemFooter :proposal="proposal" />
       </div>
     </router-link>
   </div>

--- a/src/components/ProposalsItemFooter.vue
+++ b/src/components/ProposalsItemFooter.vue
@@ -12,11 +12,24 @@ defineProps<{
 
 <template>
   <div class="mt-3">
-    {{
-      capitalize(
-        getRelativeProposalPeriod(proposal.state, proposal.start, proposal.end)
-      )
-    }}
+    <span
+      v-tippy="{
+        content: new Date(
+          (proposal.state === 'pending' ? proposal.start : proposal.end) * 1000
+        ).toUTCString()
+      }"
+      class="cursor-help text-sm"
+    >
+      {{
+        capitalize(
+          getRelativeProposalPeriod(
+            proposal.state,
+            proposal.start,
+            proposal.end
+          )
+        )
+      }}
+    </span>
     <template v-if="proposal.quorum && proposal.scores_total">
       -
       {{

--- a/src/components/ProposalsItemFooter.vue
+++ b/src/components/ProposalsItemFooter.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import capitalize from 'lodash/capitalize';
 import { Proposal } from '@/helpers/interfaces';
 
 const { getRelativeProposalPeriod, formatPercentNumber, formatCompactNumber } =
@@ -12,9 +13,11 @@ defineProps<{
 <template>
   <div class="mt-3">
     {{
-      getRelativeProposalPeriod(proposal.state, proposal.start, proposal.end)
+      capitalize(
+        getRelativeProposalPeriod(proposal.state, proposal.start, proposal.end)
+      )
     }}
-    <span v-if="proposal.quorum && proposal.scores_total">
+    <template v-if="proposal.quorum && proposal.scores_total">
       -
       {{
         formatPercentNumber(
@@ -22,6 +25,6 @@ defineProps<{
         )
       }}
       {{ $t('quorumReached') }}
-    </span>
+    </template>
   </div>
 </template>

--- a/src/composables/useIntl.ts
+++ b/src/composables/useIntl.ts
@@ -142,14 +142,19 @@ export function useIntl() {
     formatNumber(number, percentNumberFormatter.value);
 
   const getRelativeProposalPeriod = (state: any, start: any, end: any): any => {
-    const now: any = new Date().getTime() / 1e3;
     if (state === 'closed') {
-      return t('endedAgo', [formatRelativeTime(end)]);
+      return t('endedAgo', [
+        formatRelativeTime(end, longRelativeTimeFormatter.value)
+      ]);
     }
     if (state === 'active') {
-      return t('proposalTimeLeft', [formatDuration(end - now)]);
+      return t('endIn', [
+        formatRelativeTime(end, longRelativeTimeFormatter.value)
+      ]);
     }
-    return t('startIn', [formatRelativeTime(start)]);
+    return t('startIn', [
+      formatRelativeTime(start, longRelativeTimeFormatter.value)
+    ]);
   };
 
   return {

--- a/src/locales/ar-SA.json
+++ b/src/locales/ar-SA.json
@@ -114,7 +114,7 @@
   "addFavorites": "إضافة للمفضلة",
   "createdBy": "بواسطة: {0}",
   "startIn": "البدء {0}",
-  "endIn": "إنهاء {1}",
+  "endIn": "إنهاء {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "بواسطة: {0}",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -114,7 +114,7 @@
   "addFavorites": "Favoriten hinzufügen",
   "createdBy": "Von {0}",
   "startIn": "start {0}",
-  "endIn": "ende {1}",
+  "endIn": "ende {0}",
   "proposalTimeLeft": "{0} verbleibend",
   "endedAgo": "endete {0}",
   "proposalBy": "von {0}",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -113,7 +113,7 @@
   "addFavorites": "Add favorites",
   "createdBy": "By {0}",
   "startIn": "start {0}",
-  "endIn": "end {1}",
+  "endIn": "end {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "by {0}",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -113,7 +113,7 @@
   "addFavorites": "Add favorites",
   "createdBy": "By {0}",
   "startIn": "start {0}",
-  "endIn": "end {0}",
+  "endIn": "ends {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "by {0}",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -114,7 +114,7 @@
   "addFavorites": "Añadir favoritos",
   "createdBy": "Por {0}",
   "startIn": "iniciar {0}",
-  "endIn": "finalizar {1}",
+  "endIn": "finalizar {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "por {0}",

--- a/src/locales/fil-PH.json
+++ b/src/locales/fil-PH.json
@@ -114,7 +114,7 @@
   "addFavorites": "Magdagdag ng mga paborito",
   "createdBy": "By {0}",
   "startIn": "simula {0}",
-  "endIn": "pagtatapos {1}",
+  "endIn": "pagtatapos {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "by {0}",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -114,7 +114,7 @@
   "addFavorites": "Ajouter aux favoris",
   "createdBy": "Par {0}",
   "startIn": "début {0}",
-  "endIn": "fin {1}",
+  "endIn": "fin {0}",
   "proposalTimeLeft": "{0} restant(s)",
   "endedAgo": "terminé {0}",
   "proposalBy": "par {0}",

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -98,7 +98,7 @@
   "addFavorites": "पसंदीदा में जोड़ें",
   "createdBy": "तक {0}",
   "startIn": "शुरू {0}",
-  "endIn": "ख़त्म {1}",
+  "endIn": "ख़त्म {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "द्वारा{0}",

--- a/src/locales/id-ID.json
+++ b/src/locales/id-ID.json
@@ -114,7 +114,7 @@
   "addFavorites": "Tambahkan favorit",
   "createdBy": "Oleh {0}",
   "startIn": "mulai {0}",
-  "endIn": "akhir {1}",
+  "endIn": "akhir {0}",
   "proposalTimeLeft": "{0} tersisa",
   "endedAgo": "berakhir {0}",
   "proposalBy": "oleh {0}",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -114,7 +114,7 @@
   "addFavorites": "Aggiungi preferiti",
   "createdBy": "Da {0}",
   "startIn": "inizio {0}",
-  "endIn": "fine {1}",
+  "endIn": "fine {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "di {0}",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -114,7 +114,7 @@
   "addFavorites": "お気に入りに追加",
   "createdBy": "{0} が作成",
   "startIn": "{0} 後に開始",
-  "endIn": "{1} 後に終了",
+  "endIn": "{0} 後に終了",
   "proposalTimeLeft": "残り{0}",
   "endedAgo": "{0} に終了しました",
   "proposalBy": "{0} が作成",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -114,7 +114,7 @@
   "addFavorites": "즐겨찾기 추가",
   "createdBy": "{0} 에 의해",
   "startIn": "시작 {0}",
-  "endIn": "종료 {1}",
+  "endIn": "종료 {0}",
   "proposalTimeLeft": "{0} 남음",
   "endedAgo": "{0} 에 종료됨",
   "proposalBy": "{0} 에 의해",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -114,7 +114,7 @@
   "addFavorites": "Adicionar favoritos",
   "createdBy": "Por {0}",
   "startIn": "iniciar: {0}",
-  "endIn": "terminar {1}",
+  "endIn": "terminar {0}",
   "proposalTimeLeft": "{0} esquerda",
   "endedAgo": "finalizado {0}",
   "proposalBy": "por {0}",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -114,7 +114,7 @@
   "addFavorites": "Adaugă la favorite",
   "createdBy": "De către {0}",
   "startIn": "pornește {0}",
-  "endIn": "sfârșit {1}",
+  "endIn": "sfârșit {0}",
   "proposalTimeLeft": "{0} rămas",
   "endedAgo": "încheiat {0}",
   "proposalBy": "de către {0}",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -114,7 +114,7 @@
   "addFavorites": "Добавить в избранное",
   "createdBy": "От: {0}",
   "startIn": "начать {0}",
-  "endIn": "по {1}",
+  "endIn": "по {0}",
   "proposalTimeLeft": "{0} осталось",
   "endedAgo": "завершился {0}",
   "proposalBy": "от: {0}",

--- a/src/locales/tr-TR.json
+++ b/src/locales/tr-TR.json
@@ -114,7 +114,7 @@
   "addFavorites": "Favorileri ekleyin",
   "createdBy": "{0} Tarafından",
   "startIn": "başlangıç {0}",
-  "endIn": "bitiş {1}",
+  "endIn": "bitiş {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "{0} tarafından",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -98,7 +98,7 @@
   "addFavorites": "Додати улюблені",
   "createdBy": "Від {0}",
   "startIn": "початок {0}",
-  "endIn": "кінець {1}",
+  "endIn": "кінець {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "від {0}",

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -98,7 +98,7 @@
   "addFavorites": "Thêm yêu thích",
   "createdBy": "Bởi {0}",
   "startIn": "bắt đầu {0}",
-  "endIn": "kết thúc {1}",
+  "endIn": "kết thúc {0}",
   "proposalTimeLeft": "{0} left",
   "endedAgo": "ended {0}",
   "proposalBy": "bởi {0}",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -114,7 +114,7 @@
   "addFavorites": "添加收藏",
   "createdBy": "由 {0}",
   "startIn": "从 {0} 开始",
-  "endIn": "结束 {1}",
+  "endIn": "结束 {0}",
   "proposalTimeLeft": "还剩 {0}",
   "endedAgo": "结束 {0}",
   "proposalBy": "由 {0}",


### PR DESCRIPTION
### Issues
Add relative date for closed proposal in proposals list.

Relative date was already present for open and pending proposals, only missing for closed proposals.

Fixes #3426

### Changes 

1. Add relative date to end time, for closed proposals
2. Enhance UI of all proposals relative time
3. Add tooltip showing precise UTC time

### How to test

1. Go to any proposals list (timeline or space)
2. Relative time should appear on the bottom, with a more consise time reference (end in, start in, ended x)
3. Hovering over the time should show a tooltip with the UTC time

### To-Do

Nothing

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

