### PR TITLE
fix: Block short URLs on proposal creation

### DIFF
--- a/src/components/SpaceCreateWarnings.vue
+++ b/src/components/SpaceCreateWarnings.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   validationFailed: boolean;
   isValidAuthor: boolean;
   validationName: string;
+  containsShortUrl: boolean;
 }>();
 
 const { web3, web3Account } = useWeb3();
@@ -104,5 +105,9 @@ const strategySymbolsString = computed(() => {
       :min-score="minScore"
       :symbol="strategySymbolsString || space.symbol"
     />
+
+    <BaseMessageBlock v-else-if="containsShortUrl" level="warning">
+      {{ $t('warningShortUrl') }}
+    </BaseMessageBlock>
   </div>
 </template>

--- a/src/composables/useShortUrls.ts
+++ b/src/composables/useShortUrls.ts
@@ -1,0 +1,21 @@
+const shortUrls = ref<string[]>([]);
+
+export function useShortUrls() {
+  async function getShortUrls(): Promise<string[]> {
+    const response = await fetch(
+      'https://raw.githubusercontent.com/PeterDaveHello/url-shorteners/master/list'
+    );
+    const data = await response.text();
+    const lines = data.split('\n');
+    const urls = lines.filter(
+      line => !line.startsWith('#') && line.trim() !== ''
+    );
+    return urls;
+  }
+
+  onMounted(async () => {
+    if (shortUrls.value.length === 0) shortUrls.value = await getShortUrls();
+  });
+
+  return { shortUrls };
+}

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -31,6 +31,7 @@
   "verifiedSpace": "Verified space",
   "warningSpace": "This space has been flagged as potentially malicious. Proceed with caution.",
   "warningFlagged": "The proposal might contain scams, offensive material, or be malicious in nature. Please proceed with caution.",
+  "warningShortUrl": "Short URLs are not allowed. Please use the full URL.",
   "version": "Version",
   "timeline": "Timeline",
   "ended": "ended",

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -42,6 +42,7 @@ const { modalTermsOpen, termsAccepted, acceptTerms } = useTerms(props.space.id);
 const { isGnosisAndNotSpaceNetwork } = useGnosis(props.space);
 const { isSnapshotLoading } = useSnapshot();
 const { apolloQuery, queryLoading } = useApolloQuery();
+const { shortUrls } = useShortUrls();
 
 const {
   form,
@@ -98,6 +99,32 @@ const isFormValid = computed(() => {
   );
 });
 
+const formContainsShortUrl = computed(() => {
+  const { body, name, discussion } = form.value;
+
+  const bodyContainsShortUrl = shortUrls.value.some(
+    shortUrl =>
+      body.includes(`http://${shortUrl}`) ||
+      body.includes(`https://${shortUrl}`)
+  );
+
+  const nameContainsShortUrl = shortUrls.value.some(
+    shortUrl =>
+      name.includes(`http://${shortUrl}`) ||
+      name.includes(`https://${shortUrl}`)
+  );
+
+  const discussionContainsShortUrl = shortUrls.value.some(
+    shortUrl =>
+      discussion.includes(`http://${shortUrl}`) ||
+      discussion.includes(`https://${shortUrl}`)
+  );
+
+  return (
+    bodyContainsShortUrl || nameContainsShortUrl || discussionContainsShortUrl
+  );
+});
+
 const stepIsValid = computed(() => {
   if (
     currentStep.value === Step.CONTENT &&
@@ -105,7 +132,8 @@ const stepIsValid = computed(() => {
     form.value.body.length <= BODY_LIMIT_CHARACTERS &&
     isValidAuthor.value &&
     !getValidation('name').message &&
-    !getValidation('discussion').message
+    !getValidation('discussion').message &&
+    !formContainsShortUrl.value
   )
     return true;
   else if (
@@ -207,6 +235,7 @@ async function loadSourceProposal() {
 }
 
 function nextStep() {
+  if (formContainsShortUrl.value) return;
   currentStep.value++;
 }
 
@@ -305,6 +334,7 @@ onMounted(async () => {
         :validation-failed="hasAuthorValidationFailed"
         :is-valid-author="isValidAuthor"
         :validation-name="validationName"
+        :contains-short-url="formContainsShortUrl"
         data-testid="create-proposal-connect-wallet-warning"
       />
 


### PR DESCRIPTION
### Fixes

Scammers are exploiting short URLs, which allows them to repeatedly utilize blacklisted URLs simply by generating new short URLs for the same malicious sites.

### Changes 


1. Get a list of short URLs from https://github.com/PeterDaveHello/url-shorteners
2. Check proposal name, body and discussion link for short URLs
3. Show warning and disable Continue button if short URL detected

### How to test


1. Create proposal enter bit.ly in any input field

### To-Do


- [ ] We should also consider flagging existing proposal with short URLs 
- [ ] We should enforce this on HUB too as scammer could potentially create a workaround on the Ui


### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

