### PR TITLE
fix: Prevent clickable links and link descriptions in markdown

### DIFF
--- a/src/components/BaseMarkdown.vue
+++ b/src/components/BaseMarkdown.vue
@@ -16,6 +16,13 @@ const remarkable = new Remarkable({
   linkTarget: '_blank'
 }).use(linkify);
 
+remarkable.renderer.rules.link_open = function () {
+  return '';
+};
+remarkable.renderer.rules.link_close = function () {
+  return '';
+};
+
 const markdown = computed(() => {
   let body = props.body;
 


### PR DESCRIPTION
Fixes issue where scammers are hiding scam links behind legit looking links like on https://snapshot.org/#/lido-snapshot.eth/proposal/0xd4e4bb2bb4bf725a3dc199d48b4442104b19768c22801dc192afb5001047c860

<img width="801" alt="image" src="https://user-images.githubusercontent.com/51686767/233257154-ba8b68a6-1fe2-4326-b7f7-29bd7dd07a80.png">
