### PR TITLE
fix: Rename develop to master branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 'develop' ]
+    branches: [ 'master' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ 'develop' ]
+    branches: [ 'master' ]
   schedule:
     - cron: '36 5 * * 6'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       # Checks-out repo on develop branch
       - uses: actions/checkout@v3
         with:
-          ref: 'develop'
+          ref: 'master'
       # Overwrite target
       - run: |
           git checkout -b ${{ github.event.inputs.target }}

--- a/src/components/BasePluginItem.vue
+++ b/src/components/BasePluginItem.vue
@@ -36,7 +36,7 @@ defineProps<{
       </div>
 
       <BaseLink
-        :link="`https://github.com/snapshot-labs/snapshot/tree/develop/src/plugins/${plugin.key}`"
+        :link="`https://github.com/snapshot-labs/snapshot/tree/master/src/plugins/${plugin.key}`"
         @click.stop
       >
         {{ $t('learnMore') }}

--- a/src/plugins/commentBox/plugin.json
+++ b/src/plugins/commentBox/plugin.json
@@ -2,6 +2,6 @@
   "name": "Comment Box",
   "version": "0.0.1",
   "author": "spiritbro1",
-  "website": "https://github.com/snapshot-labs/snapshot/tree/develop/src/plugins/commentBox",
+  "website": "https://github.com/snapshot-labs/snapshot/tree/master/src/plugins/commentBox",
   "icon": "ipfs://QmWpLpFpeQ3iH69uCeXXAfLu56YaL9mNESMGfeJ5XSpkhY"
 }

--- a/src/plugins/hal/plugin.json
+++ b/src/plugins/hal/plugin.json
@@ -2,6 +2,6 @@
   "name": "HAL",
   "version": "1.0.0",
   "author": "hal.xyz",
-  "website": "https://github.com/snapshot-labs/snapshot/tree/develop/src/plugins/hal",
+  "website": "https://github.com/snapshot-labs/snapshot/tree/master/src/plugins/hal",
   "icon": "ipfs://QmUjiGPfzTUT6KZJe2iDNtca9XnuVw9iXwQUB2ncCLSoMK"
 }

--- a/src/plugins/poap/plugin.json
+++ b/src/plugins/poap/plugin.json
@@ -2,6 +2,6 @@
   "name": "Poap Module",
   "version": "1.0.0",
   "author": "Poap-xyz",
-  "website": "https://github.com/snapshot-labs/snapshot/tree/develop/src/plugins/poap",
+  "website": "https://github.com/snapshot-labs/snapshot/tree/master/src/plugins/poap",
   "icon": "ipfs://QmSH2PsJUSpHUwS9XAoqLKRvF7qibrsqmBTdmM9Mmyv5fb"
 }

--- a/src/plugins/projectGalaxy/plugin.json
+++ b/src/plugins/projectGalaxy/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Galxe",
   "description": "Galxe OAT",
-  "website": "https://github.com/snapshot-labs/snapshot/tree/develop/src/plugins/projectGalaxy",
+  "website": "https://github.com/snapshot-labs/snapshot/tree/master/src/plugins/projectGalaxy",
   "icon": "https://ipfs.io/ipfs/bafkreibjxoeegwucimd4hjfn3xmxrmkes3je5gwa723gaqosirzgewutfq",
   "defaults": {
     "space": {

--- a/src/plugins/quorum/plugin.json
+++ b/src/plugins/quorum/plugin.json
@@ -2,7 +2,7 @@
   "name": "Quorum",
   "version": "0.1.0",
   "author": "lbeder",
-  "website": "https://github.com/snapshot-labs/snapshot/tree/develop/src/plugins/quorum",
+  "website": "https://github.com/snapshot-labs/snapshot/tree/master/src/plugins/quorum",
   "icon": "ipfs://Qmbyq2emXpjv1oFFJnhS3jL8aXZAqnya7zmNtKYXEs8jXa",
   "defaults": {
     "space": {


### PR DESCRIPTION
Recently we renamed our default branch from develop to master, so better if we change the code references 