### PR TITLE
fix: mint button on POAP plugin

### DIFF
--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -11,7 +11,7 @@ export async function getProposalVotes(
     first = 1000,
     voter = '',
     skip = 0,
-    space = '',
+    space = undefined,
     orderBy = 'vp',
     orderDirection = 'desc',
     created_gte = 0


### PR DESCRIPTION
There is a bug with the POAP plugin, when someone vote it's not detected and the button is greyed. You can check on this proposal: http://localhost:8080/#/rocketpool-dao.eth/proposal/0x19504a2bc3ac5b2b4fe9f54ef08ca23656fb4f6e678d17adb68c82d3bdf369af
by adding a valid voter address here <https://github.com/snapshot-labs/snapshot/blob/31411c83771b9ac4c4c2b3bf2c7bfbac76a9be43/src/plugins/poap/index.ts#L37> You'll see that the button stay grey, this is because the request we are sending to hub to check if someone voted is incorrect, we are sending `space = ''`. This PR fixes this