### PR TITLE
feat: add ipfs link next to transaction viewer

### DIFF
--- a/src/plugins/safeSnap/components/Config.vue
+++ b/src/plugins/safeSnap/components/Config.vue
@@ -73,7 +73,7 @@ export default {
       <h4>
         {{ $t('safeSnap.transactions') }}
       </h4>
-      <BaseLink v-if="ipfs" :link="ipfs"> View Strategy </BaseLink>
+      <BaseLink v-if="ipfs" :link="ipfs"> View Details </BaseLink>
     </div>
 
     <div

--- a/src/plugins/safeSnap/components/Config.vue
+++ b/src/plugins/safeSnap/components/Config.vue
@@ -1,6 +1,7 @@
 <script>
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 import { coerceConfig, isValidInput, getSafeHash } from '../index';
+import { getIpfsUrl } from '@/helpers/utils';
 
 import SafeTransactions from './SafeTransactions.vue';
 
@@ -38,7 +39,7 @@ export default {
       input = coerceConfig(value, this.network);
     }
 
-    return { input };
+    return { input, ipfs: getIpfsUrl(this?.proposal?.ipfs) };
   },
   methods: {
     updateSafeTransactions() {
@@ -59,11 +60,22 @@ export default {
 <template>
   <div
     v-if="!preview || input.safes.length > 0"
-    class="mb-4 rounded-none border-t border-b bg-skin-block-bg md:rounded-xl md:border"
+    class="mb-4 rounded-none border-b border-t bg-skin-block-bg md:rounded-xl md:border"
   >
-    <h4 class="block border-b px-4 pt-3" style="padding-bottom: 12px">
-      {{ $t('safeSnap.transactions') }}
-    </h4>
+    <div
+      class="block border-b px-4 pt-3"
+      style="
+        padding-bottom: 12px;
+        display: flex;
+        justify-content: space-between;
+      "
+    >
+      <h4>
+        {{ $t('safeSnap.transactions') }}
+      </h4>
+      <BaseLink v-if="ipfs" :link="ipfs"> View Strategy </BaseLink>
+    </div>
+
     <div
       v-for="(safe, index) in input.safes"
       :key="index"


### PR DESCRIPTION
### Issues
There was a request to include ipfs link next to transaction viewer


### Changes 
This will render an ipfs link whenever it exists, next to the transaction title.
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/17968246-658a-4972-8fe8-6ef2af699381)


### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. view any proposal with a transaction viewer, see the ipfs link exists, click it. 

### To-Do
*_(List any outstanding tasks be addressed before or after this PR is merged)_*

- [ ] 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

