### PR TITLE
fix: Build error with node 16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Node 16 is causing an error:

```
error lint-staged@15.1.0: The engine "node" is incompatible with this module. Expected version ">=18.12.0". Got "16.20.2"
error Found incompatible module.
```

Link here https://github.com/snapshot-labs/snapshot/actions/runs/6901813993/job/18777319524?pr=4368

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
