### PR TITLE
feat: restore focusable popover content on keyboard navigation

### DIFF
--- a/src/components/BasePopover.vue
+++ b/src/components/BasePopover.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue';
+import {
+  Popover,
+  PopoverButton,
+  PopoverPanel,
+  FocusTrap
+} from '@headlessui/vue';
 import { Float } from '@headlessui-float/vue';
 import type { Placement } from '@floating-ui/dom';
 
@@ -49,7 +54,9 @@ withDefaults(
           <div
             class="no-scrollbar max-h-[85vh] overflow-y-auto overscroll-contain"
           >
-            <slot name="content" :close="close" />
+            <FocusTrap>
+              <slot name="content" :close="close" />
+            </FocusTrap>
           </div>
         </div>
       </PopoverPanel>


### PR DESCRIPTION
### Issues
Resolving the issue from #3743 for good, where opening a popover make the page scroll back to the top. Hotfix was to disable the focus until the issue from the headlessui/float library was fixed

The library author has stated he won't fixed, but offer another method to implement the same result.

### Changes 

1. Add a FocusTrap element to handle the popover focus, instead of using the `focus` prop.

### How to test

1. Opening any popover
2. The popover should open without scolling the page to the top
3. The next focus element should be something inside the popover 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

