### PR TITLE
feat: space members add with lowercase

### DIFF
--- a/src/components/SettingsMembersBlock.vue
+++ b/src/components/SettingsMembersBlock.vue
@@ -133,7 +133,7 @@ function addMembers(addresses: string) {
 
   const addressesArray = addresses
     .split(',')
-    .map(address => address.trim())
+    .map(address => address.trim().toLowerCase())
     .filter(address => isAddress(address))
     .filter(address => {
       const isNotMember =
@@ -168,7 +168,7 @@ const errorMessage = computed(() => {
 
   const membersArray = inputAddMembers.value
     .split(',')
-    .map(address => address.trim());
+    .map(address => address.trim().toLowerCase());
 
   let message = '';
 


### PR DESCRIPTION
### Issues
Lowercase addresses to check duplicates in space members.

Fixes https://github.com/snapshot-labs/snapshot/issues/3809

### Changes 
1. Added .toLowerCase() to address addressesArray/membersArray mapping.

### How to test
1. Go to your space and try to add members with mixed case and the the same with lowercase.

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed