### PR TITLE
chore(3855): fix missing border on warning

### DIFF
--- a/src/components/BaseBlock.vue
+++ b/src/components/BaseBlock.vue
@@ -21,7 +21,7 @@ const isCollapsed = ref(true);
 
 <template>
   <div
-    class="border-y border-skin-border bg-skin-block-bg text-base md:rounded-xl md:border"
+    class="border-x border-y border-skin-border bg-skin-block-bg text-base md:rounded-xl"
   >
     <div
       v-if="title"


### PR DESCRIPTION
### Issues
https://github.com/snapshot-labs/snapshot/issues/3855

Fixes #

### Changes 
1. Previously the border was only being handled for resolutions greater than or equal to `md`, I removed the specific class for md resolutions and added the `border-x` class that handles all resolutions.

### How to test
1. Easy way to test, just remove the v-if on the component `SpaceWarningFlagged.vue # Line 36` and open any profile like `http://localhost:8080/#/yam.eth`, after that it's just validating for different sizes of resolution.


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on a custom domain
- [x] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

