### PR TITLE
chore: fix JS out of memory error when running lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lint-staged": "^13.2.1",
     "postcss": "^8.4.16",
     "prettier": "^2.8.7",
-    "prettier-plugin-tailwindcss": "^0.2.7",
+    "prettier-plugin-tailwindcss": "0.2.5",
     "rollup-plugin-visualizer": "^5.9.0",
     "sass": "~1.55.0",
     "sass-loader": "^13.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11079,10 +11079,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-tailwindcss@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.7.tgz#2314d728cce9c9699ced41a01253eb48b4218da5"
-  integrity sha512-jQopIOgjLpX+y8HeD56XZw7onupRTC0cw7eKKUimI7vhjkPF5/1ltW5LyqaPtSyc8HvEpvNZsvvsGFa2qpa59w==
+prettier-plugin-tailwindcss@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.5.tgz#fb9f07f22d0658fdedbf4d83254bf907656f7500"
+  integrity sha512-vZ/iKieyCx0WTxHbkf5E1rBlv/ybFk8WTT4hL5W2jlVxum2Zbe0jMUpuQdDrpa4z2vnPiJ5KIWCqL/kd16fKYg==
 
 prettier@^2.8.4, prettier@^2.8.7:
   version "2.8.7"


### PR DESCRIPTION
### Issues
Since a few commits ago, lint task start running out of memory. 

From the internal discord discussion, seems like removing the lint task from the workflow has been decided as a fix, but the memory issue still exist when trying to run it, preventing running lint on local env. Even bumping my node dedicated memory from 2GB to 8GB does not resolve the issue, it's some kind of memory leak, and not just a not enough memory issue.

From my tests, after testing by reverting each commit, seems like the issue is coming from `prettier-plugin-tailwindcss` package, which is introducing ESM and TS config file support in 0.2.6.

### Changes 

1. Freeze `prettier-plugin-tailwindcss` to `0.2.5`

### How to test

1. run yarn 
2. run yarn lint
3. linting should finish with success, and not out of memory error


### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed
