### PR TITLE
fix: Message block border responsive

### DIFF
--- a/src/components/BaseMessageBlock.vue
+++ b/src/components/BaseMessageBlock.vue
@@ -12,7 +12,7 @@ defineProps<{
       { '!border-skin-text': level === 'warning' },
       { '!border-red': level === 'warning-red' },
       {
-        ' rounded-none border-x-0': isResponsive
+        '!rounded-none border-x-0 md:!rounded-xl': isResponsive
       }
     ]"
   >

--- a/src/components/SpaceWarningFlagged.vue
+++ b/src/components/SpaceWarningFlagged.vue
@@ -33,7 +33,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <BaseContainer v-if="isWarningFlaggedShowing" class="mb-4 px-0 md:px-4">
+  <BaseContainer v-if="isWarningFlaggedShowing" class="mb-4 !px-0 md:!px-4">
     <BaseMessageBlock is-responsive level="warning-red">
       {{ $t('warningSpace') }}
       <BaseLink link="https://docs.snapshot.org/spaces/badges-and-warnings">{{


### PR DESCRIPTION
### Issues

Fixes https://github.com/snapshot-labs/snapshot/issues/3855

### Changes 

1. Fixes the issue above that stems from a recent update of Tailwind CSS that brought about changes to "specificity". Not exactly sure how and why.
<img width="659" alt="image" src="https://user-images.githubusercontent.com/51686767/235589319-62ccfcf2-770f-4004-9add-e8c8affd0f37.png">

### How to test

1. Go to flagged space `zksyncvote.eth` and check for on sm and md screen sizes.

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment


