### PR TITLE
feat: Add link preview modal

### DIFF
--- a/src/components/BaseMarkdown.vue
+++ b/src/components/BaseMarkdown.vue
@@ -9,6 +9,9 @@ const props = defineProps<{
 }>();
 const { copyToClipboard } = useCopy();
 
+const showModal = ref(false);
+const clickedUrl = ref('');
+
 const remarkable = new Remarkable({
   html: false,
   breaks: true,
@@ -28,9 +31,19 @@ const markdown = computed(() => {
   return remarkable.render(body);
 });
 
+function handleLinkClick(e, url) {
+  e.preventDefault();
+  clickedUrl.value = url;
+  showModal.value = true;
+}
+
+function handleConfirm() {
+  window.open(clickedUrl.value, '_blank', 'noopener,noreferrer');
+}
+
 onMounted(() => {
   const body = document.querySelector('.markdown-body');
-  if (body !== null)
+  if (body !== null) {
     body.querySelectorAll('pre>code').forEach(function (code) {
       const parent = code.parentElement;
       if (parent !== null) parent.classList.add('rounded-lg');
@@ -46,12 +59,36 @@ onMounted(() => {
       });
       code.appendChild(copyButton);
     });
+    body.querySelectorAll('a[href]').forEach(function (link) {
+      link.addEventListener('click', function (e) {
+        handleLinkClick(e, link.getAttribute('href'));
+      });
+    });
+  }
 });
 </script>
 
 <template>
-  <!-- eslint-disable-next-line vue/no-v-html -->
+  <!-- eslint-disable vue/no-v-html -->
   <div v-viewer class="markdown-body break-words" v-html="markdown" />
+  <Teleport to="#modal">
+    <ModalConfirmAction
+      :open="showModal"
+      title="Link preview"
+      show-cancel
+      @close="showModal = false"
+      @confirm="handleConfirm"
+    >
+      <div
+        class="p-4 text-center"
+        v-html="
+          $t('linkPreview', {
+            url: `<span class='text-skin-link font-semibold'>${clickedUrl}</span>`
+          })
+        "
+      />
+    </ModalConfirmAction>
+  </Teleport>
 </template>
 
 <style lang="scss">

--- a/src/components/ModalConfirmAction.vue
+++ b/src/components/ModalConfirmAction.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 defineProps<{
   open: boolean;
+  title?: string;
   showCancel?: boolean;
   disabled?: boolean;
 }>();
@@ -12,7 +13,7 @@ defineEmits(['close', 'confirm']);
   <BaseModal :open="open" @close="$emit('close')">
     <template #header>
       <div class="flex flex-row items-center justify-center">
-        <h3>{{ $t('confirmAction') }}</h3>
+        <h3>{{ title ? title : $t('confirmAction') }}</h3>
       </div>
     </template>
 

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -32,6 +32,7 @@
   "warningSpace": "This space has been flagged as potentially malicious. Proceed with caution.",
   "warningShortUrl": "Short URLs are not allowed. Please use the full URL.",
   "warningFlagged": "This proposal might contain scams, offensive material, or be malicious in nature. Please proceed with caution.",
+  "linkPreview": "This link will take you to {url}.</br> Are you sure you want to continue?",
   "version": "Version",
   "timeline": "Timeline",
   "ended": "ended",


### PR DESCRIPTION
### Issues

Fixes part of Chaitus comment https://github.com/snapshot-labs/snapshot/pull/3791#issuecomment-1515800097

### Changes 

Loom: https://www.loom.com/share/61b44aa2107c4cb3a9bb956843687dc6

1. Show modal with real URL when clicking URL from proposal body

### How to test

1. Proposal: `lido-snapshot.eth/proposal/0xd4e4bb2bb4bf725a3dc199d48b4442104b19768c22801dc192afb5001047c860`



### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed



