### PR TITLE
feat: check if vote passes before allowing execution

### DIFF
--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -53,7 +53,8 @@ type QuestionState =
   | 'completely-executed'
   | 'waiting-for-proposal'
   | 'waiting-for-liveness'
-  | 'proposal-approved';
+  | 'proposal-approved'
+  | 'proposal-denied';
 
 type Action1State = 'idle' | 'approve-bond' | 'submit-proposal';
 type Action2State = 'idle' | 'execute-proposal';
@@ -212,6 +213,29 @@ const networkName = computed(() => {
   return networks[props.network].name;
 });
 
+type Proposal = {
+  choices: string[];
+  scores: number[];
+  scores_total: number;
+  quorum: number;
+  created: number;
+  end: number;
+  state: string;
+};
+function didProposalPass(proposal: Proposal) {
+  // ensure the vote has ended
+  if (proposal.state !== 'closed') return false;
+  // ensure total votes are more than quorum
+  if (proposal.scores_total < proposal.quorum) return false;
+  const votes = Object.fromEntries(
+    proposal.choices.map((choice, i) => {
+      return [choice.toLowerCase(), proposal.scores[i]];
+    })
+  );
+  // ensure the for votes pass quorum and that there are more for votes than against
+  return votes['for'] > votes['against'];
+}
+
 const questionState = computed<QuestionState>(() => {
   if (!web3.value.account) return 'no-wallet-connection';
 
@@ -224,26 +248,36 @@ const questionState = computed<QuestionState>(() => {
 
   if (noTransactions) return 'no-transactions';
 
+  // check if proposal passed snapshot rules, ie votes for, and quorum
+  const proposalPassed = didProposalPass(props.proposal);
+
+  // ordering of this is deliberate. it will prevent you from executing proposals that did not pass,
+  // but if for some reason the proposal did get executed elsewhere, it will still show that it was.
   // If proposal has already been executed, prevents user from proposing again.
   if (proposalExecuted) return 'completely-executed';
 
   // User can confirm vote results if not done already and there is no proposal yet.
-  if (!activeProposal && !voteResultsConfirmed.value)
+  if (!activeProposal && !voteResultsConfirmed.value && proposalPassed)
     return 'waiting-for-vote-confirmation';
 
   // Proposal can be made if it has not been made already and user confirmed vote results.
-  if (!activeProposal && voteResultsConfirmed) return 'waiting-for-proposal';
+  if (!activeProposal && voteResultsConfirmed && proposalPassed)
+    return 'waiting-for-proposal';
 
   // Proposal has been made and is waiting for liveness period to complete.
-  if (!assertionEvent?.isExpired) return 'waiting-for-liveness';
+
+  if (assertionEvent && !assertionEvent.isExpired)
+    return 'waiting-for-liveness';
 
   // Proposal is approved if it expires without a dispute and hasn't been settled.
-  if (assertionEvent?.isExpired && !assertionEvent?.isSettled)
+  if (assertionEvent && assertionEvent.isExpired && !assertionEvent.isSettled)
     return 'proposal-approved';
 
   // Proposal is approved if it has been settled without a disputer and hasn't been executed.
-  if (assertionEvent?.isSettled && !proposalExecuted)
+  if (assertionEvent && assertionEvent.isSettled && !proposalExecuted)
     return 'proposal-approved';
+
+  if (!proposalPassed) return 'proposal-denied';
 
   return 'error';
 });
@@ -464,6 +498,9 @@ onMounted(async () => {
 
     <div v-if="questionState === 'completely-executed'" class="my-4">
       {{ $t('safeSnap.labels.executed') }}
+    </div>
+    <div v-if="questionState === 'proposal-denied'" class="my-4">
+      {{ $t('safeSnap.labels.rejected') }}
     </div>
   </template>
 </template>


### PR DESCRIPTION
### Issues
currently the oSnap UI does not check if a vote has passed quorum, or even if majority voted "for" the proposal before allowing a request for execution. we want to prevent requesting execution of osnap votes unless they first pass snapshot rules.

Fixes #

### Changes 
*_(Briefly describe the changes made in this PR)_*

1. adds a utility function that looks at the proposal state, and does some basic checks for votes against quorum and that "for" is more than "against". 

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. we can check #/frp.eth/proposal/0x3d12840b17a64af60fb75c7dae17846f64836b702eab3c9ae178debe40a4af6c and now see that if a proposal is voted down, it shows "proposal rejected":
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/e3e51c5d-e6c2-4156-8071-d80c9e0818ae)
2. it continues to show proper states ( no regressions ) for the rest of passed votes:
 - #/barnbridge.eth/proposal/0x74cf6f3372aaeebfc2e99ff54604a5e63ca3d44cb84bdbf202a85581dfac9f5d
 - #/acrossprotocol.eth/proposal/0xb1ad4c7e16b750009becc991297e7a014aaf7f46a4427cb13c61ee08f19e2053
3. there is a special case where a vote did not pass, but it could be proposed outside of the UI. this can still show up, for example here: #/acrossprotocol.eth/proposal/0x58db9b7f8d91027b9cc88087069f33170482e3be6d0f5878302ac40f510b95e4

### To-Do
*_(List any outstanding tasks be addressed before or after this PR is merged)_*

- [ ] 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

