### PR TITLE
fix: Hide poap block if there is no POAP is setup

### DIFF
--- a/src/plugins/poap/components/CustomBlock.vue
+++ b/src/plugins/poap/components/CustomBlock.vue
@@ -5,12 +5,6 @@ const { notify } = useFlashNotification();
 const { web3Account } = useWeb3();
 
 const STATES = {
-  NO_POAP: {
-    header: 'poap.no_poap_header',
-    headerImage: 'https://snapshotsplugin.s3.us-west-2.amazonaws.com/empty.svg',
-    mainImage:
-      'https://snapshotsplugin.s3.us-west-2.amazonaws.com/placeholder.png'
-  },
   NOT_VOTED: {
     headerImage: 'https://snapshotsplugin.s3.us-west-2.amazonaws.com/vote.svg',
     header: 'poap.no_voted_header',
@@ -48,7 +42,7 @@ export default {
     return {
       loading: false,
       plugin: new Plugin(),
-      currentState: NO_POAP,
+      currentState: LOADING,
       address: '',
       poapImg: '',
       loadButton: false
@@ -148,7 +142,7 @@ export default {
 
 <template>
   <BaseBlock
-    v-if="currentState !== 'NO_POAP'"
+    v-if="currentState === 'LOADING' || currentState !== 'NO_POAP'"
     title="I voted POAP"
     :loading="loading"
   >

--- a/src/plugins/poap/components/CustomBlock.vue
+++ b/src/plugins/poap/components/CustomBlock.vue
@@ -147,7 +147,11 @@ export default {
 </script>
 
 <template>
-  <BaseBlock title="I voted POAP" :loading="loading">
+  <BaseBlock
+    title="I voted POAP"
+    :loading="loading"
+    v-if="currentState !== 'NO_POAP'"
+  >
     <div class="flex flex-col items-center">
       <img :src="headerImg" alt="" class="mb-2" />
       <div class="mb-2 text-center text-skin-link">{{ $t(header) }}</div>

--- a/src/plugins/poap/components/CustomBlock.vue
+++ b/src/plugins/poap/components/CustomBlock.vue
@@ -148,9 +148,9 @@ export default {
 
 <template>
   <BaseBlock
+    v-if="currentState !== 'NO_POAP'"
     title="I voted POAP"
     :loading="loading"
-    v-if="currentState !== 'NO_POAP'"
   >
     <div class="flex flex-col items-center">
       <img :src="headerImg" alt="" class="mb-2" />


### PR DESCRIPTION
### Issues

Fixes https://github.com/snapshot-labs/pitches/issues/14

### Changes 
*_(Briefly describe the changes made in this PR)_*
1. Hides the poap block if Poap is not setup for the proposal
2. There is no way to hide the 404 error message, so i am gonna ignore it for now

### How to test:
- POAP block should not show up here https://snapshot-git-hide-poap-if-no-poap-snapshot.vercel.app/#/stgdao.eth/proposal/0x108a9e597560c4f249cd8be23acd409059fcd17bb2290d69a550ac2232676e7d
- POAP block should show up here 
https://snapshot-git-hide-poap-if-no-poap-snapshot.vercel.app/#/fractiontoken.eth/proposal/0xeaaf4b685084762f952f587fc8aa0725b40bc4c2d77e4e976a4125d3621cf7c3

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

