### PR TITLE
feat: add timestamp to profile activity

### DIFF
--- a/src/components/ProfileActivityListItem.vue
+++ b/src/components/ProfileActivityListItem.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ProfileActivity } from '@/helpers/interfaces';
 
+const { formatRelativeTime, longRelativeTimeFormatter } = useIntl();
+
 defineProps<{ activity: ProfileActivity }>();
 </script>
 
@@ -24,14 +26,26 @@ defineProps<{ activity: ProfileActivity }>();
           </div>
         </div>
         <div class="ml-4 w-[calc(100%-64px)]">
-          <div class="text-xs leading-5 text-skin-text">
-            {{
-              $t('profile.activity.votedFor', {
-                choice: activity.vote?.choice
-                  ? `"${activity.vote?.choice}"`
-                  : ''
-              })
-            }}
+          <div class="flex text-xs leading-5 text-skin-text">
+            <div class="flex-grow">
+              {{
+                $t('profile.activity.votedFor', {
+                  choice: activity.vote?.choice
+                    ? `"${activity.vote?.choice}"`
+                    : ''
+                })
+              }}
+            </div>
+            <div
+              v-tippy="{
+                content: new Date(activity.created * 1000).toUTCString()
+              }"
+              class="cursor-help"
+            >
+              {{
+                formatRelativeTime(activity.created, longRelativeTimeFormatter)
+              }}
+            </div>
           </div>
           <div class="truncate pr-2">
             {{ activity.title }}


### PR DESCRIPTION
### Issues
Add timestamp to profile activity

Fixes #3340 (partially)


### Changes 

1. Add relative time to profile activity

### How to test

1. Go to a user profile
2. A relative time should appear for each activity
3. Hovering over the time should display a tooltip with the precise UTC time


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed
