### PR TITLE
fix: Strategy form Listbox not showing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@snapshot-labs/lock": "^0.2.0",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/snapshot.js": "^0.7.3",
-    "@snapshot-labs/tune": "^0.1.33",
+    "@snapshot-labs/tune": "^0.1.34",
     "@vue/apollo-composable": "4.0.0-beta.4",
     "@vueuse/core": "^10.4.0",
     "@vueuse/head": "^1.3.1",


### PR DESCRIPTION
### Issues
*_(Include references to issues that this PR addresses)_*

Fixes https://discord.com/channels/955773041898573854/1030772384308932608/1159426982942093353

### Changes 
*_(Briefly describe the changes made in this PR)_*

1. Update Tune with fixed Listbox dropdown
<img width="459" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/51686767/442889ef-a869-4b6b-8703-bd74ac1d1632">


### How to test
*_(Explain how the changes can be tested, including any required setup steps)_*

1. Go to strategies and add `aave-governance-power` strategy
2. Click `Add` without filling out any fields
3. See error message
