### PR TITLE
fix: fix failing percentage formatting for big number

### DIFF
--- a/src/components/ProposalsItemFooter.vue
+++ b/src/components/ProposalsItemFooter.vue
@@ -6,8 +6,7 @@ defineProps<{
   proposal: Proposal;
 }>();
 
-const { getRelativeProposalPeriod, formatPercentNumber, formatCompactNumber } =
-  useIntl();
+const { getRelativeProposalPeriod, formatPercentNumber } = useIntl();
 </script>
 
 <template>
@@ -38,11 +37,7 @@ const { getRelativeProposalPeriod, formatPercentNumber, formatCompactNumber } =
       "
     >
       -
-      {{
-        formatPercentNumber(
-          Number(formatCompactNumber(proposal.scores_total / proposal.quorum))
-        )
-      }}
+      {{ formatPercentNumber(Number(proposal.scores_total / proposal.quorum)) }}
       {{ $t('quorumReached') }}
     </template>
   </div>


### PR DESCRIPTION
### Issues
Quorum % in proposal item footer is failing when percentage number is too big, due to number formatting converting it to something like "277K" first

Fixes #

### Changes 

1. Remove the number compact formatting

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Test 

- Visit https://snapshot-git-fix-nan-quorum-snapshot.vercel.app/#/grants.safe.eth
- Quorum percentage should not show `NaN` anymore

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

