### PR TITLE
fix: Remove abstain votes from the basic voting quorum score

### DIFF
--- a/src/composables/useQuorum.ts
+++ b/src/composables/useQuorum.ts
@@ -20,6 +20,11 @@ export function useQuorum(props: QuorumProps) {
       return props.results.scores
         .filter((c, i) => basicCount.includes(i))
         .reduce((a, b) => a + b, 0);
+    if (props.space.voting.hideAbstain && props.proposal.type === 'basic') {
+      return props.results.scores
+        .filter((c, i) => i !== 2)
+        .reduce((a, b) => a + b, 0);
+    }
     if (props.results.scoresTotal) return props.results.scoresTotal;
     return 0;
   });


### PR DESCRIPTION
When `voting.hideAbstain` is set in the space settings we should not count Abstain votes towards the quorum.

### Changes 

1. Added a condition and filter to remove Abstain votes from Quorum score.

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. `testsnap.eth/proposal/0xad2c5d0d860c0a897e02893a723c2530e85badaf0a055a1efad4ffc7e811ecd3`

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment



