### PR TITLE
fix(ui): improve playground error message readability

### DIFF
--- a/src/views/PlaygroundView.vue
+++ b/src/views/PlaygroundView.vue
@@ -247,10 +247,10 @@ function handleNetworkSelect(value) {
             />
             <BaseBlock
               v-if="strategyError"
+              class="mt-3 overflow-x-auto"
               style="border-color: red !important"
             >
-              <BaseIcon name="warning" class="mr-2 !text-red" />
-              <span class="!text-red"> {{ strategyError }}</span>
+              <pre class="!text-red whitespace-pre-wrap"> {{ strategyError }}</pre>
             </BaseBlock>
           </BaseBlock>
           <BaseBlock :title="$t('addresses')">


### PR DESCRIPTION
### Summary

The playground error message readability can be improved. It currently looks like:

![Screenshot 2023-10-11 at 10 31 21](https://github.com/snapshot-labs/snapshot/assets/495709/c541b362-7249-4361-afc9-bee2eea45302)

Most of the error messages will come in a JSON-RPC format (default error response returned by the snapshot.js SDK), we should pretty print the JSON like

![Screenshot 2023-10-11 at 10 31 50](https://github.com/snapshot-labs/snapshot/assets/495709/b114fab6-824f-43cb-ad59-3d8b565654a7)


### How to test

1. Go to the playground
2. Trigger any scenario with error messages (test this one: https://snapshot-git-improve-playground-error-ui-snapshot.vercel.app/#/playground/erc20-balance-of?query=eyJwYXJhbXMiOnsic3ltYm9sIjoiQlJQIiwiYWRkcmVzcyI6IjB4QUI3ODExODhkNEY0MWYzNmVmRmY1MDc3OERDODczZjY4Rjk3ZTkzOSIsImRlY2ltYWxzIjo0fSwibmV0d29yayI6IjgwMDAxIiwic25hcHNob3QiOiIifQ..)
3. The error messages should shown pretty printed

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
