### PR TITLE
improve: show token address in tx builder

### DIFF
--- a/src/plugins/safeSnap/components/Form/TransferFunds.vue
+++ b/src/plugins/safeSnap/components/Form/TransferFunds.vue
@@ -109,7 +109,7 @@ export default {
       :key="index"
       :value="token.address"
     >
-      {{ token.symbol }}
+      {{ token.symbol }} ({{ token.address }})
     </option>
   </UiSelect>
   <div class="space-y-2">


### PR DESCRIPTION
### Issues
When showing a token symbol to user, its ambiguous, since there may be tokens with the same symbol. 

Fixes #

### Changes 
*_(Briefly describe the changes made in this PR)_*

1. This includes token address next to symbol to sanity check against expected token.

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. Go to acrossprotocol.eth/proposal/0xddf31bb0cfade3c8571e88816b029d20056068c922c1fdcbe4eb6fd9a80d0b72
2. go to the transaction builder at the bottom, expand it to show the tokens being transferred
3. see that theres a token address now next to the "ACX" symbol

### To-Do
A better solution would provide a direct link to etherscan for the token in question, and provide a way for user to inspect token before building the transaction.  


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

