### PR TITLE
fix: Load follows on custom domain

### DIFF
--- a/src/components/ButtonFollow.vue
+++ b/src/components/ButtonFollow.vue
@@ -6,15 +6,27 @@ const props = defineProps<{
   primary?: boolean;
 }>();
 
+const { domain } = useApp();
 const { isGnosisSafe } = useClient();
+const { web3Account } = useWeb3();
 const { modalTermsOpen, termsAccepted, acceptTerms } = useTerms(props.space.id);
-const { clickFollow, loadingFollow, isFollowing } = useFollowSpace(
+const { clickFollow, loadingFollow, isFollowing, loadFollows } = useFollowSpace(
   props.space.id
 );
 
 const canFollow = computed(() =>
   props.space.terms ? termsAccepted.value || isFollowing.value : true
 );
+
+watch(
+  web3Account,
+  () => {
+    // Only for custom domain, else follows are loaded on sidebar
+    domain && loadFollows(props.space.id);
+  },
+  { immediate: true }
+);
+
 </script>
 
 <template>

--- a/src/composables/useFollowSpace.ts
+++ b/src/composables/useFollowSpace.ts
@@ -27,7 +27,7 @@ export function useFollowSpace(spaceId: any = {}) {
     )
   );
 
-  async function loadFollows() {
+  async function loadFollows(spaceId: string | undefined = undefined) {
     const { isAuthenticated } = getInstance();
 
     if (!isAuthenticated.value) return;
@@ -38,7 +38,8 @@ export function useFollowSpace(spaceId: any = {}) {
         {
           query: FOLLOWS_QUERY,
           variables: {
-            follower_in: web3Account.value
+            follower_in: web3Account.value,
+            space_in: spaceId ? [spaceId] : undefined
           }
         },
         'follows'

--- a/src/composables/useFollowSpace.ts
+++ b/src/composables/useFollowSpace.ts
@@ -27,7 +27,7 @@ export function useFollowSpace(spaceId: any = {}) {
     )
   );
 
-  async function loadFollows(spaceId: string | undefined = undefined) {
+  async function loadFollows(spaceId?: string) {
     const { isAuthenticated } = getInstance();
 
     if (!isAuthenticated.value) return;


### PR DESCRIPTION
### Summary
We are not loading follows on custom domain, so user are not able to see if they already follow a space or not
Closes: #4317 

### How to test

1. Checkout this branch in local
2. Add this to domains.json `"localhost": "zkswapfinance.eth"`
3. Click on "Join" button and reload, before fix you should see the "Join" button again after fix you should see the "Joined" button

### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
