### PR TITLE
fix: Strategies changes

### DIFF
--- a/src/components/StrategiesListItem.vue
+++ b/src/components/StrategiesListItem.vue
@@ -18,7 +18,12 @@ defineEmits(['delete', 'edit']);
 <template>
   <BaseBlock slim class="group mb-3 p-4 text-skin-link">
     <div class="items-center justify-between sm:flex">
-      <h3 class="my-0 leading-5" v-text="strategy.name" />
+      <BaseLink
+        hide-external-icon
+        :link="`https://snapshot.org/#/strategy/${strategy.name}`"
+      >
+        <h3 class="my-0 leading-5 hover:underline" v-text="strategy.name" />
+      </BaseLink>
       <div class="flex">
         <div
           class="-mx-[8px] my-2 flex shrink flex-row-reverse items-center gap-3 sm:my-0 sm:flex-row"

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -356,8 +356,8 @@
     },
     "website": "Website",
     "strategies": {
-      "label": "Strategie(s)",
-      "information": "Strategies are used to determine voting power or whether a user is eligible to create a proposal"
+      "label": "Strategies",
+      "information": "Strategies are primarily used to determine on-chain voting power, which is used to calculate the weight of a vote. Strategies can be added or removed at any time, but changes will only affect future proposals."
     },
     "network": {
       "label": "Network",

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -213,11 +213,11 @@ const isViewOnly = computed(() => {
           </template>
 
           <template v-if="currentPage === Page.VOTING">
-            <SettingsStrategiesBlock
+            <SettingsVotingBlock
               context="settings"
               :is-view-only="isViewOnly"
             />
-            <SettingsVotingBlock
+            <SettingsStrategiesBlock
               context="settings"
               :is-view-only="isViewOnly"
             />

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -53,7 +53,6 @@ const {
 
 enum Page {
   GENERAL,
-  STRATEGIES,
   PROPOSAL,
   VOTING,
   MEMBERS,
@@ -80,10 +79,6 @@ const settingsPages = computed(() => [
   {
     id: Page.GENERAL,
     title: t('settings.navigation.general')
-  },
-  {
-    id: Page.STRATEGIES,
-    title: t('settings.navigation.strategies')
   },
   {
     id: Page.PROPOSAL,
@@ -206,13 +201,6 @@ const isViewOnly = computed(() => {
             <SettingsLinkBlock context="settings" :is-view-only="isViewOnly" />
           </template>
 
-          <template v-if="currentPage === Page.STRATEGIES">
-            <SettingsStrategiesBlock
-              context="settings"
-              :is-view-only="isViewOnly"
-            />
-          </template>
-
           <template v-if="currentPage === Page.PROPOSAL">
             <SettingsValidationBlock
               context="settings"
@@ -225,6 +213,10 @@ const isViewOnly = computed(() => {
           </template>
 
           <template v-if="currentPage === Page.VOTING">
+            <SettingsStrategiesBlock
+              context="settings"
+              :is-view-only="isViewOnly"
+            />
             <SettingsVotingBlock
               context="settings"
               :is-view-only="isViewOnly"


### PR DESCRIPTION
### Issues

Fixes https://github.com/snapshot-labs/snapshot/issues/3778

### Changes

1. Remove the `Strategies` page in settings and move the `Voting strategies` block into `Voting` page <img width="1158" alt="image" src="https://user-images.githubusercontent.com/51686767/232994510-b9bd4430-9cb5-4a1f-a21c-d57d06e5cbf6.png">

3. Add link to strategie item name that links to the information page
4. Fix text

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes
Including a "Strategies" page within the settings implies that strategies function as universal settings. However, these strategies are solely applicable to the voting process. Relocating them to the voting page would provide greater clarity on their purpose.

