### PR TITLE
Fix popover missing focus trap

### DIFF
--- a/src/components/BasePopover.vue
+++ b/src/components/BasePopover.vue
@@ -55,6 +55,7 @@ withDefaults(
             class="no-scrollbar max-h-[85vh] overflow-y-auto overscroll-contain"
           >
             <FocusTrap>
+              <span tabindex="0"></span>
               <slot name="content" :close="close" />
             </FocusTrap>
           </div>

--- a/src/components/SpaceProposalVotesList.vue
+++ b/src/components/SpaceProposalVotesList.vue
@@ -71,6 +71,7 @@ watch(web3Account, loadUserVote, { immediate: true });
       tabindex="0"
       class="block rounded-b-none border-t px-4 py-3 text-center md:rounded-b-md"
       @click="modalVotesmOpen = true"
+      @keypress="modalVotesmOpen = true"
     >
       <span v-text="$t('seeMore')" />
     </a>


### PR DESCRIPTION
### Issues

Fixes #3940

<img width="298" alt="241664056-10704615-ccd4-449d-8a21-044ef5960582" src="https://github.com/snapshot-labs/snapshot/assets/495709/da62a307-8eb5-4fe2-8224-4b6a96451c97">

### Changes 

1. UI: Add a focus trap to popover, so on open, the focus is on a hidden element, instead of the first clickable element. 
2. UX: Fix "See more" button, for opening the votes modal, not actionable by keyboard navigation.

### How to test

1. Use `TAB` key to navigate to header notification menu.
2. Open the menu
3. Nothing should be focused
4. Press `TAB`
5. The first element should be focused

1. Go to a closed proposal with votes
2. Scroll down to the votes list
3. Use the `TAB` key to navigate and focus the "See more" link
4. Press ENTER
5. The votes modal should open

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
