### PR TITLE
fix: Clamp error in flash notification

### DIFF
--- a/src/components/TheFlashNotification.vue
+++ b/src/components/TheFlashNotification.vue
@@ -17,12 +17,15 @@ const { items } = useFlashNotification();
           :class="`!bg-${item.type}`"
         >
           <div class="flex items-center gap-2">
-            <i-ho-x v-if="item.type === 'red'" class="text-base" />
-            <i-ho-check v-if="item.type === 'green'" class="text-base" />
-            <span>{{ item.message }}</span>
+            <i-ho-x v-if="item.type === 'red'" class="shrink-0 text-base" />
+            <i-ho-check
+              v-if="item.type === 'green'"
+              class="shrink-0 text-base"
+            />
+            <span class="line-clamp-1 text-left">{{ item.message }}</span>
           </div>
 
-          <i-ho-x class="text-base" @click="item.remove()" />
+          <i-ho-x class="shrink-0 text-base" @click="item.remove()" />
         </BaseButton>
       </div>
     </TransitionGroup>


### PR DESCRIPTION
### Issue

Toast was getting messed up when error was too long.

### Changes 

Before: 
<img width="412" alt="Screenshot 2023-08-10 at 3 35 20 PM" src="https://github.com/snapshot-labs/snapshot/assets/51686767/e368b40d-4869-40c5-b12f-53449e469d67">

After: 
<img width="416" alt="Screenshot 2023-08-10 at 3 35 08 PM" src="https://github.com/snapshot-labs/snapshot/assets/51686767/edc1dec2-84b2-4dac-9db6-bc79ad09d1af">

