### PR TITLE
fix: page in events to fix lookback limitation

### DIFF
--- a/src/plugins/safeSnap/utils/events.ts
+++ b/src/plugins/safeSnap/utils/events.ts
@@ -1,0 +1,145 @@
+// This state is meant for adjusting a start/end block when querying events. Some apis will fail if the range
+// is too big, so the following functions will adjust range dynamically.
+export type RangeState = {
+  startBlock: number;
+  endBlock: number;
+  maxRange: number;
+  currentRange: number;
+  currentStart: number; // This is the start value you want for your query.
+  currentEnd: number; // this is the end value you want for your query.
+  done: boolean; // Signals we successfully queried the entire range.
+  multiplier?: number; // Multiplier increases or decreases range by this value, depending on success or failure
+};
+
+/**
+ * rangeStart. This starts a new range query and sets defaults for state.  Use this as the first call before starting your queries
+ *
+ * @param {Pick} state
+ * @returns {RangeState}
+ */
+export function rangeStart(
+  state: Pick<RangeState, 'startBlock' | 'endBlock' | 'multiplier'> & {
+    maxRange?: number;
+  }
+): RangeState {
+  const { startBlock, endBlock, multiplier = 2 } = state;
+  if (state.maxRange && state.maxRange > 0) {
+    const range = endBlock - startBlock;
+    if ((!(range >= 0), 'End block must be higher than start block'));
+    const currentRange = Math.min(state.maxRange, range);
+    const currentStart = endBlock - currentRange;
+    const currentEnd = endBlock;
+    return {
+      done: false,
+      startBlock,
+      endBlock,
+      maxRange: state.maxRange,
+      currentRange,
+      currentStart,
+      currentEnd,
+      multiplier
+    };
+  } else {
+    // the largest range we can have, since this is the users query for start and end
+    const maxRange = endBlock - startBlock;
+    if ((!(maxRange > 0), 'End block must be higher than start block'));
+    const currentStart = startBlock;
+    const currentEnd = endBlock;
+    const currentRange = maxRange;
+
+    return {
+      done: false,
+      startBlock,
+      endBlock,
+      maxRange,
+      currentRange,
+      currentStart,
+      currentEnd,
+      multiplier
+    };
+  }
+}
+/**
+ * rangeSuccessDescending. We have 2 ways of querying events, from oldest to newest, or newest to oldest. Typically we want them in order, from
+ * oldest to newest, but for this particular case we want them newest to oldest, ie descending ( larger timestamp to smaller timestamp).
+ * This function will increase the range between start/end block and return a new start/end to use since by calling this you are signalling
+ * that the last range ended in a successful query.
+ *
+ * @param {RangeState} state
+ * @returns {RangeState}
+ */
+export function rangeSuccessDescending(state: RangeState): RangeState {
+  const {
+    startBlock,
+    currentStart,
+    maxRange,
+    currentRange,
+    multiplier = 2
+  } = state;
+  // we are done if we succeeded querying where the currentStart matches are initial start block
+  const done = currentStart <= startBlock;
+  // increase range up to max range for every successful query
+  const nextRange = Math.min(Math.ceil(currentRange * multiplier), maxRange);
+  // move our end point to the previously successful start, ie moving from newest to oldest
+  const nextEnd = currentStart;
+  // move our start block to the next range down
+  const nextStart = Math.max(nextEnd - nextRange, startBlock);
+  return {
+    ...state,
+    currentStart: nextStart,
+    currentEnd: nextEnd,
+    currentRange: nextRange,
+    done
+  };
+}
+/**
+ * rangeFailureDescending. Like the previous function, this will decrease the range between start/end for your query, because you are signalling
+ * that the last query failed. It will also keep the end of your range the same, while moving the start range up. This is why
+ * its considered descending, it will attempt to move from end to start, rather than start to end.
+ *
+ * @param {RangeState} state
+ * @returns {RangeState}
+ */
+export function rangeFailureDescending(state: RangeState): RangeState {
+  const { startBlock, currentEnd, currentRange, multiplier = 2 } = state;
+  const nextRange = Math.floor(currentRange / multiplier);
+  // this will eventually throw an error if you keep calling this function, which protects us against re-querying a broken api in a loop
+  if (currentRange <= 0) throw new Error('Current range must be above 0');
+  if (!(nextRange > 0)) throw new Error('Range must be above 0');
+  // we stay at the same end block
+  const nextEnd = currentEnd;
+  // move our start block closer to the end block, shrinking the range
+  const nextStart = Math.max(nextEnd - nextRange, startBlock);
+  return {
+    ...state,
+    currentStart: nextStart,
+    currentEnd: nextEnd,
+    currentRange: nextRange
+  };
+}
+
+// The main interface to wrap the above pure functions up. requires you to pass in a generic function
+// which returns the events based on a start/end block query.
+export async function pageEvents<E>(
+  startBlock: number,
+  endBlock: number,
+  maxRange: number,
+  //start and end block range to query
+  fetchEvents: (query: { start: number; end: number }) => Promise<E[]>
+): Promise<E[]> {
+  const events = [];
+  let state = rangeStart({ startBlock, endBlock, maxRange });
+  do {
+    try {
+      const e = await fetchEvents({
+        start: state.currentStart,
+        end: state.currentEnd
+      });
+      events.push(...e);
+      state = rangeSuccessDescending(state);
+    } catch (err) {
+      state = rangeFailureDescending(state);
+    }
+  } while (!state.done);
+  return events;
+}


### PR DESCRIPTION
### Issues
After executing a proposal for Barnbridge, we are unable to determine the proposal was executed, which causes us to display a button to do this again. this will waste users funds if acted on. 

Fixes #

### Changes 
The bug was introduced as a side effect of fixing another bug. Previously we were getting block range limits when querying for events, due to having to look back to block 0. This was rectified by hardcoding a block range of 3k which seems to be the maximum block range for the specific provider we are bound to. This caused us to miss past events as we need to look back to block 4k+. 

1. The changes made are to respect the block range limit, while also "paging" through the broader range. We also limit lookback which was previously set to 0, to the start of the mainned OG and OO contract deployment

![image](https://github.com/snapshot-labs/snapshot/assets/4429761/f41c80bf-4acc-4cb2-9d55-03d38c05a007)

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. You should be able to visit the barnbridge proposal which is currently displaying it has not been executed when it has
`#/barnbridge.eth/proposal/0xb5bfbb34a7d0aecf3ceb2950a5f19f1c17e441636843244e883a7d8ac533c202`
2. you should now see that it has been executed. 

### To-Do
We will eventually need to optimize this, a side effect of this technique is long processing time. we should wrap up state in the graph eventually, or some other caching mechanism. 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
for uma people: https://linear.app/uma/issue/UMA-1529/osnap-bug-can-execute-proposal-multiple-times-in-snapshot

