### PR TITLE
fix: Add basic form schema and add useVotingStrategies property

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@snapshot-labs/lock": "^0.1.1014",
     "@snapshot-labs/pineapple": "^0.1.0-beta.1",
     "@snapshot-labs/snapshot.js": "^0.4.75",
-    "@snapshot-labs/tune": "^0.1.9",
+    "@snapshot-labs/tune": "^0.1.10",
     "@vue/apollo-composable": "4.0.0-beta.4",
     "@vueuse/core": "^10.0.2",
     "@vueuse/head": "^1.1.23",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@snapshot-labs/lock": "^0.1.1014",
     "@snapshot-labs/pineapple": "^0.1.0-beta.1",
     "@snapshot-labs/snapshot.js": "^0.4.75",
-    "@snapshot-labs/tune": "^0.1.8",
+    "@snapshot-labs/tune": "^0.1.9",
     "@vue/apollo-composable": "4.0.0-beta.4",
     "@vueuse/core": "^10.0.2",
     "@vueuse/head": "^1.1.23",

--- a/src/components/InputSelectVoteValidation.vue
+++ b/src/components/InputSelectVoteValidation.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { VoteValidation } from '@/helpers/interfaces';
+import { VoteValidation, ExtendedSpace } from '@/helpers/interfaces';
 
 defineProps<{
   validation: VoteValidation;
   isDisabled?: boolean;
+  space?: ExtendedSpace;
 }>();
 
 const emit = defineEmits(['add']);
@@ -25,6 +26,7 @@ const isModalOpen = ref(false);
     <ModalVoteValidation
       :open="isModalOpen"
       :validation="validation"
+      :space="space"
       @close="isModalOpen = false"
       @add="emit('add', $event)"
     />

--- a/src/components/ModalValidation.vue
+++ b/src/components/ModalValidation.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { SpaceValidation } from '@/helpers/interfaces';
+import { ExtendedSpace, SpaceValidation } from '@/helpers/interfaces';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 import { validateForm } from '@/helpers/validation';
 
@@ -7,6 +7,7 @@ const props = defineProps<{
   open: boolean;
   validation: SpaceValidation;
   filterMinScore: number;
+  space?: ExtendedSpace;
 }>();
 
 const DEFAULT_PARAMS: Record<string, any> = {};
@@ -41,8 +42,8 @@ const basicDefinition = computed(() => {
     validations.value?.basic.schema?.definitions?.Validation
   );
 
-  if (input.value.params.useVotingStrategies) {
-    delete definition.properties.strategies;
+  if (!props.space) {
+    delete definition.properties.useVotingStrategies;
   }
 
   return definition;
@@ -129,6 +130,15 @@ watch(open, () => {
     };
   }
 });
+
+watch(
+  () => input.value.params.useVotingStrategies,
+  (val: boolean) => {
+    if (val && props.space) {
+      input.value.params.strategies = props.space.strategies;
+    }
+  }
+);
 </script>
 
 <template>
