### PR TITLE
fix: loadProfiles is called multiple times

### DIFF
--- a/src/components/NavbarAccount.vue
+++ b/src/components/NavbarAccount.vue
@@ -19,9 +19,10 @@ async function handleLogin(connector) {
 
 const profile = computed(() => profiles.value[web3Account.value]);
 
-watchEffect(() => {
+watch(web3Account, () => {
   loadProfiles([web3Account.value]);
 });
+
 </script>
 
 <template>

--- a/src/components/NavbarAccount.vue
+++ b/src/components/NavbarAccount.vue
@@ -22,7 +22,6 @@ const profile = computed(() => profiles.value[web3Account.value]);
 watch(web3Account, () => {
   loadProfiles([web3Account.value]);
 });
-
 </script>
 
 <template>


### PR DESCRIPTION
- With `watchEffect`: `loadProfiles` is being called multiple times (when the component is created and when `web3Account.value` is updated)
- With `watch`: `loadProfiles` will be called only when `web3Account.value` is updated

How to test:
- Go to snapshot.org
- Login with any wallet
- Notice the difference in number of network calls to brovider

Or in local add a comment in `loadProfiles` to see how many times it is being called