### PR TITLE
fix: fix broken gql call, narrow block query range

### DIFF
--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -421,7 +421,8 @@ export const contractData: ContractData[] = [
     name: 'OptimisticOracleV3',
     address: '0x072819Bb43B50E7A251c64411e7aA362ce82803B',
     subgraph:
-      'https://api.thegraph.com/subgraphs/name/umaprotocol/optimism-optimistic-oracle-v3'
+      'https://api.thegraph.com/subgraphs/name/umaprotocol/optimism-optimistic-oracle-v3',
+    deployBlock: 74537234
   },
   {
     // gnosis
@@ -429,7 +430,8 @@ export const contractData: ContractData[] = [
     name: 'OptimisticOracleV3',
     address: '0x22A9AaAC9c3184f68C7B7C95b1300C4B1D2fB95C',
     subgraph:
-      'https://api.thegraph.com/subgraphs/name/umaprotocol/gnosis-optimistic-oracle-v3'
+      'https://api.thegraph.com/subgraphs/name/umaprotocol/gnosis-optimistic-oracle-v3',
+    deployBlock: 27087150
   },
   {
     // polygon
@@ -437,7 +439,8 @@ export const contractData: ContractData[] = [
     name: 'OptimisticOracleV3',
     address: '0x5953f2538F613E05bAED8A5AeFa8e6622467AD3D',
     subgraph:
-      'https://api.thegraph.com/subgraphs/name/umaprotocol/polygon-optimistic-oracle-v3'
+      'https://api.thegraph.com/subgraphs/name/umaprotocol/polygon-optimistic-oracle-v3',
+    deployBlock: 39331673
   },
   {
     //arbitrum
@@ -445,7 +448,8 @@ export const contractData: ContractData[] = [
     name: 'OptimisticOracleV3',
     address: '0xa6147867264374F324524E30C02C331cF28aa879',
     subgraph:
-      'https://api.thegraph.com/subgraphs/name/umaprotocol/arbitrum-optimistic-oracle-v3'
+      'https://api.thegraph.com/subgraphs/name/umaprotocol/arbitrum-optimistic-oracle-v3',
+    deployBlock: 61236565
   },
   {
     // avalanche
@@ -453,7 +457,8 @@ export const contractData: ContractData[] = [
     name: 'OptimisticOracleV3',
     address: '0xa4199d73ae206d49c966cF16c58436851f87d47F',
     subgraph:
-      'https://api.thegraph.com/subgraphs/name/umaprotocol/avalanche-optimistic-oracle-v3'
+      'https://api.thegraph.com/subgraphs/name/umaprotocol/avalanche-optimistic-oracle-v3',
+    deployBlock: 27816737
   },
   {
     // mainnet
@@ -480,6 +485,7 @@ export const contractData: ContractData[] = [
     network: '10',
     name: 'OptimisticGovernor',
     address: '0x357fe84E438B3150d2F68AB9167bdb8f881f3b9A',
+    deployBlock: 83168480,
     subgraph:
       'https://api.thegraph.com/subgraphs/name/umaprotocol/optimism-optimistic-governor'
   },
@@ -487,6 +493,7 @@ export const contractData: ContractData[] = [
     // gnosis
     network: '100',
     name: 'OptimisticGovernor',
+    deployBlock: 27102135,
     subgraph:
       'https://api.thegraph.com/subgraphs/name/umaprotocol/gnosis-optimistic-governor'
   },
@@ -495,6 +502,7 @@ export const contractData: ContractData[] = [
     network: '137',
     name: 'OptimisticGovernor',
     address: '0x3Cc4b597E9c3f51288c6Cd0c087DC14c3FfdD966',
+    deployBlock: 40677035,
     subgraph:
       'https://api.thegraph.com/subgraphs/name/umaprotocol/polygon-optimistic-governor'
   },
@@ -503,6 +511,7 @@ export const contractData: ContractData[] = [
     network: '42161',
     name: 'OptimisticGovernor',
     address: '0x30679ca4ea452d3df8a6c255a806e08810321763',
+    deployBlock: 72850751,
     subgraph:
       'https://api.thegraph.com/subgraphs/name/umaprotocol/arbitrum-optimistic-governor'
   },
@@ -511,6 +520,7 @@ export const contractData: ContractData[] = [
     network: '43114',
     name: 'OptimisticGovernor',
     address: '0xEF8b46765ae805537053C59f826C3aD61924Db45',
+    deployBlock: 28050250,
     subgraph:
       'https://api.thegraph.com/subgraphs/name/umaprotocol/avalanche-optimistic-governor'
   }

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -103,7 +103,9 @@ const findProposalGql = async (
   const subgraph = getOptimisticGovernorSubgraph(network);
   const request = `
   {
-    proposals(where:{proposalHash:"${params.proposalHash}",explanation:"${params.explanation}",optimisticGovernor:"${params.ogAddress}"}){
+    proposals(where:{proposalHash:"${params.proposalHash}",explanation:"${
+    params.explanation
+  }",optimisticGovernor:"${params.ogAddress.toLowerCase()}"}){
       id
       executed
       assertionId

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -18,7 +18,7 @@ import filter from 'lodash/filter';
 
 function getDeployBlock(network: string, name: string): number {
   const data = filter(contractData, { network, name });
-  if (data.length === 1) return data[0].deployBlock;
+  if (data.length === 1) return data[0].deployBlock ?? 0;
   return 0;
 }
 function getContractSubgraph(search: {
@@ -103,7 +103,7 @@ const findProposalGql = async (
   const subgraph = getOptimisticGovernorSubgraph(network);
   const request = `
   {
-    proposals(where:{proposalHash:"${params.proposalHash}",explanation:"${params.explanation}",ogAddress:"${params.ogAddress}"}){
+    proposals(where:{proposalHash:"${params.proposalHash}",explanation:"${params.explanation}",optimisticGovernor:"${params.ogAddress}"}){
       id
       executed
       assertionId
@@ -249,7 +249,7 @@ export const getModuleDetailsUma = async (
   // this needs to be optimized to reduce loading time, currently takes a long time to parse 3k blocks at a time.
   const oGstartBlock = getDeployBlock(network, 'OptimisticGovernor');
   const oOStartBlock = getDeployBlock(network, 'OptimisticOracleV3');
-  const maxRange = network === '1' || network === '5' ? 3000 : 10000;
+  const maxRange = 3000;
 
   const [assertionEvents, transactionsProposedEvents, executionEvents] =
     await Promise.all([


### PR DESCRIPTION
### Issues
There were a few bugs discovered when we made breaking changes to our OG subgraph. This error caused us to fallback to web3 calls, which then also failed for some chains, discovered on gnosis chain.
1. if contract start blocks were not defined, this would cause an error with paging in events
2. once that was fixed, the block range for gnosis chain was too long (10000) so now its reduced to 3000 for all chains

### Changes 
This primarily fixes the broken subgraph call, secondarily fixes some of the web3 fallback logic when paging in events.

### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. visit https://snapshot.org/#/umadev.eth/proposal/0xdf579f44cdc6a956720f260778939b178b654069ae3262fbe03eca9c710f3df9
and see that theres an error loading the proposal button
2. visit this in the updated deployment and see that it works

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain

### Additional notes or considerations
*_(Include any other relevant information or context that may be helpful for the reviewer)_*

