### PR TITLE
feat: enable osnap selection to restrict voting types

### DIFF
--- a/src/components/SpaceCreateContent.vue
+++ b/src/components/SpaceCreateContent.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { ExtendedSpace } from '@/helpers/interfaces';
 
-const props = defineProps<{
+defineProps<{
   space: ExtendedSpace;
   preview: boolean;
   bodyLimit: number;
-  osnap: { enabled: boolean; selection: boolean };
 }>();
 
 const { formatNumber } = useIntl();
@@ -32,13 +31,6 @@ const inputBody = computed({
   }
 });
 
-const osnapSelectedValue = computed(() =>
-  props.osnap.selection ? 'yes' : 'no'
-);
-
-defineEmits<{
-  (event: 'osnapSelectionChange'): void;
-}>();
 const injectImageToBody = image => {
   const cursorPosition = textAreaEl.value?.selectionStart;
   const currentBody = textAreaEl.value?.value;
@@ -175,26 +167,6 @@ const handleDrop = e => {
         :error="validationErrors?.discussion"
         data-testid="input-proposal-discussion"
       />
-      <div v-if="osnap.enabled">
-        <h6>OSnap Proposal</h6>
-        <p>
-          Are you planning for this proposal to initiate a transaction that your
-          organizations safe will execute if approved? (Remember, oSnap enables
-          trustless and permissionless execution):
-        </p>
-        <br />
-        <select
-          v-model="osnapSelectedValue"
-          @change="$emit('osnapSelectionChange', $event.target.value)"
-        >
-          <option key="no" value="no">
-            No, this proposal does not include an executable transaction
-          </option>
-          <option key="yes" value="yes">
-            Yes, this proposal includes an executable transaction
-          </option>
-        </select>
-      </div>
     </div>
   </div>
 </template>

--- a/src/components/SpaceCreateContent.vue
+++ b/src/components/SpaceCreateContent.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ExtendedSpace } from '@/helpers/interfaces';
 
-defineProps<{
+const props = defineProps<{
   space: ExtendedSpace;
   preview: boolean;
   bodyLimit: number;
+  osnap: { enabled: boolean; selection: boolean };
 }>();
 
 const { formatNumber } = useIntl();
@@ -31,6 +32,13 @@ const inputBody = computed({
   }
 });
 
+const osnapSelectedValue = computed(() =>
+  props.osnap.selection ? 'yes' : 'no'
+);
+
+defineEmits<{
+  (event: 'osnapSelectionChange'): void;
+}>();
 const injectImageToBody = image => {
   const cursorPosition = textAreaEl.value?.selectionStart;
   const currentBody = textAreaEl.value?.value;
@@ -167,6 +175,26 @@ const handleDrop = e => {
         :error="validationErrors?.discussion"
         data-testid="input-proposal-discussion"
       />
+      <div v-if="osnap.enabled">
+        <h6>OSnap Proposal</h6>
+        <p>
+          Are you planning for this proposal to initiate a transaction that your
+          organizations safe will execute if approved? (Remember, oSnap enables
+          trustless and permissionless execution):
+        </p>
+        <br />
+        <select
+          v-model="osnapSelectedValue"
+          @change="$emit('osnapSelectionChange', $event.target.value)"
+        >
+          <option key="no" value="no">
+            No, this proposal does not include an executable transaction
+          </option>
+          <option key="yes" value="yes">
+            Yes, this proposal includes an executable transaction
+          </option>
+        </select>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -83,12 +83,12 @@ defineEmits<{
 </script>
 
 <template>
-  <div v-if="osnap.enabled">
-    <h6>OSnap Proposal</h6>
+  <div v-if="osnap.enabled" class="mb-4">
+    <h6>oSnap Proposal</h6>
     <p>
       Are you planning for this proposal to initiate a transaction that your
-      organizations safe will execute if approved? (Remember, oSnap enables
-      trustless and permissionless execution):
+      organizations Safe will execute if approved? (Remember, oSnap enables
+      trustless and permissionless execution)
     </p>
     <br />
     <input
@@ -98,16 +98,14 @@ defineEmits<{
       @change="$emit('osnapToggle')"
     />
     <label for="toggleOsnap">
-      Yes, use Osnap for transactions ( this will restrict voting types ).
+      Yes, use oSnap for transactions (this will restrict voting types).
     </label>
-    <br />
-    <br />
   </div>
   <div class="mb-5 space-y-4">
     <BaseBlock :title="$t('create.voting')">
       <InputSelectVoteType
         :type="space.voting?.type || form.type"
-        :disabled="!!space.voting?.type"
+        :disabled="!!space.voting?.type || osnap.selection"
         @update:type="value => (form.type = value)"
       />
 

--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   space: ExtendedSpace;
   dateStart: number;
   dateEnd: number;
+  isUsingOsnap?: boolean;
 }>();
 
 const {
@@ -59,8 +60,14 @@ onMounted(async () => {
   // Initialize the start date to current
   if (!sourceProposalLoaded.value && !userSelectedDateStart.value)
     form.value.start = Number((Date.now() / 1e3).toFixed());
-  // Initialize the proposal type if set in space
-  if (props.space?.voting?.type) form.value.type = props.space.voting.type;
+
+  // If using osnap, we can only allow basic voting, for, against, abstain
+  if (props.isUsingOsnap) {
+    form.value.type = 'basic';
+  } else {
+    // Initialize the proposal type if set in space
+    if (props.space?.voting?.type) form.value.type = props.space.voting.type;
+  }
   form.value.snapshot = await getSnapshot(props.space.network);
 });
 </script>
@@ -68,7 +75,9 @@ onMounted(async () => {
 <template>
   <div class="mb-5 space-y-4">
     <BaseBlock :title="$t('create.voting')">
+      <InputSelectVoteType v-if="isUsingOsnap" type="basic" disabled />
       <InputSelectVoteType
+        v-else
         :type="space.voting?.type || form.type"
         :disabled="!!space.voting?.type"
         @update:type="value => (form.type = value)"

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -5,6 +5,7 @@ import { PROPOSAL_QUERY } from '@/helpers/queries';
 import { proposalValidation } from '@/helpers/snapshot';
 import { ExtendedSpace } from '@/helpers/interfaces';
 import Plugin from '@/plugins/safeSnap';
+
 const safeSnapPlugin = new Plugin();
 
 enum Step {

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -308,7 +308,7 @@ const handleOsnapSelectionChange = ref(value => {
 });
 
 onMounted(async () => {
-  const network = props?.space?.network;
+  const network = props?.space?.plugins?.safeSnap?.safes?.[0]?.network;
   const umaAddress = props?.space?.plugins?.safeSnap?.safes?.[0]?.umaAddress;
   if (network && umaAddress) {
     // this is how we check if osnap is enabled and valid.

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -223,6 +223,8 @@ async function loadSourceProposal() {
 
 function nextStep() {
   if (formContainsShortUrl.value) return;
+  // skip transaction page if user has osnap, but chosen not to use it for this vote
+  if (shouldSkipTransactions()) return;
   currentStep.value++;
 }
 
@@ -291,6 +293,15 @@ const osnap = ref<{
   selection: false,
   enabled: false
 });
+
+// Skip transaction page if osnap is enabled, its not selected to be used, and we are on the voting page
+function shouldSkipTransactions() {
+  return (
+    osnap.value.enabled &&
+    !osnap.value.selection &&
+    currentStep.value === Step.VOTING
+  );
+}
 
 const handleOsnapSelectionChange = ref(value => {
   osnap.value.selection = value === 'yes';
@@ -387,7 +398,8 @@ onMounted(async () => {
         <BaseButton
           v-if="
             currentStep === Step.PLUGINS ||
-            (!needsPluginConfigs && currentStep === Step.VOTING)
+            (!needsPluginConfigs && currentStep === Step.VOTING) ||
+            shouldSkipTransactions()
           "
           :disabled="!isFormValid"
           :loading="isSending || queryLoading || isSnapshotLoading"

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -303,9 +303,9 @@ function shouldSkipTransactions() {
   );
 }
 
-const handleOsnapSelectionChange = ref(value => {
-  osnap.value.selection = value === 'yes';
-});
+function handleOsnapToggle() {
+  osnap.value.selection = !osnap.value.selection;
+}
 
 onMounted(async () => {
   const network = props?.space?.plugins?.safeSnap?.safes?.[0]?.network;
@@ -362,8 +362,6 @@ onMounted(async () => {
         :space="space"
         :preview="preview"
         :body-limit="BODY_LIMIT_CHARACTERS"
-        :osnap="osnap"
-        @osnapSelectionChange="handleOsnapSelectionChange"
       />
 
       <!-- Step 2 -->
@@ -372,7 +370,8 @@ onMounted(async () => {
         :space="space"
         :date-start="dateStart"
         :date-end="dateEnd"
-        :is-using-osnap="osnap.selection"
+        :osnap="osnap"
+        @osnapToggle="handleOsnapToggle"
       />
 
       <!-- Step 3 (only when plugins) -->


### PR DESCRIPTION
### Issues
Its been suggested that we restrict voting type to "basic" when doing an osnap vote. This is because osnap team does not have the ability to automatically monitor and dispute arbitrary vote types where user may define other fields. Restricting this will allow more robust on chain monitoring and disputing of bad proposals.

Fixes #

### Changes 
1. we add code to check if the user has a valid osnap install
2. if they do, during proposal building, we add a selection where the user can specify if they want to use osnap 
3. if they choose yes, we hard code the vote type to basic, and prevent user from selecting anything else

this only shows if osnap is enabled and working:
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/3c66147d-9639-4979-95b6-6a2262ffa246)

### How to test
1. go to /#/outcomefinance.eth/create, which should be an osnap space
2. begin the proposal process, see that you are asked if you want to make this an osnap vote. 
3. select yes, see that in the next screen you are limited to basic vote.
4. go to next page. see that you can add transaction information
5. go back to first page, select no.
6. go to next page, see that you are free to select any type of vote
7. see that on vote page, you can only plublish, skipping transaction page.
8. go to a non osnap space that you can propose on
9. create new proposal and see that there is no osnap related messaging, and all vote types are enabled.


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

