### PR TITLE
feat(subscription management): load current user subscriptions

### DIFF
--- a/src/composables/useEmailSubscription.ts
+++ b/src/composables/useEmailSubscription.ts
@@ -3,6 +3,7 @@ import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 
 let auth;
 let isInitialized = false;
+let isSubscriptionsLoading = false;
 
 enum Status {
   waiting,
@@ -21,9 +22,46 @@ const status: Ref<Status> = ref(Status.waiting);
 const postSubscribeLevel: Ref<Level> = ref(Level.info);
 const postSubscribeMessage = ref('');
 const loading = ref(false);
+const isSubscribed = ref(false);
 
 const { t } = useI18n();
-const { web3 } = useWeb3();
+const { web3Account } = useWeb3();
+const apiSubscriptions = ref([]);
+
+async function loadEmailSubscriptions() {
+  const address = web3Account.value;
+
+  if (!address) return;
+  if (isSubscriptionsLoading) return;
+
+  isSubscriptionsLoading = true;
+
+  try {
+    const url = `${import.meta.env.VITE_ENVELOP_URL}/subscriber`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ address })
+    });
+
+    const result = await response.json();
+
+    if ('error' in result) {
+      isSubscribed.value = false;
+      throw new Error(result.error.message);
+    }
+
+    apiSubscriptions.value = result;
+    isSubscribed.value = true;
+  } catch (e) {
+    isSubscribed.value = false;
+    console.error(e);
+  } finally {
+    isSubscriptionsLoading = false;
+  }
+}
 
 async function subscribe(email: string, address: string) {
   loading.value = true;
@@ -31,7 +69,7 @@ async function subscribe(email: string, address: string) {
   try {
     const signature = await sign(
       auth.web3,
-      web3.value.account,
+      web3Account.value,
       {
         email
       },
@@ -84,16 +122,23 @@ function reset() {
 }
 
 export function useEmailSubscription() {
-  onBeforeMount(() => {
+  onBeforeMount(async () => {
     if (isInitialized) return;
 
     auth = getInstance();
 
-    isInitialized = true;
+    if (!web3Account.value) return;
+
+    try {
+      await loadEmailSubscriptions();
+    } finally {
+      isInitialized = true;
+    }
   });
 
   return {
     subscribe,
+    loadEmailSubscriptions,
     status,
     loading,
     reset,


### PR DESCRIPTION
### Issues
[#3754](https://github.com/snapshot-labs/snapshot/pull/3754)
[#3907](https://github.com/snapshot-labs/snapshot/pull/3907)

### Changes 

Add functionality of email management

### How to test

1. Log in to your account
2. Click on your profile in the header navigation
3. In the dropdown, select "SUBSCRIBE"
4. Fill out the email form in the modal
5. Submit
6. Sign the message
7. Validate the email with a letter on your email provider
8. Close the form
9. Click on your profile in the header navigation
10. In the dropdown, select "Manage subscriptions"
11. Update your subscription preferences
12. Sign the message
13. Validate that subscription preferences are changed. It also can be checked in DB. Also, you can ask BE to send test email.


### To-Do

- [ ] load initial state of subscriptions
- [ ] implement email management modal
- [ ] show `Subscribe` or `Manage subscriptions` in the account menu, based on the state of the subscription
- [ ] display email management modal if the user subscribed
- [ ] implement email removal functionality

### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed
