### PR TITLE
Show error on load

### DIFF
--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -48,7 +48,7 @@ defineEmits(['update:modelValue']);
 
 const BaseInputEL = ref<HTMLDivElement | undefined>(undefined);
 
-const visited = ref(false);
+const visited = ref(true);
 
 const showErrorMessage = computed(() => visited.value || props.error?.push);
 


### PR DESCRIPTION
### Issues
Right now if there is some error in settings, it is showing errors until we change something in the field, and it is hard to guess which field is having issues

How to reproduce:
- Go to https://snapshot.org/#/vote-perp.eth/settings
- Connect with `0xC5E73744260E50a98164475E2ebcc223a9a58FB4`
- Try changing a few settings
- Save button is always disabled

### Changes 
1. Display errors on load, so they can be fixed
2. 
![Apr-20-2023 14-15-55](https://user-images.githubusercontent.com/15967809/233311739-a3b3eccd-05d5-48f4-8864-fcd0a075cf82.gif)


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
- [ ] We should also have a global warnings list to display errors from other sections (for example if there is some error in  "strategies". it is hard to guess them in the "general" section) @samuveth Any ideas?