### PR TITLE
fix: avoid github.com be detected as shortener provider

### DIFF
--- a/src/composables/useShortUrls.ts
+++ b/src/composables/useShortUrls.ts
@@ -33,9 +33,9 @@ export function useShortUrls() {
     if (shortUrls.value.length === 0) return false;
     return shortUrls.value.some(
       shortUrl =>
-        text.includes(`http://${shortUrl}`) ||
-        text.includes(`https://${shortUrl}`) ||
-        text.includes(`.${shortUrl}`)
+        text.includes(`http://${shortUrl}/`) ||
+        text.includes(`https://${shortUrl}/`) ||
+        text.includes(`.${shortUrl}/`)
     );
   }
 


### PR DESCRIPTION
This is a quick fix to avoid this:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/16245250/234652996-fd4ee927-1ec8-4010-a676-a2927be9f745.png">
