### PR TITLE
fix: Increase votes loaded to fix voted indicator not showing

### DIFF
--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -351,7 +351,7 @@ export const PROFILES_QUERY = gql`
 
 export const USER_VOTED_PROPOSAL_IDS_QUERY = gql`
   query Votes($voter: String!, $proposals: [String]!) {
-    votes(where: { voter: $voter, proposal_in: $proposals }) {
+    votes(first: 1000, where: { voter: $voter, proposal_in: $proposals }) {
       proposal {
         id
       }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fixes https://discord.com/channels/955773041898573854/1037286915549958164/1162138062223061055

Before we were loading only the last 20 votes of the user, in this PR we increase it to 1000.

### How to test

1. Go to a space where you have voted on many proposal over the past weeks, see if the voted indicator appears on all the proposal as you scroll down


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
