### PR TITLE
feat: add wrappedDomains, filter out .addr.reverse

### DIFF
--- a/src/composables/useEns.ts
+++ b/src/composables/useEns.ts
@@ -45,31 +45,29 @@ export function useEns() {
   async function fetchDomainData(domain) {
     const hash = domain.name.match(/\[(.*?)\]/)?.[1];
 
-    if (hash) {
-      const response = await ensApolloQuery({
-        query: ENS_DOMAIN_BY_HASH_QUERY,
-        variables: {
-          id: `0x${hash}`
-        }
-      });
+    if (!hash) return domain;
 
-      if (response.registration?.domain?.labelName) {
-        return {
-          ...domain,
-          name: domain.name.replace(
-            `[${hash}]`,
-            response.registration.domain.labelName
-          )
-        };
+    const response = await ensApolloQuery({
+      query: ENS_DOMAIN_BY_HASH_QUERY,
+      variables: {
+        id: `0x${hash}`
       }
+    });
 
+    if (response.registration?.domain?.labelName) {
       return {
         ...domain,
-        isInvalid: true
+        name: domain.name.replace(
+          `[${hash}]`,
+          response.registration.domain.labelName
+        )
       };
     }
 
-    return domain;
+    return {
+      ...domain,
+      isInvalid: true
+    };
   }
 
   // Check if a domain is valid based on the TLD

--- a/src/composables/useEns.ts
+++ b/src/composables/useEns.ts
@@ -3,71 +3,85 @@ import {
   ENS_DOMAIN_BY_HASH_QUERY
 } from '@/helpers/queries';
 
+const VALID_ENS_TLDS = ['eth', 'xyz', 'com', 'org', 'io', 'app', 'art'];
+
 export function useEns() {
-  const validEnsTlds = ['eth', 'xyz', 'com', 'org', 'io', 'app', 'art'];
-
   const { ensApolloQuery } = useApolloQuery();
-
   const ownedEnsDomains = ref<Record<string, any>[]>([]);
 
+  // Fetch owned ENS domains for a given address
   const loadOwnedEnsDomains = async (address: string) => {
-    if (!address) return (ownedEnsDomains.value = []);
+    if (!address) {
+      ownedEnsDomains.value = [];
+      return;
+    }
 
-    const res = await ensApolloQuery({
+    const response = await ensApolloQuery({
       query: ENS_DOMAINS_BY_ACCOUNT_QUERY,
       variables: {
         id: address.toLowerCase()
       }
     });
 
-    const domains = res.account?.domains || [];
-    const wrappedDomains = res.account?.wrappedDomains || [];
+    const domains = response.account?.domains || [];
+    const wrappedDomains = response.account?.wrappedDomains || [];
     const allDomains = [...domains, ...wrappedDomains];
 
-    // The ens subgraph returns only the hash for domain TLDs other than .eth, so we
-    // have to make a second request to fetch the actual domain.
-    ownedEnsDomains.value =
-      (await Promise.all(
-        allDomains
-          .filter(domain => !domain.name.endsWith('.addr.reverse'))
-          .map(async domain => {
-            const hash = domain.name.match(/\[(.*?)\]/)?.[1];
-            if (hash) {
-              const res = await ensApolloQuery({
-                query: ENS_DOMAIN_BY_HASH_QUERY,
-                variables: {
-                  id: `0x${hash}`
-                }
-              });
-              if (res.registration?.domain?.labelName) {
-                return {
-                  ...domain,
-                  name: domain.name.replace(
-                    `[${hash}]`,
-                    res.registration.domain.labelName
-                  )
-                };
-              }
-              return {
-                ...domain,
-                isInvalid: true
-              };
-            }
-
-            return domain;
-          }) ?? []
-      )) || [];
+    ownedEnsDomains.value = await fetchAllDomainData(allDomains);
   };
 
-  function isValidEnsDomain(domain) {
+  // Fetch data for all domains and handle hash-based TLDs
+  async function fetchAllDomainData(domains: any[]) {
+    const filteredDomains = domains.filter(
+      domain => !domain.name.endsWith('.addr.reverse')
+    );
+
+    const domainPromises = filteredDomains.map(fetchDomainData);
+
+    return (await Promise.all(domainPromises)) || [];
+  }
+
+  // Fetch data for a single domain and update the name if it's a hash-based TLD
+  async function fetchDomainData(domain) {
+    const hash = domain.name.match(/\[(.*?)\]/)?.[1];
+
+    if (hash) {
+      const response = await ensApolloQuery({
+        query: ENS_DOMAIN_BY_HASH_QUERY,
+        variables: {
+          id: `0x${hash}`
+        }
+      });
+
+      if (response.registration?.domain?.labelName) {
+        return {
+          ...domain,
+          name: domain.name.replace(
+            `[${hash}]`,
+            response.registration.domain.labelName
+          )
+        };
+      }
+
+      return {
+        ...domain,
+        isInvalid: true
+      };
+    }
+
+    return domain;
+  }
+
+  // Check if a domain is valid based on the TLD
+  function isValidEnsDomain(domain: string): boolean {
     if (!domain.includes('.')) return false;
-    return validEnsTlds.includes(domain.split('.').pop());
+    return VALID_ENS_TLDS.includes(domain.split('.').pop() ?? '');
   }
 
   return {
     loadOwnedEnsDomains,
     ownedEnsDomains,
-    validEnsTlds,
+    validEnsTlds: VALID_ENS_TLDS,
     isValidEnsDomain
   };
 }

--- a/src/composables/useEns.ts
+++ b/src/composables/useEns.ts
@@ -20,36 +20,42 @@ export function useEns() {
       }
     });
 
+    const domains = res.account?.domains || [];
+    const wrappedDomains = res.account?.wrappedDomains || [];
+    const allDomains = [...domains, ...wrappedDomains];
+
     // The ens subgraph returns only the hash for domain TLDs other than .eth, so we
     // have to make a second request to fetch the actual domain.
     ownedEnsDomains.value =
       (await Promise.all(
-        res.account?.domains.map(async domain => {
-          const hash = domain.name.match(/\[(.*?)\]/)?.[1];
-          if (hash) {
-            const res = await ensApolloQuery({
-              query: ENS_DOMAIN_BY_HASH_QUERY,
-              variables: {
-                id: `0x${hash}`
+        allDomains
+          .filter(domain => !domain.name.endsWith('.addr.reverse'))
+          .map(async domain => {
+            const hash = domain.name.match(/\[(.*?)\]/)?.[1];
+            if (hash) {
+              const res = await ensApolloQuery({
+                query: ENS_DOMAIN_BY_HASH_QUERY,
+                variables: {
+                  id: `0x${hash}`
+                }
+              });
+              if (res.registration?.domain?.labelName) {
+                return {
+                  ...domain,
+                  name: domain.name.replace(
+                    `[${hash}]`,
+                    res.registration.domain.labelName
+                  )
+                };
               }
-            });
-            if (res.registration?.domain?.labelName) {
               return {
                 ...domain,
-                name: domain.name.replace(
-                  `[${hash}]`,
-                  res.registration.domain.labelName
-                )
+                isInvalid: true
               };
             }
-            return {
-              ...domain,
-              isInvalid: true
-            };
-          }
 
-          return domain;
-        }) ?? []
+            return domain;
+          }) ?? []
       )) || [];
   };
 

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -272,6 +272,9 @@ export const ENS_DOMAINS_BY_ACCOUNT_QUERY = gql`
       domains {
         name
       }
+      wrappedDomains {
+        name
+      }
     }
   }
 `;


### PR DESCRIPTION
### Issues
Resolve ENS domains and wrappedDomains, filter out reverse domains

Fixes https://github.com/snapshot-labs/snapshot/issues/3818

### Changes 
1. Extended ENS_DOMAINS_BY_ACCOUNT_QUERY
2. allDomains in useEns composable

### How to test
1. Need account like @aurelianoB 0xa561e70cd46B6445D98Ffa26e0288C9E49C70B1a with wrapped domains
2. Go to create space and see wrapped domains and no reverse domains

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed