### PR TITLE
improve: restrict snapshot proposal types to basic when using osnap

### DIFF
--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   space: ExtendedSpace;
   dateStart: number;
   dateEnd: number;
+  isUsingOsnap?: boolean;
 }>();
 
 const {
@@ -60,7 +61,12 @@ onMounted(async () => {
   if (!sourceProposalLoaded.value && !userSelectedDateStart.value)
     form.value.start = Number((Date.now() / 1e3).toFixed());
   // Initialize the proposal type if set in space
-  if (props.space?.voting?.type) form.value.type = props.space.voting.type;
+  // If using osnap, we can only allow basic voting, for, against, abstain
+  if (props.isUsingOsnap) {
+    form.value.type = 'basic';
+  } else {
+    if (props.space?.voting?.type) form.value.type = props.space.voting.type;
+  }
   form.value.snapshot = await getSnapshot(props.space.network);
 });
 </script>
@@ -68,7 +74,9 @@ onMounted(async () => {
 <template>
   <div class="mb-5 space-y-4">
     <BaseBlock :title="$t('create.voting')">
+      <InputSelectVoteType v-if="isUsingOsnap" type="basic" disabled />
       <InputSelectVoteType
+        v-else
         :type="space.voting?.type || form.type"
         :disabled="!!space.voting?.type"
         @update:type="value => (form.type = value)"


### PR DESCRIPTION
### Issues
Its been suggested that we restrict voting type to "basic" when doing an osnap vote. This is because we don't have the ability to automatically monitor and dispute arbitrary vote types where user may define other fields. Restricting this will allow more robust on chain monitoring and disputing of bad proposals. 

Fixes #

### Changes 
*_(Briefly describe the changes made in this PR)_*

1. When building your proposal, we check if the space is using osnap
2. if it is, we hard code the vote type to basic, and prevent user from selecting anything else

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. go to /#/outcomefinance.eth/create, which should be an osnap space
2. begin the proposal process, see that voting types are restricted to basic voting
3. go to a non osnap space
4. begin proposal process. see that voting types are not restricted to basic voting

### To-Do
*_(List any outstanding tasks be addressed before or after this PR is merged)_*

- [ ] - may eventually want to explain to the user somewhere why voting options are disabled


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain
- [ ] I have run end-to-end tests `yarn cypress:test:e2e`, and they have passed

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

Would like to get a vercel build up, and have people from UMA team test this out before merging
