### PR TITLE
fix: Use config network for tokens explore url

### DIFF
--- a/src/plugins/safeSnap/components/Form/TokensModal.vue
+++ b/src/plugins/safeSnap/components/Form/TokensModal.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   open: boolean;
   tokenAddress: string;
   tokens: TokenAsset[];
+  network: string;
 }>();
 
 const emit = defineEmits(['close', 'tokenAddress']);
@@ -110,6 +111,7 @@ function handleTokenClick(token) {
           :key="token.address"
           :token="token"
           :is-selected="token.address === tokenAddress"
+          :network="network"
           @select="handleTokenClick"
         />
 

--- a/src/plugins/safeSnap/components/Form/TokensModalItem.vue
+++ b/src/plugins/safeSnap/components/Form/TokensModalItem.vue
@@ -6,6 +6,7 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 const props = defineProps<{
   token: TokenAsset;
   isSelected: boolean;
+  network: string;
 }>();
 
 const emit = defineEmits(['select']);
@@ -14,9 +15,7 @@ const { formatNumber, getNumberFormatter } = useIntl();
 const { copyToClipboard } = useCopy();
 
 const exploreUrl = computed(() => {
-  const network = props.token.verified ? String(props.token.chainId) : null;
-  if (!network) return null;
-  return explorerUrl(network, props.token.address);
+  return explorerUrl(props.network, props.token.address);
 });
 </script>
 
@@ -70,12 +69,6 @@ const exploreUrl = computed(() => {
         >
           {{ shorten(token.address) }}</BaseLink
         >
-        <span
-          v-else-if="token.address !== 'main'"
-          @click.stop="copyToClipboard(token.address)"
-        >
-          {{ shorten(token.address) }}
-        </span>
       </div>
     </div>
   </button>

--- a/src/plugins/safeSnap/components/Form/TransferFunds.vue
+++ b/src/plugins/safeSnap/components/Form/TransferFunds.vue
@@ -162,6 +162,7 @@ export default {
       :tokens="tokens"
       :token-address="tokenAddress"
       :open="modalTokensOpen"
+      :network="config.network"
       @token-address="tokenAddress = $event"
       @close="modalTokensOpen = false"
     />


### PR DESCRIPTION
### Issues

Fixes #4026 

### Changes 


1. Use the network from the safe config to generate the explorer urls for tokens

### How to test


1. https://snapshot-git-samuv-fix-token-explore-snapshot.vercel.app/#/outcomefinance.eth



### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment



