### PR TITLE
fix: fix incorrect hex 0x replacements

### DIFF
--- a/src/plugins/safeSnap/utils/index.ts
+++ b/src/plugins/safeSnap/utils/index.ts
@@ -20,7 +20,7 @@ export const mustBeEthereumContractAddress = memoize(
     const contractCode = await provider.getCode(address);
 
     return (
-      contractCode && contractCode.replace('0x', '').replace(/0/g, '') !== ''
+      contractCode && contractCode.replace(/^0x/, '').replace(/0/g, '') !== ''
     );
   },
   (url, contractAddress) => `${url}_${contractAddress}`

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -108,17 +108,17 @@ export const getModuleDetailsUma = async (
       [
         '',
         pack(['string', 'string'], ['proposalHash', ':']),
-        toUtf8Bytes(proposalHash.replace('0x', '')),
+        toUtf8Bytes(proposalHash.replace(/^0x/, '')),
         pack(
           ['string', 'string', 'string', 'string'],
           [',', 'explanation', ':', '"']
         ),
-        toUtf8Bytes(explanation.replace('0x', '')),
+        toUtf8Bytes(explanation.replace(/^0x/, '')),
         pack(
           ['string', 'string', 'string', 'string', 'string'],
           ['"', ',', 'rules', ':', '"']
         ),
-        toUtf8Bytes(rules.replace('0x', '')),
+        toUtf8Bytes(rules.replace(/^0x/, '')),
         pack(['string'], ['"'])
       ]
     );


### PR DESCRIPTION
### Issues

There is a problem showing the execution date of proposals in liveness, errors are being showin in console. 

Fixes #

The bug was caused by replacing 0x in incorrect places in ancillary data, causing a slight mismatch when searching for events relevant to proposal. this would create an impossible state, and undefined values further down the code. 

### Changes 

1. We change to use a regex to only replace 0x in the front of hex strings before doing comparisons.


### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. visit https://snapshot.org/#/acrossprotocol.eth/proposal/0x58069d8f80093bea2a91955dcd871a6f0f321005dd9e9ca9756ef98d416b3fd1 and see no execution time show for this proposal, errors show in console

2. visit the same proposal in the preview link, see that it shows a future execution date

### To-Do
*_(List any outstanding tasks be addressed before or after this PR is merged)_*

- [ ] 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [x] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

