### PR TITLE
fix: upgrade to pineapple@1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@sentry/vue": "^7.55.2",
     "@shutter-network/shutter-crypto": "0.1.0-beta.3",
     "@snapshot-labs/lock": "^0.2.0",
-    "@snapshot-labs/pineapple": "^0.2.0",
+    "@snapshot-labs/pineapple": "^1.0.1",
     "@snapshot-labs/snapshot.js": "^0.5.8",
     "@snapshot-labs/tune": "^0.1.33",
     "@vue/apollo-composable": "4.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@sentry/vue": "^7.55.2",
     "@shutter-network/shutter-crypto": "0.1.0-beta.3",
     "@snapshot-labs/lock": "^0.2.0",
-    "@snapshot-labs/pineapple": "^1.0.1",
+    "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/snapshot.js": "^0.5.8",
     "@snapshot-labs/tune": "^0.1.33",
     "@vue/apollo-composable": "4.0.0-beta.4",

--- a/src/composables/useImageUpload.ts
+++ b/src/composables/useImageUpload.ts
@@ -43,18 +43,12 @@ export function useImageUpload() {
     try {
       const receipt = await pin(formData, import.meta.env.VITE_PINEAPPLE_URL);
 
-      if (receipt.error) {
-        imageUploadError.value = receipt.error.message;
-        isUploadingImage.value = false;
-        return;
-      }
-
       imageUrl.value = `ipfs://${receipt.cid}`;
       imageName.value = file.name;
       onSuccess({ name: file.name, url: imageUrl.value });
-    } catch (err) {
+    } catch (err: any) {
       notify(['red', t('notify.somethingWentWrong')]);
-      imageUploadError.value = (err as Error).message;
+      imageUploadError.value = err.error?.message || err;
     } finally {
       isUploadingImage.value = false;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,10 +1862,10 @@
     "@walletconnect/modal" "^2.5.4"
     fortmatic "^2.2.1"
 
-"@snapshot-labs/pineapple@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/pineapple/-/pineapple-1.0.1.tgz#fbf4696bdf8be06cc45f722e1109c9dac899f02e"
-  integrity sha512-bBazy4gsRYjhZqvK3ZDmmS4YOsttPFBEa5Loz2lT/rqICjm1gON72t4IoTKnBCqx6zwxBhQs8UsWy9ugD8AYrA==
+"@snapshot-labs/pineapple@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/pineapple/-/pineapple-1.1.0.tgz#cccd1b8c81889b2109a46fddc362908493a8c07c"
+  integrity sha512-LIWmpdO3UF8WhKSlMkGsnCk2eY8KktVUS+qhMWIpXI+ffv0KTSBEnUj7J0v8baoOgSfv1u9HIgG+V2zJFrdk1w==
   dependencies:
     ofetch "^1.3.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,12 +1862,12 @@
     "@walletconnect/modal" "^2.5.4"
     fortmatic "^2.2.1"
 
-"@snapshot-labs/pineapple@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/pineapple/-/pineapple-0.2.0.tgz#b7005baa1ee6b56d446668972fe52b420fa12357"
-  integrity sha512-qphtrQQVYyDVbviak2Zluuh73SWaQFnG9+K/oLsSKSLg0TQmrY8aYxxjDipOTtX0Oyz7+OWYaADZ37gVyp/JxA==
+"@snapshot-labs/pineapple@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/pineapple/-/pineapple-1.0.1.tgz#fbf4696bdf8be06cc45f722e1109c9dac899f02e"
+  integrity sha512-bBazy4gsRYjhZqvK3ZDmmS4YOsttPFBEa5Loz2lT/rqICjm1gON72t4IoTKnBCqx6zwxBhQs8UsWy9ugD8AYrA==
   dependencies:
-    cross-fetch "^3.1.5"
+    ofetch "^1.3.3"
 
 "@snapshot-labs/snapshot.js@^0.5.8":
   version "0.5.8"
@@ -6360,6 +6360,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
+
+destr@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.1.tgz#2fc7bddc256fed1183e03f8d148391dde4023cb2"
+  integrity sha512-M1Ob1zPSIvlARiJUkKqvAZ3VAqQY6Jcuth/pBKQ2b1dX/Qx0OnJ8Vux6J2H5PTMQeRzWrrbTu70VxBfv/OPDJA==
 
 destroy@1.2.0:
   version "1.2.0"
@@ -11378,6 +11383,11 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
+node-fetch-native@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.4.0.tgz#fbe8ac033cb6aa44bd106b5e4fd2b6277ba70fa1"
+  integrity sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==
+
 node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -11623,6 +11633,15 @@ obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
+ofetch@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.3.3.tgz#588cb806a28e5c66c2c47dd8994f9059a036d8c0"
+  integrity sha512-s1ZCMmQWXy4b5K/TW9i/DtiN8Ku+xCiHcjQ6/J/nDdssirrQNOoB165Zu8EqLMA2lln1JUth9a0aW9Ap2ctrUg==
+  dependencies:
+    destr "^2.0.1"
+    node-fetch-native "^1.4.0"
+    ufo "^1.3.0"
 
 on-exit-leak-free@^0.2.0:
   version "0.2.0"
@@ -14728,6 +14747,11 @@ ufo@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.1.2.tgz#d0d9e0fa09dece0c31ffd57bd363f030a35cfe76"
   integrity sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==
+
+ufo@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.3.0.tgz#c92f8ac209daff607c57bbd75029e190930a0019"
+  integrity sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==
 
 uint8arrays@^3.0.0, uint8arrays@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
### Issues

Pineapple.js library throw an error on network error, and return a Promise rejection on pineapple server error. This duplicate the error handling process.

### Changes 

1. Upgrade pineapple.js to v1, which now return a Promise rejection following the same format for pineapple server error, as well as network error. This introduce no new features, just  remove the duplicate error handling.

### How to test

1. Upload an image invalid image
2. It should show an error (from pineapple)
3. Switch off internet, and upload an image
4. It should show an error (network error)
5. Set the pineapple backend url to a 404 url
6. It should show a "Not Found" error message

Both errors should appear in the same format

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
- [ ] I have tested my changes on a custom domain
