### PR TITLE
fix: disabled prop for voting date inputs

### DIFF
--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -192,14 +192,14 @@ defineEmits<{
           <SpaceCreateVotingDateStart
             :delay="space.voting?.delay"
             :date="dateStart"
-            :disabled="isEditing"
+            :disabled="isEditing || !!space.voting?.delay"
             @select="value => setDateStart(value)"
           />
 
           <SpaceCreateVotingDateEnd
             :period="space.voting?.period"
             :date="dateEnd"
-            :disabled="isEditing"
+            :disabled="isEditing || !!space.voting?.period"
             @select="value => setDateEnd(value)"
           />
         </div>

--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -192,14 +192,14 @@ defineEmits<{
           <SpaceCreateVotingDateStart
             :delay="space.voting?.delay"
             :date="dateStart"
-            :disabled="isEditing || !!space.voting?.delay"
+            :is-editing="isEditing"
             @select="value => setDateStart(value)"
           />
 
           <SpaceCreateVotingDateEnd
             :period="space.voting?.period"
             :date="dateEnd"
-            :disabled="isEditing || !!space.voting?.period"
+            :is-editing="isEditing"
             @select="value => setDateEnd(value)"
           />
         </div>

--- a/src/components/SpaceCreateVotingDateEnd.vue
+++ b/src/components/SpaceCreateVotingDateEnd.vue
@@ -4,6 +4,7 @@ const { d } = useI18n();
 const props = withDefaults(
   defineProps<{
     period?: number | null;
+    isEditing?: boolean;
     date: number;
   }>(),
   {
@@ -12,6 +13,7 @@ const props = withDefaults(
 );
 
 const dateString = computed(() => d(props.date * 1e3, 'short', 'en-US'));
+const isDisabled = computed(() => !!props.period || props.isEditing);
 
 const emit = defineEmits(['select']);
 </script>
@@ -20,9 +22,10 @@ const emit = defineEmits(['select']);
   <InputDate
     type="end"
     :title="$t(`create.end`)"
+    :disabled="isDisabled"
     :date="date"
     :date-string="dateString"
-    :tooltip="!!period ? $t('create.periodEnforced') : null"
+    :tooltip="(!!period && !isEditing) ? $t('create.periodEnforced') : null"
     @update:date="emit('select', $event)"
   />
 </template>

--- a/src/components/SpaceCreateVotingDateEnd.vue
+++ b/src/components/SpaceCreateVotingDateEnd.vue
@@ -25,7 +25,7 @@ const emit = defineEmits(['select']);
     :disabled="isDisabled"
     :date="date"
     :date-string="dateString"
-    :tooltip="(!!period && !isEditing) ? $t('create.periodEnforced') : null"
+    :tooltip="!!period && !isEditing ? $t('create.periodEnforced') : null"
     @update:date="emit('select', $event)"
   />
 </template>

--- a/src/components/SpaceCreateVotingDateEnd.vue
+++ b/src/components/SpaceCreateVotingDateEnd.vue
@@ -20,7 +20,6 @@ const emit = defineEmits(['select']);
   <InputDate
     type="end"
     :title="$t(`create.end`)"
-    :disabled="!!period"
     :date="date"
     :date-string="dateString"
     :tooltip="!!period ? $t('create.periodEnforced') : null"

--- a/src/components/SpaceCreateVotingDateStart.vue
+++ b/src/components/SpaceCreateVotingDateStart.vue
@@ -4,6 +4,7 @@ const { t, d } = useI18n();
 const props = withDefaults(
   defineProps<{
     delay?: number | null;
+    isEditing?: boolean;
     date: number;
   }>(),
   {
@@ -17,6 +18,7 @@ const dateString = computed(() =>
     ? t('create.now')
     : d(props.date * 1e3, 'short', 'en-US')
 );
+const isDisabled = computed(() => !!props.delay || props.isEditing);
 
 const emit = defineEmits(['select']);
 </script>
@@ -25,9 +27,10 @@ const emit = defineEmits(['select']);
   <InputDate
     type="start"
     :title="$t(`create.start`)"
+    :disabled="isDisabled"
     :date="date"
     :date-string="dateString"
-    :tooltip="!!delay ? $t('create.delayEnforced') : null"
+    :tooltip="(!!delay && !isEditing) ? $t('create.delayEnforced') : null"
     @update:date="emit('select', $event)"
   />
 </template>

--- a/src/components/SpaceCreateVotingDateStart.vue
+++ b/src/components/SpaceCreateVotingDateStart.vue
@@ -30,7 +30,7 @@ const emit = defineEmits(['select']);
     :disabled="isDisabled"
     :date="date"
     :date-string="dateString"
-    :tooltip="(!!delay && !isEditing) ? $t('create.delayEnforced') : null"
+    :tooltip="!!delay && !isEditing ? $t('create.delayEnforced') : null"
     @update:date="emit('select', $event)"
   />
 </template>

--- a/src/components/SpaceCreateVotingDateStart.vue
+++ b/src/components/SpaceCreateVotingDateStart.vue
@@ -25,7 +25,6 @@ const emit = defineEmits(['select']);
   <InputDate
     type="start"
     :title="$t(`create.start`)"
-    :disabled="!!delay"
     :date="date"
     :date-string="dateString"
     :tooltip="!!delay ? $t('create.delayEnforced') : null"


### PR DESCRIPTION
### Summary

### Problem: 
Date modal opens even if the space has a fixed voting delay and period, refer to the screen below

![Nov-09-2023 06-50-09](https://github.com/snapshot-labs/snapshot/assets/15967809/5f5e3eb4-5769-46fc-aadd-bd93d7805fd9)

### Expected:
Date buttons should be disabled and should not be clickable

### Why:
`SpaceCreateVotingDateEnd` and `SpaceCreateVotingDateStart` component is wrongly inheriting `disabled` property from the `SpaceCreateVoting` 

### How to test

1. Add voting delay and voting period on your space
2. Try creating a proposal
3. should see the date fields to be disabled and non-clickable
4. Also try editing the proposal, here date fields should be disabled irrespective of the voting period and delay
