### PR TITLE
Use v2 safe API URL for collectibles endpoint

### DIFF
--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -33,14 +33,14 @@ export const EXPLORER_API_URLS = {
 };
 
 export const GNOSIS_SAFE_TRANSACTION_API_URLS = {
-  '1': 'https://safe-transaction-mainnet.safe.global/api/v1',
-  '5': 'https://safe-transaction-goerli.safe.global/api/v1',
-  '100': 'https://safe-transaction-gnosis-chain.safe.global/api/v1',
-  '73799': 'https://safe-transaction-volta.safe.global/api/v1',
-  '246': 'https://safe-transaction-ewc.safe.global//api/v1',
-  '137': 'https://safe-transaction-polygon.safe.global//api/v1',
-  '56': 'https://safe-transaction-bsc.safe.global//api/v1',
-  '42161': 'https://safe-transaction-arbitrum.safe.global/api/v1'
+  '1': 'https://safe-transaction-mainnet.safe.global/api',
+  '5': 'https://safe-transaction-goerli.safe.global/api',
+  '100': 'https://safe-transaction-gnosis-chain.safe.global/api',
+  '73799': 'https://safe-transaction-volta.safe.global/api',
+  '246': 'https://safe-transaction-ewc.safe.global/api',
+  '137': 'https://safe-transaction-polygon.safe.global/api',
+  '56': 'https://safe-transaction-bsc.safe.global/api',
+  '42161': 'https://safe-transaction-arbitrum.safe.global/api'
 };
 
 // ABIs

--- a/src/plugins/safeSnap/utils/safe.ts
+++ b/src/plugins/safeSnap/utils/safe.ts
@@ -10,7 +10,7 @@ async function callGnosisSafeTransactionApi(network: string, url: string) {
 
 export const getGnosisSafeBalances = memoize(
   (network, safeAddress) => {
-    const endpointPath = `/safes/${safeAddress}/balances/`;
+    const endpointPath = `/v1/safes/${safeAddress}/balances/`;
     return callGnosisSafeTransactionApi(network, endpointPath);
   },
   (safeAddress, network) => `${safeAddress}_${network}`
@@ -18,7 +18,7 @@ export const getGnosisSafeBalances = memoize(
 
 export const getGnosisSafeCollectibles = memoize(
   (network, safeAddress) => {
-    const endpointPath = `/safes/${safeAddress}/collectibles/`;
+    const endpointPath = `/v2/safes/${safeAddress}/collectibles/`;
     return callGnosisSafeTransactionApi(network, endpointPath);
   },
   (safeAddress, network) => `${safeAddress}_${network}`
@@ -26,7 +26,7 @@ export const getGnosisSafeCollectibles = memoize(
 
 export const getGnosisSafeToken = memoize(
   async (network, tokenAddress): Promise<TokenAsset> => {
-    const endpointPath = `/tokens/${tokenAddress}`;
+    const endpointPath = `/v1/tokens/${tokenAddress}`;
     return callGnosisSafeTransactionApi(network, endpointPath);
   },
   (tokenAddress, network) => `${tokenAddress}_${network}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,13 +1561,15 @@
     json-to-graphql-query "^2.2.4"
     lodash.set "^4.3.2"
 
-"@snapshot-labs/tune@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/tune/-/tune-0.1.8.tgz#9f31d92540dc8c9e4f111ff303457b7054848dcb"
-  integrity sha512-0TvnhQJqLu6w+duDDMrxINNe4IkyAW6l+fxYFUmusr5ms9N06EJlgvrMnSIHfsTK6U7xM2WhJURC+VjG6bP5tQ==
+"@snapshot-labs/tune@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/tune/-/tune-0.1.10.tgz#a52d98c56570e26d1135c707d59bc0e5009aebf3"
+  integrity sha512-0ayV+A5GvI7Rgjj98D8Oza1dC6r9eNHSXC0EBK8o0KwyvxZqO/+bVsLHlcA0d2VFVAWIdzPP+yE/CHqywPAX6g==
   dependencies:
+    "@headlessui-float/vue" "^0.11.0"
     "@headlessui/vue" "^1.7.12"
     lodash "^4.17.21"
+    minisearch "^6.0.1"
     sass "^1.60.0"
     vue "^3.2.47"
     vue-tippy "^6.0.0"
@@ -10008,6 +10010,11 @@ minipass@^2.6.0, minipass@^2.9.0:
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
+
+minisearch@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-6.0.1.tgz#55e40135e7e6be60f1c1c2f5ee890c334e179a86"
+  integrity sha512-Ly1w0nHKnlhAAh6/BF/+9NgzXfoJxaJ8nhopFhQ3NcvFJrFIL+iCg9gw9e9UMBD+XIsp/RyznJ/o5UIe5Kw+kg==
 
 minizlib@^1.3.3:
   version "1.3.3"


### PR DESCRIPTION
### Issues

Fixes https://github.com/snapshot-labs/snapshot/issues/3723

### Changes 
1. Use v2 URL for collectibles and v1 for others
2. Update yarn.lock

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. Go to https://snapshot.org/#/%F0%9F%8D%AFdao.eth/create/0 and go to transaction page
4. Open the networks tab to see the failing request for collectibles

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [x] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

