### PR TITLE
fix(start): remove start time restriction for Safe

### DIFF
--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -42,7 +42,7 @@ const { send, isSending } = useClient();
 const { pluginIndex } = usePlugins();
 const { modalAccountOpen } = useModal();
 const { modalTermsOpen, termsAccepted, acceptTerms } = useTerms(props.space.id);
-const { isGnosisAndNotSpaceNetwork } = useGnosis(props.space);
+const { isGnosisAndNotSpaceNetwork, isGnosisSafe } = useGnosis(props.space);
 const { isSnapshotLoading } = useSnapshot();
 const { apolloQuery, queryLoading } = useApolloQuery();
 const { containsShortUrl } = useShortUrls();
@@ -163,7 +163,9 @@ function getFormattedForm() {
     .filter(choiceText => choiceText.length > 0);
   updateTime();
   const thisMomentTimestamp = parseInt((Date.now() / 1e3).toFixed());
-  clonedForm.start = Math.max(thisMomentTimestamp, dateStart.value);
+  clonedForm.start = isGnosisSafe.value
+    ? dateStart.value
+    : Math.max(thisMomentTimestamp, dateStart.value);
   clonedForm.end = dateEnd.value;
   return clonedForm;
 }


### PR DESCRIPTION
### Issues
[Discord](https://discord.com/channels/955773041898573854/1030772384308932608/1125979225078370385)

Fixes #
Remove the restriction of the start time for Safe wallets

### Changes 
1. add a check of Safe to the `SpaceCreate` view. If it's Safe, then the start time will not be restricted to be greater than now.

### How to test
1. Try to create a proposal with the Safe wallet.

### To-Do
- [ ] 


### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

