### PR TITLE
refactor(sign): simplified interface for `sign` helper

### DIFF
--- a/src/composables/useEmailSubscription.ts
+++ b/src/composables/useEmailSubscription.ts
@@ -1,5 +1,12 @@
-import sign, { SubscribeType } from '@/helpers/sign';
+import sign, { DataType } from '@/helpers/sign';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
+
+const SubscribeType: DataType = {
+  Subscribe: [
+    { name: 'address', type: 'address' },
+    { name: 'email', type: 'string' }
+  ]
+};
 
 export function useEmailSubscription() {
   enum Status {
@@ -30,8 +37,8 @@ export function useEmailSubscription() {
     try {
       const signature = await sign(
         auth.web3,
-        web3.value.account,
         {
+          address: web3.value.account,
           email
         },
         SubscribeType

--- a/src/composables/useEmailSubscription.ts
+++ b/src/composables/useEmailSubscription.ts
@@ -1,7 +1,7 @@
 import sign, { DataType } from '@/helpers/sign';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 
-const SubscribeType: DataType = {
+const SubscribeSchema: DataType = {
   Subscribe: [
     { name: 'address', type: 'address' },
     { name: 'email', type: 'string' }
@@ -41,7 +41,7 @@ export function useEmailSubscription() {
           address: web3.value.account,
           email
         },
-        SubscribeType
+        SubscribeSchema
       );
 
       const response = await fetch(import.meta.env.VITE_ENVELOP_URL, {

--- a/src/helpers/sign.ts
+++ b/src/helpers/sign.ts
@@ -7,30 +7,18 @@ const domain = {
   version: '0.1.4'
 };
 
-type DataType = Record<string, { name: string; type: string }[]>;
+export type DataType = Record<string, { name: string; type: string }[]>;
 
-export const SubscribeType: DataType = {
-  Subscribe: [
-    { name: 'from', type: 'address' },
-    { name: 'email', type: 'string' }
-  ]
-};
-
-export interface ISubscribe {
-  from?: string;
-  timestamp?: number;
-  email: string;
-}
+export type ISubscribe = {
+  address: string;
+} & Record<string, any>;
 
 export default async function sign(
   web3: Web3Provider | Wallet,
-  address: string,
   message: ISubscribe,
   types: DataType
 ) {
   const signer = 'getSigner' in web3 ? web3.getSigner() : web3;
-  const checksumAddress = getAddress(address);
-  message.from = message.from ? getAddress(message.from) : checksumAddress;
-
+  message.address = getAddress(message.address);
   return await signer._signTypedData(domain, types, message);
 }


### PR DESCRIPTION
### Issues
*_[#3907](https://github.com/snapshot-labs/snapshot/pull/3907)_*
*_[#3754](https://github.com/snapshot-labs/snapshot/pull/3754)_*

Fixes #
This PR refactors `sign` helper. 

### Changes 
1. I have removed the `address` argument from the function interface. Instead, I enforced having the `address` property in the message passed to `sign` by type definition.
2. Moved signature schema out of `sign` because intentionally we will have a lot of such schemas and better to store them near the place we execute the function

### How to test

1. Log in to your account
2. Click on your profile in the header navigation
3. In the dropdown, select "SUBSCRIBE"
4. Fill out the email form in the modal
5. Submit
6. Sign the message
7. See success/error message

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed
