### PR TITLE
Show detailed error message for proposal creation validation settings…

### DIFF
--- a/src/components/ModalMessage.vue
+++ b/src/components/ModalMessage.vue
@@ -2,7 +2,6 @@
 defineProps<{
   open: boolean;
   title: string;
-  message: string;
   level: 'info' | 'warning' | 'warning-red';
 }>();
 
@@ -17,8 +16,8 @@ defineEmits(['close']);
       </div>
     </template>
 
-    <BaseMessageBlock :level="level" class="m-4">
-      {{ message }}
+    <BaseMessageBlock :level="level" class="m-4 whitespace-pre-line">
+      <slot name="message" />
     </BaseMessageBlock>
     <template #footer>
       <BaseButton class="w-full" primary @click="$emit('close')">

--- a/src/components/TheModalNotification.vue
+++ b/src/components/TheModalNotification.vue
@@ -11,10 +11,20 @@ const { items } = useModalNotification();
         v-if="defaults.modalNotifications?.[item.description]"
         :open="items.length > 0"
         :title="$t(`modalNotifications.${item.description}.title`)"
-        :message="$t(`modalNotifications.${item.description}.message`)"
         :level="item.type"
         @close="item.remove()"
       >
+        <template #message>
+          <i18n-t
+            :keypath="`modalNotifications.${item.description}.message`"
+            tag="span"
+            scope="global"
+          >
+            <template #discord>
+              <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
+            </template>
+          </i18n-t>
+        </template>
       </ModalMessage>
     </template>
   </teleport>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -308,11 +308,11 @@
     },
     "space with ticket requires voting validation": {
       "title": "Missing voting validation",
-      "message": "The system is unable to submit this proposal due to a missing validation rule.\n\n In order to use the \"ticket\" strategy you are required to set a Gitcoin Passport voting validation. This combination reduces the risk of spam and sybil attacks.\n\n Please update your settings accordingly and try again. If you need further assistance, feel free to reach out to our support team on {discord}."
+      "message": "Your proposal cannot be submitted due to a missing Gitcoin Passport voting validation rule required with the 'ticket' strategy. Please adjust your settings by either using another strategy or adding the required validation. If further assistance is needed, contact our support team on {discord}."
     },
     "space missing proposal validation": {
       "title": "Missing proposal validation",
-      "message": "The system is unable to submit this proposal due to a missing validation rule.\n\n This rule has been recently enforced to prevent unauthorized and spam proposals. In order to resolve this issue, you need to enforce some form of proposal validation in your space settings. This could be as simple as allowing only members of the space to post proposals or defining a minimum amount of voting power to be able to propose.\n\n Please update your settings accordingly and try again. If you need further assistance, feel free to reach out to our support team on {discord}."
+      "message": "Your proposal cannot be submitted due to a missing proposal validation rule. For preventing unauthorized proposals and spam, add a validation rule in your space settings. For assistance, reach out to our support team on {discord}."
     }
   },
   "modalTerms": {

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -304,7 +304,15 @@
   "modalNotifications": {
     "wrong timestamp": {
       "title": "Wrong timestamp",
-      "message": "The message timestamp is not valid. Please check the clock on your device, make sure it is set to the correct date and time and try again."
+      "message": "The message timestamp is not valid. Please check the clock on your device, make sure it is set to the correct date and time and try again.\n\n If you need further assistance, feel free to reach out to our support team on {discord}."
+    },
+    "space with ticket requires voting validation": {
+      "title": "Missing voting validation",
+      "message": "The system is unable to submit this proposal due to a missing validation rule.\n\n In order to use the \"ticket\" strategy you are required to set a Gitcoin Passport voting validation. This combination reduces the risk of spam and sybil attacks.\n\n Please update your settings accordingly and try again. If you need further assistance, feel free to reach out to our support team on {discord}."
+    },
+    "space missing proposal validation": {
+      "title": "Missing proposal validation",
+      "message": "The system is unable to submit this proposal due to a missing validation rule.\n\n This rule has been recently enforced to prevent unauthorized and spam proposals. In order to resolve this issue, you need to enforce some form of proposal validation in your space settings. This could be as simple as allowing only members of the space to post proposals or defining a minimum amount of voting power to be able to propose.\n\n Please update your settings accordingly and try again. If you need further assistance, feel free to reach out to our support team on {discord}."
     }
   },
   "modalTerms": {

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -308,11 +308,11 @@
     },
     "space with ticket requires voting validation": {
       "title": "Missing voting validation",
-      "message": "Your proposal cannot be submitted due to a missing Gitcoin Passport voting validation rule required with the 'ticket' strategy. Please adjust your settings by either using another strategy or adding the required validation. If further assistance is needed, contact our support team on {discord}."
+      "message": "Your proposal cannot be submitted due to a missing Gitcoin Passport voting validation rule required with the 'ticket' strategy. Please adjust your settings by either using another strategy or adding the required validation.\n\n If further assistance is needed, contact our support team on {discord}."
     },
     "space missing proposal validation": {
       "title": "Missing proposal validation",
-      "message": "Your proposal cannot be submitted due to a missing proposal validation rule. For preventing unauthorized proposals and spam, add a validation rule in your space settings. For assistance, reach out to our support team on {discord}."
+      "message": "Your proposal cannot be submitted due to a missing proposal validation rule. To prevent unauthorized proposals and spam, add a validation rule in your space settings.\n\n For assistance, reach out to our support team on {discord}."
     }
   },
   "modalTerms": {


### PR DESCRIPTION

### Issues

Part of https://github.com/snapshot-labs/snapshot/issues/3936

### Changes 

1. Show detailed error messages for missing validation settings that are now enforced on the HUB in order to be able to create a proposal. 
<img width="1133" alt="Screenshot 2023-06-01 at 10 23 41 AM" src="https://github.com/snapshot-labs/snapshot/assets/51686767/61fd5e99-9021-4305-b35a-77116aae8531">

<img width="1132" alt="Screenshot 2023-06-01 at 10 27 58 AM" src="https://github.com/snapshot-labs/snapshot/assets/51686767/30cc4488-9698-4ab6-93c3-0521795e83c8">


### How to test

1. https://snapshot.org/#/test2.testsnapnew.eth/create



### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed
