### PR TITLE
fix: disable osnap if basic voting is not allowed and inform

### DIFF
--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -86,22 +86,39 @@ defineEmits<{
 
 <template>
   <div v-if="osnap.enabled" class="mb-4">
-    <h6>oSnap Proposal</h6>
-    <p>
-      Are you planning for this proposal to initiate a transaction that your
-      organizations Safe will execute if approved? (Remember, oSnap enables
-      trustless and permissionless execution)
-    </p>
-    <br />
-    <input
-      id="toggleOsnap"
-      type="checkbox"
-      :checked="osnap.selection"
-      @change="$emit('osnapToggle')"
-    />
-    <label for="toggleOsnap">
-      Yes, use oSnap for transactions (this will restrict voting types).
-    </label>
+    <div v-if="space?.voting?.type && space.voting.type !== 'basic'">
+      <h6>Where is oSnap?</h6>
+      <p class="mb-3">
+        oSnap is currently disabled because your space's voting settings
+        disallow the basic voting type which is a requirement for oSnap to work
+        properly.
+      </p>
+      <p>
+        Have your admin visit your
+        <a :href="`#/${space.id}/settings`">settings page</a> under Voting ->
+        Type, and make sure either "Any" or "Basic Voting" is selected. This
+        will allow you to create oSnap proposals.
+      </p>
+    </div>
+    <div v-else>
+      <h6>oSnap Proposal</h6>
+      <p>
+        Are you planning for this proposal to initiate a transaction that your
+        organizations Safe will execute if approved? (Remember, oSnap enables
+        trustless and permissionless execution)
+      </p>
+      <br />
+      <input
+        id="toggleOsnap"
+        type="checkbox"
+        :checked="osnap.selection"
+        @change="$emit('osnapToggle')"
+      />
+      <label for="toggleOsnap">
+        Yes, use oSnap for transactions (this will restrict voting type to
+        Basic).
+      </label>
+    </div>
   </div>
   <div class="mb-5 space-y-4">
     <BaseBlock :title="$t('create.voting')">


### PR DESCRIPTION
### Issues
In order for oSnap to work properly, the space needs to be able to create proposals with basic voting. If a space disallows this through space settings, then we must let them know. Currently this situation is not checked, and allows the user to go through 
the proposal process, only to fail in the end. 

### Changes 
*_(Briefly describe the changes made in this PR)_*

1. this adds logic to notify the user that the spaces settings are incompatible with osnap, and directs them to the settings they must change to enable it. it will also disallow user from using osnap.
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/daecbb0d-f7fc-46f1-9a1a-bbd6d7dd9f38)


### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1.  visit a space a space with osnap and basic voting dissallowed, like #/umadev.eth/create
2. create a proposal, and see osnap disabled, with text explaning why and how to fix it
3. visit any other osnap enabled space, with correct settings. start proposal and see that osnap is enabled

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain



