### PR TITLE
Disable schedule but keep manual dispatch for package update

### DIFF
--- a/.github/workflows/update-snapshot-packages.yml
+++ b/.github/workflows/update-snapshot-packages.yml
@@ -1,9 +1,6 @@
 name: Update Snapshot packages
 
-on:
- workflow_dispatch:
- schedule:
-   - cron: 0 10 * * 1
+on: workflow_dispatch
 
 jobs:
   update-dep:


### PR DESCRIPTION

<img width="1315" alt="image" src="https://user-images.githubusercontent.com/15967809/233175082-a9448257-4ea6-45f8-8ce2-8a2c03f9d0ae.png">
This workflow is disabled right now,

If there are already 5 PRs from dependabot, it is hard to update snapshot.js
