### PR TITLE
hotfix: fix tooltip link color

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -276,6 +276,7 @@ input[type='number'] {
 .tippy-box[data-theme~='urlified'] {
   max-width: 200px;
   white-space: pre-wrap;
+  color: var(--header-bg);
 
   a {
     color: var(--header-bg);

--- a/src/style.scss
+++ b/src/style.scss
@@ -276,7 +276,10 @@ input[type='number'] {
 .tippy-box[data-theme~='urlified'] {
   max-width: 200px;
   white-space: pre-wrap;
-  color: inherit;
+
+  a {
+    color: var(--header-bg);
+  }
 }
 
 .lazy-loading {


### PR DESCRIPTION
### Issues
Fix tooltip link color

Fixes #3742

### Changes 

1. Fix color property not applied to link

### How to test

1. Go to a proposal list with vote
2. Hover the icon, the tooltip text should be same as if it was a text 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed
