### PR TITLE
fix(activities): prevent loading activities for empty list

### DIFF
--- a/src/views/ProfileActivity.vue
+++ b/src/views/ProfileActivity.vue
@@ -85,6 +85,7 @@ async function loadVotes(skip = 0) {
 useInfiniteScroll(
   document,
   () => {
+    if (activities.value.length === 0) return;
     loadMore(() => loadVotes(activities.value.length));
   },
   { distance: 400 }


### PR DESCRIPTION
### Issues
[Discord](https://discord.com/channels/955773041898573854/1030772384308932608/1126143002285453413)

Fixes #

### Changes 
1. add a check that prevents loading activities if the list is empty. In other words - there is nothing to load and the infinite scroll triggers continuously

### How to test
1. Go to profile activities and check that you don't have duplicates

### To-Do
- [ ] 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
- [x] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

