### PR TITLE
chore(refactor): remove useless submit property

### DIFF
--- a/src/components/ModalNotice.vue
+++ b/src/components/ModalNotice.vue
@@ -13,12 +13,7 @@ defineEmits(['close']);
     </div>
     <template #footer>
       <div>
-        <BaseButton
-          type="submit"
-          class="w-full"
-          primary
-          @click="$emit('close')"
-        >
+        <BaseButton class="w-full" primary @click="$emit('close')">
           {{ $t('continue') }}
         </BaseButton>
       </div>

--- a/src/components/ModalSelectDate.vue
+++ b/src/components/ModalSelectDate.vue
@@ -101,7 +101,6 @@ watch(step, () => {
       </div>
       <div class="float-left w-2/4 pl-2">
         <BaseButton
-          type="submit"
           :disabled="!isTimeValid"
           class="w-full"
           primary

--- a/src/components/ModalTerms.vue
+++ b/src/components/ModalTerms.vue
@@ -44,7 +44,7 @@ function accept() {
         </BaseButton>
       </div>
       <div class="float-left w-2/4 pl-2">
-        <BaseButton type="submit" class="w-full" primary @click="accept">
+        <BaseButton class="w-full" primary @click="accept">
           {{ $t('agree') }}
         </BaseButton>
       </div>

--- a/src/components/ModalVote.vue
+++ b/src/components/ModalVote.vue
@@ -314,7 +314,6 @@ watch(
             isGnosisAndNotSpaceNetwork
           "
           :loading="isSending || isLoadingShutter"
-          type="submit"
           class="w-full"
           primary
           data-testid="confirm-vote-button"


### PR DESCRIPTION
### Issues
There's a few button with `type="submit"`
Unless the submit button is inside a `<form>` tag, it's basically useless, and just a regular `button`

### Changes 

1. Remove all `type="submit"` property for button not inside a `<form>` tag

### How to test

1. 

### To-Do
*_(List any outstanding tasks be addressed before or after this PR is merged)_*

- [ ] 


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

