### PR TITLE
fix(404): redirect to dashboard page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/(.*)",
-      "destination": "/index.html"
+      "destination": "/"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "rewrites": [
+  "redirects": [
     {
       "source": "/(.*)",
       "destination": "/index.html"

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/*",
+      "source": "/(.*)",
       "destination": "/"
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "redirects": [
+  "rewrites": [
     {
       "source": "/:path*",
       "destination": "/#/:path*",

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "redirects": [
     {
-      "source": "/(.*)",
-      "destination": "/#/",
+      "source": "/:path*",
+      "destination": "/",
       "permanent": true
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "rewrites": [
     {
-      "source": "/:path*",
-      "destination": "/#/:path*"
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
-  "redirects": [
+  "rewrites": [
     {
-      "source": "/(.+)",
+      "source": "/(.*)",
       "destination": "/"
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,9 @@
 {
-  "rewrites": [
+  "redirects": [
     {
       "source": "/(.*)",
-      "destination": "/"
+      "destination": "/",
+      "permanent": true
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "redirects": [
     {
-      "source": "/(.*)",
+      "source": "/(.+)",
       "destination": "/"
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/*",
       "destination": "/"
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/:path*",
-      "destination": "/",
+      "destination": "/#/:path*",
       "permanent": true
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/(.*)",
-      "destination": "/",
+      "destination": "/#/",
       "permanent": true
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,7 @@
   "rewrites": [
     {
       "source": "/:path*",
-      "destination": "/#/:path*",
-      "permanent": true
+      "destination": "/#/:path*"
     }
   ]
 }


### PR DESCRIPTION
### Issues
#102 

Fixes #
add redirect to `/`

### Changes 
add vercel.json config file

### How to test
1. Open some not existing pages, e.g. `https://snapshot.org/sialala` (use your own domain)
2. Vercel shouldn't show 404 and just show a dashboard (unfortunately the link will be `https://snapshot.org/sialala/#/`

### To-Do
- [ ] 

### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

