### PR TITLE
fix: Clickable reasons links and link previews

### DIFF
--- a/src/components/BaseMarkdown.vue
+++ b/src/components/BaseMarkdown.vue
@@ -3,6 +3,7 @@ import { Remarkable } from 'remarkable';
 import { linkify } from 'remarkable/linkify';
 // import sanitizeHtml from 'sanitize-html';
 import { getIpfsUrl } from '@/helpers/utils';
+import { isSnapshotUrl } from '@/helpers/utils';
 
 const props = defineProps<{
   body: string;
@@ -34,7 +35,11 @@ const markdown = computed(() => {
 function handleLinkClick(e, url) {
   e.preventDefault();
   clickedUrl.value = url;
-  if (url.includes('snapshot.org/#/')) return handleConfirm();
+
+  if (isSnapshotUrl(url)) {
+    return handleConfirm();
+  }
+
   showModal.value = true;
 }
 

--- a/src/components/SpaceProposalVotesListItem.vue
+++ b/src/components/SpaceProposalVotesListItem.vue
@@ -112,11 +112,11 @@ useTippy(refReasonTooltip, {
           </div>
         </template>
       </BasePopover>
-      <div ref="refReasonTooltip">
-        <BaseButtonIcon
-          v-if="vote.reason !== '' && props.proposal.privacy !== 'shutter'"
-          class="cursor-default p-0"
-        >
+      <div
+        v-if="vote.reason !== '' && props.proposal.privacy !== 'shutter'"
+        ref="refReasonTooltip"
+      >
+        <BaseButtonIcon class="cursor-default p-0">
           <i-ho-annotation class="text-[16px]" />
         </BaseButtonIcon>
       </div>

--- a/src/components/SpaceProposalVotesListItem.vue
+++ b/src/components/SpaceProposalVotesListItem.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import { ExtendedSpace, Proposal, Vote, Profile } from '@/helpers/interfaces';
-import { shorten, getIpfsUrl, urlify } from '@/helpers/utils';
+import { shorten, getIpfsUrl } from '@/helpers/utils';
+import { useTippy } from 'vue-tippy';
+import TextAutolinker from './TextAutolinker.vue';
 
 const props = defineProps<{
   space: ExtendedSpace;
@@ -12,6 +14,7 @@ const props = defineProps<{
 defineEmits(['openReceiptModal']);
 
 const relayerIpfsHash = ref('');
+const refReasonTooltip = ref();
 
 const titles = computed(() =>
   props.proposal.strategies.map(strategy => strategy.params.symbol || '')
@@ -22,6 +25,12 @@ const { formatCompactNumber } = useIntl();
 const balanceFormatted = computed(() => {
   const balance = formatCompactNumber(props.vote.balance);
   return balance.length >= 8 ? shorten(balance) : balance;
+});
+
+useTippy(refReasonTooltip, {
+  content: h(TextAutolinker, { text: props.vote.reason }),
+  interactive: true,
+  theme: 'urlified'
 });
 </script>
 
@@ -103,18 +112,14 @@ const balanceFormatted = computed(() => {
           </div>
         </template>
       </BasePopover>
-      <BaseButtonIcon
-        v-if="vote.reason !== '' && props.proposal.privacy !== 'shutter'"
-        v-tippy="{
-          content: urlify(vote.reason.replace(/^[\s\n]+|[\s\n]+$/g, '')),
-          allowHTML: false,
-          interactive: true,
-          theme: 'urlified'
-        }"
-        class="cursor-default p-0"
-      >
-        <i-ho-annotation class="text-[16px]" />
-      </BaseButtonIcon>
+      <div ref="refReasonTooltip">
+        <BaseButtonIcon
+          v-if="vote.reason !== '' && props.proposal.privacy !== 'shutter'"
+          class="cursor-default p-0"
+        >
+          <i-ho-annotation class="text-[16px]" />
+        </BaseButtonIcon>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/TextAutolinker.vue
+++ b/src/components/TextAutolinker.vue
@@ -23,7 +23,19 @@ const textWithLinks = computed(() =>
 function handleLinkClick(e, url) {
   e.preventDefault();
   clickedUrl.value = url;
-  if (url.includes('snapshot.org/#/')) return handleConfirm();
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (err) {
+    console.error('Invalid URL', err);
+    return;
+  }
+
+  if (parsedUrl.hostname === 'snapshot.org') {
+    return handleConfirm();
+  }
+
   showModal.value = true;
 }
 

--- a/src/components/TextAutolinker.vue
+++ b/src/components/TextAutolinker.vue
@@ -8,15 +8,47 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   truncate: 0
 });
+
+const textAutolinker = ref();
+const showModal = ref(false);
+const clickedUrl = ref('');
+
 const textWithLinks = computed(() =>
   Autolinker.link(props.text, {
     truncate: props.truncate,
     sanitizeHtml: true
   })
 );
+
+function handleLinkClick(e, url) {
+  e.preventDefault();
+  clickedUrl.value = url;
+  if (url.includes('snapshot.org/#/')) return handleConfirm();
+  showModal.value = true;
+}
+
+function handleConfirm() {
+  window.open(clickedUrl.value, '_blank', 'noopener,noreferrer');
+}
+
+onMounted(() => {
+  textAutolinker.value.querySelectorAll('a[href]').forEach(function (link) {
+    link.addEventListener('click', function (e) {
+      handleLinkClick(e, link.getAttribute('href'));
+    });
+  });
+});
 </script>
 
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <span v-html="textWithLinks" />
+  <span ref="textAutolinker" v-html="textWithLinks" />
+  <Teleport to="#modal">
+    <ModalLinkPreview
+      :open="showModal"
+      :clicked-url="clickedUrl"
+      @close="showModal = false"
+      @confirm="handleConfirm"
+    />
+  </Teleport>
 </template>

--- a/src/components/TextAutolinker.vue
+++ b/src/components/TextAutolinker.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Autolinker from 'autolinker';
+import { isSnapshotUrl } from '@/helpers/utils';
 
 interface Props {
   text: string;
@@ -24,15 +25,7 @@ function handleLinkClick(e, url) {
   e.preventDefault();
   clickedUrl.value = url;
 
-  let parsedUrl;
-  try {
-    parsedUrl = new URL(url);
-  } catch (err) {
-    console.error('Invalid URL', err);
-    return;
-  }
-
-  if (parsedUrl.hostname === 'snapshot.org') {
+  if (isSnapshotUrl(url)) {
     return handleConfirm();
   }
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -165,3 +165,19 @@ export async function resolveLens(handle: string) {
     return null;
   }
 }
+
+export function isSnapshotUrl(url: string) {
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (err) {
+    console.error('Invalid URL', err);
+    return;
+  }
+
+  if (parsedUrl.hostname === 'snapshot.org') {
+    return true;
+  }
+
+  return false;
+}

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -121,14 +121,6 @@ export async function clearStampCache(id: string, type = 'space') {
     return await fetch(`https://cdn.stamp.fyi/clear/avatar/eth:${id}`);
 }
 
-export function urlify(text: string, target = '_blank') {
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
-  return text.replace(
-    urlRegex,
-    `<a href="$1" target="${target}" rel="noopener">$1</a>`
-  );
-}
-
 export async function resolveEns(handle: string) {
   try {
     const broviderUrl = import.meta.env.VITE_BROVIDER_URL;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fixes https://discord.com/channels/955773041898573854/1031838169282392144/1162028062846746666

1. Instead of disabling HTML in the reason tooltip, we use TextAutolinker component which sensitizes the HTML and prevents attacks.
2. Added link preview to TextAutolinker so when the link is clicked it will also show a modal with the real link before opening, this prevents hiding malicious links inside the HTML.

### How to test

1. Go to `testsnap.eth/proposal/0xcc3b8b204d80e86a95248e23bfa674ebbbe4315875a35f91892f2c96089b0a51`

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
