### PR TITLE
fix: fix email notifications label in menu account

### DIFF
--- a/src/components/MenuAccount.vue
+++ b/src/components/MenuAccount.vue
@@ -53,7 +53,7 @@ function handleAction(e) {
           extras: { icon: 'switch' }
         },
         {
-          text: t('emailSubscription.title'),
+          text: 'Email notifications',
           action: 'subscribeEmail',
           extras: { icon: 'mail' }
         },


### PR DESCRIPTION
Change label from `Email subscriptions` to `Email notifications` in account menu