### PR TITLE
feat: strategy link

### DIFF
--- a/src/components/StrategiesListItem.vue
+++ b/src/components/StrategiesListItem.vue
@@ -5,7 +5,7 @@ import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 
 import { Proposal, SpaceStrategy } from '@/helpers/interfaces';
 
-defineProps<{
+const props = defineProps<{
   strategy: SpaceStrategy;
   proposal?: Proposal;
   showDelete?: boolean;
@@ -13,6 +13,23 @@ defineProps<{
 }>();
 
 defineEmits(['delete', 'edit']);
+
+const { domain } = useApp();
+const router = useRouter();
+
+function openStrategy() {
+  if (domain) {
+    return window.open(
+      `https://snapshot.org/#/strategy/${props.strategy.name}`,
+      '_blank'
+    );
+  }
+  const strategyRoute = router.resolve({
+    name: 'strategy',
+    params: { name: props.strategy.name }
+  });
+  window.open(strategyRoute.href, '_blank');
+}
 </script>
 
 <template>
@@ -35,6 +52,9 @@ defineEmits(['delete', 'edit']);
             :params="strategy.params"
             :snapshot="proposal?.snapshot"
           />
+          <BaseButtonIcon @click="openStrategy()">
+            <i-ho-information-circle />
+          </BaseButtonIcon>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Issues
Open strategy page from strategy item.

Fixes https://github.com/snapshot-labs/snapshot/issues/3778

### Changes 
1. Added one more button to strategy item.

### How to test
1. Go to '#/ens.eth/settings' and click on information icon
2. Test it with custom domain space

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed