### PR TITLE
fix: Show error if user reach follow limit

### DIFF
--- a/src/composables/useFollowSpace.ts
+++ b/src/composables/useFollowSpace.ts
@@ -11,7 +11,10 @@ export function useFollowSpace(spaceId: any = {}) {
   const { modalAccountOpen } = useModal();
   const { apolloQuery } = useApolloQuery();
   const { setAlias, aliasWallet, isValidAlias, checkAlias } = useAliasAction();
+  const { notifyModal } = useModalNotification();
   const { toggleSubscription, isSubscribed } = useSpaceSubscription(spaceId);
+  const { notify } = useFlashNotification();
+  const { t } = useI18n();
 
   const loadingFollow = ref('');
 
@@ -82,9 +85,10 @@ export function useFollowSpace(spaceId: any = {}) {
         await loadFollows();
         loadingFollow.value = '';
       }
-    } catch (e) {
+    } catch (e: any) {
       loadingFollow.value = '';
       console.error(e);
+      notify(['red', e?.error_description ? `Oops, ${e.error_description}` : t('notify.somethingWentWrong')]);
     }
   }
 

--- a/src/composables/useFollowSpace.ts
+++ b/src/composables/useFollowSpace.ts
@@ -11,7 +11,6 @@ export function useFollowSpace(spaceId: any = {}) {
   const { modalAccountOpen } = useModal();
   const { apolloQuery } = useApolloQuery();
   const { setAlias, aliasWallet, isValidAlias, checkAlias } = useAliasAction();
-  const { notifyModal } = useModalNotification();
   const { toggleSubscription, isSubscribed } = useSpaceSubscription(spaceId);
   const { notify } = useFlashNotification();
   const { t } = useI18n();


### PR DESCRIPTION
### Summary
Right now we are not displaying any errors if `follow` action return any error, this is effecting a case while user trying to follow more spaces than the limit

### How to test

1. Go to the home page
2. follow 26 spaces
3. you should see the error like below now
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/fc429fc7-a58e-4ae2-aa26-9e270f633b5c)


Or 

1. Go to the home page 
2. Disable network
3. Try following a space
5. you should see an error now


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
