### PR TITLE
fix: remove trailing and leading spaces and line break  from reason

### DIFF
--- a/src/components/SpaceProposalVotesListItem.vue
+++ b/src/components/SpaceProposalVotesListItem.vue
@@ -106,7 +106,7 @@ const balanceFormatted = computed(() => {
       <BaseButtonIcon
         v-if="vote.reason !== '' && props.proposal.privacy !== 'shutter'"
         v-tippy="{
-          content: urlify(vote.reason),
+          content: urlify(vote.reason.replace(/^[\s\n]+|[\s\n]+$/g, '')),
           allowHTML: true,
           interactive: true,
           theme: 'urlified'


### PR DESCRIPTION
### Issues

Votes reason with trailing and leading line breaks are shown as is in the tooltip.

Part of #3944

### Changes 

1. Trim leading and trailing line break from the reason

### How to test

1. Go to https://snapshot-git-fix-3944-snapshot.vercel.app/#/opcollective.eth/proposal/0x88583c43b196ec86cee45345611b582108f1d6933ab688a7cae992a6baa552a6
2. Open the votes list modal
3. Filter with the following address: `0xe43C840612d5672920FC33ACc55390357D9EcE3d`
4. The reason should shown without leading line break


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

