### PR TITLE
fix(walletconnect): changed wc config

### DIFF
--- a/src/helpers/connectors.json
+++ b/src/helpers/connectors.json
@@ -14,9 +14,9 @@
       "methods": [
         "eth_sendTransaction",
         "personal_sign",
-        "eth_accounts",
         "eth_signTypedData_v4"
       ],
+      "optionalMethods": ["eth_accounts"],
       "rpcMap": {
         "1": "https://rpc.snapshot.org/1",
         "4": "https://rpc.snapshot.org/4",


### PR DESCRIPTION
Fixes #
1. Problem with connection using Rainbow Wallet

### Changes 
1. Moved `eth_accounts` to optional methods

### How to test
1. You need to try to login using Rainbow Wallet and WalletConnect v2

### To-Do
- [ ] 

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

