### PR TITLE
fix: use contract to resolve Unstoppable Domains

### DIFF
--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -51,7 +51,6 @@ const {
   sourceProposalLoaded,
   sourceProposal,
   validationErrors,
-  isValid,
   resetForm
 } = useFormSpaceProposal();
 


### PR DESCRIPTION
The API return a CORS error, UD contacted us with a new way to resolve domain using a contract, this PR move from the API to the contract to resolve domains which should be much more stable.