### PR TITLE
improve: parallelize event loading

### DIFF
--- a/src/plugins/safeSnap/utils/events.ts
+++ b/src/plugins/safeSnap/utils/events.ts
@@ -127,19 +127,12 @@ export async function pageEvents<E>(
   //start and end block range to query
   fetchEvents: (query: { start: number; end: number }) => Promise<E[]>
 ): Promise<E[]> {
-  const events = [];
   let state = rangeStart({ startBlock, endBlock, maxRange });
+  const ranges = [];
   do {
-    try {
-      const e = await fetchEvents({
-        start: state.currentStart,
-        end: state.currentEnd
-      });
-      events.push(...e);
-      state = rangeSuccessDescending(state);
-    } catch (err) {
-      state = rangeFailureDescending(state);
-    }
+    ranges.push({ start: state.currentStart, end: state.currentEnd });
+    state = rangeSuccessDescending(state);
   } while (!state.done);
-  return events;
+
+  return (await Promise.all(ranges.map(fetchEvents))).flat();
 }

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -163,18 +163,48 @@ export const getModuleDetailsUma = async (
   const oOStartBlock = network === '1' ? 16636058 : 0;
   const maxRange = network === '1' ? 3000 : 10000;
 
-  const assertionEvents = await pageEvents(
-    oOStartBlock,
-    latestBlock.number,
-    maxRange,
-    ({ start, end }: { start: number; end: number }) => {
-      return oracleContract.queryFilter(
-        oracleContract.filters.AssertionMade(assertionId),
-        start,
-        end
-      );
-    }
-  );
+  const [assertionEvents, transactionsProposedEvents, executionEvents] =
+    await Promise.all([
+      pageEvents(
+        oOStartBlock,
+        latestBlock.number,
+        maxRange,
+        ({ start, end }: { start: number; end: number }) => {
+          return oracleContract.queryFilter(
+            oracleContract.filters.AssertionMade(assertionId),
+            start,
+            end
+          );
+        }
+      ),
+      // Check if this specific proposal has already been executed.
+      // note usage of pageEvents, which query only based on a limit number of blocks within a broader range
+      // this prevents block range too large errors.
+      pageEvents(
+        oGstartBlock,
+        latestBlock.number,
+        maxRange,
+        ({ start, end }: { start: number; end: number }) => {
+          return moduleContract.queryFilter(
+            moduleContract.filters.TransactionsProposed(),
+            start,
+            end
+          );
+        }
+      ),
+      pageEvents(
+        oGstartBlock,
+        latestBlock.number,
+        maxRange,
+        ({ start, end }: { start: number; end: number }) => {
+          return moduleContract.queryFilter(
+            moduleContract.filters.ProposalExecuted(proposalHash),
+            start,
+            end
+          );
+        }
+      )
+    ]);
   const thisModuleAssertionEvent = assertionEvents.filter(event => {
     return (
       event.args?.claim === ancillaryData &&
@@ -202,39 +232,10 @@ export const getModuleDetailsUma = async (
     })
   );
 
-  // Check if this specific proposal has already been executed.
-  // note usage of pageEvents, which query only based on a limit number of blocks within a broader range
-  // this prevents block range too large errors.
-  const transactionsProposedEvents = await pageEvents(
-    oGstartBlock,
-    latestBlock.number,
-    maxRange,
-    ({ start, end }: { start: number; end: number }) => {
-      return moduleContract.queryFilter(
-        moduleContract.filters.TransactionsProposed(),
-        start,
-        end
-      );
-    }
-  );
-
   const thisProposalTransactionsProposedEvents =
     transactionsProposedEvents.filter(
       event => toUtf8String(event.args?.explanation) === explanation
     );
-
-  const executionEvents = await pageEvents(
-    oGstartBlock,
-    latestBlock.number,
-    maxRange,
-    ({ start, end }: { start: number; end: number }) => {
-      return moduleContract.queryFilter(
-        moduleContract.filters.ProposalExecuted(proposalHash),
-        start,
-        end
-      );
-    }
-  );
 
   const assertion = thisProposalTransactionsProposedEvents.map(
     tx => tx.args?.assertionId


### PR DESCRIPTION
### Issues
A side effect of paging in all past events, is that loading is really slow. This is due to loading them in a blocking way, it can take almost a minute to complete loading of all events. 

Fixes #

### Changes 
*_(Briefly describe the changes made in this PR)_*

1. This parallelizes calls in 2 main places. First is where we paginate the events, we now create a list of start/end blocks, and then call them all in parallel, previously this was done sequentially.
2. For all event types in the uma module, previously they were called one at a time, now we call them all together.

This seems to have sped up loading significantly, and have not seen any rate limit errors. All events load in around 5 seconds.

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. Visit the barnbridge proposal on current mainnet, take note of how long the transaction information at the bottom of the page takes to load: https://snapshot.org/#/barnbridge.eth/proposal/0xf329a9211d7c87626c97d085af4cd81d6c6d3bd0bad5d1e9bfedfefdcf230884

2. compare it to the deployed version here, and see that theres a significant improvement


### To-Do
*_(List any outstanding tasks be addressed before or after this PR is merged)_*

- [ ] 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

thanks to fabian for suggestion for improvement

