### PR TITLE
fix: Don't use space level voting.quorum

### DIFF
--- a/src/composables/useQuorum.ts
+++ b/src/composables/useQuorum.ts
@@ -32,8 +32,8 @@ export function useQuorum(props: QuorumProps) {
   });
 
   async function getQuorum(web3: any, quorumOptions: any, snapshot: string) {
-    if (props.proposal?.quorum || props.space.voting?.quorum) {
-      return props.proposal?.quorum || props.space.voting?.quorum;
+    if (props.proposal?.quorum) {
+      return props.proposal?.quorum;
     }
 
     if (!quorumOptions) return 0;


### PR DESCRIPTION
### Summary

Right now:
Two possibilities when we display quorum on UI:

- `proposal.quorum`
- `space.plugins.quorum`


But there are three possibilities to calculate quorum (order of priority)

1. `proposal.quorum`
2. `space.voting.quorum`
3. `space.plugins.quorum`

So removing the `space.voting.quorum` will solve our problems 

### How to test

1. Update your space settings to have only `space.plugins.quorum`
2. Create a new proposal
3. Notice that the quorum section displays a value from `space.plugins.quorum`
4. Update space settings with `space.voting.quorum` 
5. Create a new proposal
6. Notice that the new proposal will calculate quorum with `proposal.quorum`
7. Now go back to the previous proposal we created
    -  Notice that it uses `space.voting.quorum` instead of `space.plugins.quorum`
    - With this fix, it will use `space.plugins.quorum` as it is supposed to
