### PR TITLE
fix: fix page jump to the top on popover open

### DIFF
--- a/src/components/BasePopover.vue
+++ b/src/components/BasePopover.vue
@@ -41,7 +41,6 @@ withDefaults(
 
       <PopoverPanel
         v-slot="{ close }"
-        :focus="true"
         class="w-screen max-w-xs outline-none sm:max-w-sm"
       >
         <div


### PR DESCRIPTION
### Issues
Temporary hotfix for page jump, on popover open, due to `focus: true`. Seems like a library issue, waiting for a fix on their side before reintroducing this.

Fixes #3743


### Changes 

1. Remove `focus` on popover, will lose some UX, but fix page jump

### How to test

1. Click on any popover
2. Page should not scroll


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations

focus will be reintroduced once the issue is fixed on the library side