### PR TITLE
fix: Link to uma oracle url

### DIFF
--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -110,11 +110,11 @@ const approveBondUma = async () => {
   }
 };
 
-const getProposalUrl = (chain, txHash) => {
+const getProposalUrl = (chain, txHash, logIndex) => {
   if (Number(chain) !== 5 && Number(chain) !== 80001) {
-    return `https://oracle.umaproject.org/request?transactionHash=${txHash}&chainId=${chain}&oracleType=OptimisticV3&eventIndex=0`;
+    return `https://oracle.uma.xyz?transactionHash=${txHash}&logIndex=${logIndex}`;
   }
-  return `https://testnet.oracle.umaproject.org/request?transactionHash=${txHash}&chainId=${chain}&oracleType=OptimisticV3&eventIndex=0`;
+  return `https://testnet.oracle.uma.xyz?transactionHash=${txHash}&logIndex=${logIndex}`;
 };
 
 const submitProposalUma = async () => {
@@ -308,7 +308,7 @@ onMounted(async () => {
             <h3 class="title">{{ $t('safeSnap.labels.request') }}</h3>
           </template>
           <div class="my-3 p-3">
-            <div class="pr-3 pl-3">
+            <div class="pl-3 pr-3">
               <p>{{ $t('safeSnap.labels.confirmVoteResultsToolTip') }}</p>
             </div>
             <div class="my-3 rounded-lg border p-3">
@@ -390,7 +390,8 @@ onMounted(async () => {
             :href="
               getProposalUrl(
                 props.network,
-                questionDetails.assertionEvent.proposalTxHash
+                questionDetails.assertionEvent.proposalTxHash,
+                questionDetails.assertionEvent.logIndex
               )
             "
             class="rounded-lg border p-2 text-skin-text"


### PR DESCRIPTION
### Issues
*_(Include references to issues that this PR addresses)_*

Fixes #

### Changes 
*_(Briefly describe the changes made in this PR)_*
When using osnap, after an execution of a vote, there is a time window where the proposal can be disputed. this updates the dispute link to the new oracle ui.  the code was already there, but link format is modified.

1. 

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1.  on goerli, visit the outcome.eth space, propose a new approve vote, sending a small amount of eth from wallet with an expiry of 5 minutes.
2. vote affirmative, and wait till vote is over. see that you can execute the vote.
3. after execution see that theres a link to the oracle UI:
 
![image](https://user-images.githubusercontent.com/4429761/236295570-3cbf4d52-d396-4470-8bf9-e301d7ab121e.png)


### To-Do
*_(List any outstanding tasks be addressed before or after this PR is merged)_*

- [ ] 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [x] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

