### PR TITLE
fix(gnosis safe): add extra check for gnosis contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "patch-package && husky install",
     "init-submodules": "git submodule update --init",
     "test:unit": "vitest run",
-    "test:unit:coverage": "vitest run --coverage"
+    "test:unit:coverage": "vitest run --coverage "
   },
   "lint-staged": {
     "*.{js,ts,vue,json}": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "patch-package && husky install",
     "init-submodules": "git submodule update --init",
     "test:unit": "vitest run",
-    "test:unit:coverage": "vitest run --coverage "
+    "test:unit:coverage": "vitest run --coverage"
   },
   "lint-staged": {
     "*.{js,ts,vue,json}": [

--- a/src/composables/useGnosis.ts
+++ b/src/composables/useGnosis.ts
@@ -28,7 +28,7 @@ export function useGnosis(space?: ExtendedSpace) {
       web3.value?.walletConnectType === 'WalletConnect Safe App' ||
       web3.value?.walletConnectType === 'Den' ||
       connectorName.value === 'gnosis' ||
-      isContract
+      isContract.value
   );
 
   const isGnosisAndNotDefaultNetwork = computed(() => {

--- a/src/composables/useGnosis.ts
+++ b/src/composables/useGnosis.ts
@@ -1,5 +1,7 @@
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { ExtendedSpace } from '@/helpers/interfaces';
+import utils from '@snapshot-labs/snapshot.js/src/utils';
+import { computedAsync } from '@vueuse/core';
 
 const defaultNetwork = import.meta.env.VITE_DEFAULT_NETWORK;
 
@@ -9,17 +11,25 @@ export function useGnosis(space?: ExtendedSpace) {
   const auth = getInstance();
   const connectorName = computed(() => auth.provider.value?.connectorName);
 
+  const networkKey = computed(() => web3.value.network.key);
+
+  const spaceNetworkKey = computed(() => space?.network);
+
+  const isContract = computedAsync(async () => {
+    if (!web3.value.account) return false;
+    const provider = utils.getProvider(networkKey.value);
+    const code = await provider.getCode(web3.value.account);
+    return code !== '0x';
+  }, false);
+
   const isGnosisSafe = computed(
     () =>
       web3.value?.walletConnectType === 'Gnosis Safe Multisig' ||
       web3.value?.walletConnectType === 'WalletConnect Safe App' ||
       web3.value?.walletConnectType === 'Den' ||
-      connectorName.value === 'gnosis'
+      connectorName.value === 'gnosis' ||
+      isContract
   );
-
-  const networkKey = computed(() => web3.value.network.key);
-
-  const spaceNetworkKey = computed(() => space?.network);
 
   const isGnosisAndNotDefaultNetwork = computed(() => {
     return isGnosisSafe.value && networkKey.value !== defaultNetwork;


### PR DESCRIPTION
Fixes #
Add the ability to detect gnosis-safe wallets if the web3 provider doesn't contain any information

### Changes 
1. Add an extra check whether the address code is equal to `0x`. If not equal then the address belongs to a contract. 

### How to test
1. Login with gnosis safe
2. Check that you are not able to join any space

### To-Do
- [ ] 


### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

