### PR TITLE
fix: blockscout new api url

### DIFF
--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -24,7 +24,7 @@ export const EIP3770_PREFIXES = {
 export const EXPLORER_API_URLS = {
   '1': 'https://api.etherscan.io/api',
   '5': 'https://api-goerli.etherscan.io/api',
-  '100': 'https://blockscout.com/xdai/mainnet/api',
+  '100': 'https://gnosis.blockscout.com/api',
   '73799': 'https://volta-explorer.energyweb.org/api',
   '246': 'https://explorer.energyweb.org/api',
   '137': 'https://api.polygonscan.com/api',


### PR DESCRIPTION
### Issues

fix #4062

---

I have checked everything, it's just fixing the endpoint. That value is ONLY used for ABI fetching, in safeSnap/utils/abi.ts
