### PR TITLE
fix: skip the confirm save modal when the user do not have permission

### DIFF
--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -168,15 +168,16 @@ const {
   cancel: cancelDelete
 } = useConfirmDialog();
 
-onBeforeRouteLeave(async () => {
-  if (hasFormChanged.value) {
-    const { data } = await openConfirmLeave();
-    if (!data) return false;
-  }
-});
 
 const isViewOnly = computed(() => {
   return !(isSpaceController.value || isSpaceAdmin.value);
+});
+
+onBeforeRouteLeave(async () => {
+  if (hasFormChanged.value && (isSpaceController.value || isSpaceAdmin.value)) {
+    const { data } = await openConfirmLeave();
+    if (!data) return false;
+  }
 });
 </script>
 

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -168,7 +168,6 @@ const {
   cancel: cancelDelete
 } = useConfirmDialog();
 
-
 const isViewOnly = computed(() => {
   return !(isSpaceController.value || isSpaceAdmin.value);
 });

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -173,7 +173,7 @@ const isViewOnly = computed(() => {
 });
 
 onBeforeRouteLeave(async () => {
-  if (hasFormChanged.value && (isSpaceController.value || isSpaceAdmin.value)) {
+  if (hasFormChanged.value && !isViewOnly.value) {
     const { data } = await openConfirmLeave();
     if (!data) return false;
   }


### PR DESCRIPTION
### Summary

When navigating the space settings page, and leaving after browsing the different tab (strategies, delegation, etc...), it sometimes open a confirmation modal dialog, asking to confirm if we want to leave, due to unsaved changes.

This confirmation modal should be presented only to users with write permission (space controller and admins), and is irrelevant to other users.

### How to test

1. Go to a space settings page you don't have permissions, e.g https://snapshot-git-skip-save-modal-when-no-permission-snapshot.vercel.app/#/stgdao.eth/settings
2. Go to delegation tab
3. input something in the inputs
4. Click on some link to leave the space settings
5. before fix, it should open the confirm dialog, after fix, it just leave.
6. Repeat the same on a space you have admin permission
7. on leave, it should open the confirm dialog

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