@@ -148,6 +158,7 @@ watch(open, () => {
         <TuneForm
           v-if="validationDefinition"
           ref="formRef"
+          :key="input.params?.useVotingStrategies || 0"
           v-model="input.params"
           :definition="validationDefinition"
           :error="validationErrors"

--- a/src/components/ModalVoteValidation.vue
+++ b/src/components/ModalVoteValidation.vue
@@ -32,7 +32,21 @@ type Validations = Record<
 const validations = ref<Validations | null>(null);
 const isValidationsLoaded = ref(false);
 
+const basicDefinition = computed(() => {
+  if (!validations.value?.basic.schema) return null;
+  const definition = clone(
+    validations.value?.basic.schema?.definitions?.Validation
+  );
+
+  if (input.value.params.useVotingStrategies) {
+    delete definition.properties.strategies;
+  }
+
+  return definition;
+});
+
 const validationDefinition = computed(() => {
+  if (input.value.name === 'basic') return basicDefinition.value;
   return (
     validations.value?.[input.value.name]?.schema?.definitions?.Validation ||
     null
@@ -55,6 +69,7 @@ function select(n: string) {
     if (n === 'basic') {
       input.value.params = {
         minScore: 1,
+        useVotingStrategies: false,
         strategies: [
           {
             name: 'ticket',
@@ -86,7 +101,7 @@ async function getValidations() {
   const fetchedValidations: Validations = await fetch(
     `${import.meta.env.VITE_SCORES_URL}/api/validations`
   ).then(res => res.json());
-  const validationsWithAny = {
+  const validationsWithAny: Validations = {
     any: {
       key: 'any'
     },

--- a/src/components/ModalVoteValidation.vue
+++ b/src/components/ModalVoteValidation.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
-import { VoteValidation } from '@/helpers/interfaces';
+import { ExtendedSpace, VoteValidation } from '@/helpers/interfaces';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 import { validateForm } from '@/helpers/validation';
 
 const DEFAULT_PARAMS: Record<string, any> = {};
 
-const props = defineProps<{ open: boolean; validation: VoteValidation }>();
+const props = defineProps<{
+  open: boolean;
+  validation: VoteValidation;
+  space?: ExtendedSpace;
+}>();
 
 const emit = defineEmits(['add', 'close']);
 
@@ -38,8 +42,8 @@ const basicDefinition = computed(() => {
     validations.value?.basic.schema?.definitions?.Validation
   );
 
-  if (input.value.params.useVotingStrategies) {
-    delete definition.properties.strategies;
+  if (!props.space) {
+    delete definition.properties.useVotingStrategies;
   }
 
   return definition;
@@ -123,6 +127,15 @@ watch(open, () => {
     };
   }
 });
+
+watch(
+  () => input.value.params.useVotingStrategies,
+  (val: boolean) => {
+    if (val && props.space) {
+      input.value.params.strategies = props.space.strategies;
+    }
+  }
+);
 </script>
 
 <template>
@@ -142,6 +155,7 @@ watch(open, () => {
         <TuneForm
           v-if="validationDefinition"
           ref="formRef"
+          :key="input.params?.useVotingStrategies || 0"
           v-model="input.params"
           :definition="validationDefinition"
           :error="validationErrors"

--- a/src/components/ModalVoteValidation.vue
+++ b/src/components/ModalVoteValidation.vue
@@ -133,7 +133,7 @@ watch(open, () => {
     </template>
 
     <div class="mx-0 my-4 min-h-[250px] md:mx-4">
-      <div v-if="input.name" class="text-skin-link">
+      <div v-if="input.name" class="mx-4 text-skin-link">
         <TuneForm
           v-if="validationDefinition"
           ref="formRef"

--- a/src/components/SettingsValidationBlock.vue
+++ b/src/components/SettingsValidationBlock.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { ExtendedSpace } from '@/helpers/interfaces';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 
 const props = defineProps<{
   context: 'setup' | 'settings';
   isViewOnly?: boolean;
+  space?: ExtendedSpace;
 }>();
 
 const { form } = useFormSpaceSettings(props.context);
@@ -45,6 +47,7 @@ function handleClickSelectValidation() {
         :open="modalValidationOpen"
         :validation="form.validation"
         :filter-min-score="form.filters.minScore"
+        :space="space"
         @close="modalValidationOpen = false"
         @add="handleSubmitAddValidation"
       />

--- a/src/components/SettingsVotingBlock.vue
+++ b/src/components/SettingsVotingBlock.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { ExtendedSpace } from '@/helpers/interfaces';
 import { calcFromSeconds, calcToSeconds } from '@/helpers/utils';
 
 const props = defineProps<{
   context: 'setup' | 'settings';
   isViewOnly?: boolean;
+  space?: ExtendedSpace;
 }>();
 
 const { form } = useFormSpaceSettings(props.context);
@@ -101,6 +103,7 @@ const votingPeriod = computed({
         <InputSelectVoteValidation
           :validation="form.voteValidation"
           :is-disabled="isViewOnly"
+          :space="space"
           @add="value => (form.voteValidation = value)"
         />
       </div>

--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -94,13 +94,22 @@ export async function voteValidation(
   const options: any = {};
   if (import.meta.env.VITE_SCORES_URL)
     options.url = import.meta.env.VITE_SCORES_URL;
+
+  const params = proposal.validation?.params || {};
+  if (
+    proposal.validation.name === 'basic' &&
+    proposal.validation?.params?.useVotingStrategies
+  ) {
+    params.strategies = proposal.strategies;
+  }
+
   const validateRes = await validate(
     proposal.validation.name,
     address,
     space.id,
     proposal.network,
     parseInt(proposal.snapshot),
-    proposal.validation.params,
+    params,
     options
   );
   if (typeof validateRes !== 'boolean') {
@@ -125,6 +134,10 @@ export async function proposalValidation(
       space.validation?.params?.minScore || space.filters.minScore;
     params.strategies =
       space.validation?.params?.strategies || space.strategies;
+
+    if (space.validation?.params?.useVotingStrategies) {
+      params.strategies = space.strategies;
+    }
   }
 
   const validateRes = await validate(

--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -94,7 +94,6 @@ export async function voteValidation(
   const options: any = {};
   if (import.meta.env.VITE_SCORES_URL)
     options.url = import.meta.env.VITE_SCORES_URL;
-
   const validateRes = await validate(
     proposal.validation.name,
     address,

--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -95,21 +95,13 @@ export async function voteValidation(
   if (import.meta.env.VITE_SCORES_URL)
     options.url = import.meta.env.VITE_SCORES_URL;
 
-  const params = proposal.validation?.params || {};
-  if (
-    proposal.validation.name === 'basic' &&
-    proposal.validation?.params?.useVotingStrategies
-  ) {
-    params.strategies = proposal.strategies;
-  }
-
   const validateRes = await validate(
     proposal.validation.name,
     address,
     space.id,
     proposal.network,
     parseInt(proposal.snapshot),
-    params,
+    proposal.validation.params,
     options
   );
   if (typeof validateRes !== 'boolean') {
@@ -134,10 +126,6 @@ export async function proposalValidation(
       space.validation?.params?.minScore || space.filters.minScore;
     params.strategies =
       space.validation?.params?.strategies || space.strategies;
-
-    if (space.validation?.params?.useVotingStrategies) {
-      params.strategies = space.strategies;
-    }
   }
 
   const validateRes = await validate(

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -217,6 +217,7 @@ const isViewOnly = computed(() => {
             <SettingsValidationBlock
               context="settings"
               :is-view-only="isViewOnly"
+              :space="space"
             />
             <SettingsProposalBlock
               context="settings"
@@ -228,6 +229,7 @@ const isViewOnly = computed(() => {
             <SettingsVotingBlock
               context="settings"
               :is-view-only="isViewOnly"
+              :space="space"
             />
           </template>
 


### PR DESCRIPTION
### Issues


Requires https://github.com/snapshot-labs/snapshot-strategies/pull/1113

Fixes https://github.com/snapshot-labs/snapshot/issues/3621

### Changes 


1. Add useVotingStrategies to the basic validation form allowing the user to switch between custom strategies and the default voting strategies of the space https://www.loom.com/share/4a53fd0c1b724dd39cff0584306b0e18
2. Add schema for form generation


### To-Do


- [x] Merge https://github.com/snapshot-labs/snapshot-strategies/pull/1113
- [x] Handle `useVotingStrategies` param on sequencer 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

