### PR TITLE
Do not display quorum from space settings, use proposal quorum

### DIFF
--- a/src/components/SpaceProposalResultsList.vue
+++ b/src/components/SpaceProposalResultsList.vue
@@ -20,10 +20,7 @@ const choices = computed<{ i: number; choice: string }[]>(() =>
 );
 
 const showQuorum = computed(
-  () =>
-    props.proposal?.quorum ||
-    props.space.voting?.quorum ||
-    props.space?.plugins?.quorum
+  () => props.proposal?.quorum || props.space?.plugins?.quorum
 );
 </script>
 


### PR DESCRIPTION
### Issues
This was causing confusion as the proposal doesn't use a quorum but uses space settings to display it.

Fixes #
Instead of displaying the quorum from space settings, utilize the proposal quorum.

### How to test
Before: https://vote.gro.xyz/#/proposal/0x7e6a526031028514cf78fb8618a65d1cc71d457549f8c1b8180a96443d741428
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/b9e29345-03f1-4c4a-832a-c3a47725b66e)

After: https://snapshot-git-fix-quorum-with-space-settings-snapshot.vercel.app/#/gro.xyz/proposal/0x7e6a526031028514cf78fb8618a65d1cc71d457549f8c1b8180a96443d741428
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/48cc4c1f-98fb-4858-8454-11aa9a24e268)

Before it was displaying quorum section, now it should not

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain


