### PR TITLE
fix: Change testnet URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-VITE_HUB_URL=https://testnet.snapshot.org
-VITE_RELAYER_URL=https://testnet.snapshot.org
+VITE_HUB_URL=https://testnet.hub.snapshot.org
+VITE_RELAYER_URL=https://testnet.hub.snapshot.org
 VITE_SCORES_URL=https://score.snapshot.org
 VITE_ENVELOP_URL=https://core.envelop.fyi
 VITE_SIDEKICK_URL=https://sh5.co

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ yarn run lint
 
 Use `http://localhost:8080/#/fabien.eth` for testing your code.
 
-By default your instance will connect to the hub at `https://testnet.snapshot.org`. To change that (or other values) you can create a `.env.local` and overwrite the values from `.env`.
+By default your instance will connect to the hub at `https://testnet.hub.snapshot.org`. To change that (or other values) you can create a `.env.local` and overwrite the values from `.env`.
 
 ## Running service locally with Docker
 1. Run `docker build -t snapshot .` to build the image

--- a/src/helpers/clientEIP712.ts
+++ b/src/helpers/clientEIP712.ts
@@ -1,6 +1,7 @@
 import Client from '@snapshot-labs/snapshot.js/src/sign';
 
-const hubUrl = import.meta.env.VITE_HUB_URL || 'https://testnet.hub.snapshot.org';
+const hubUrl =
+  import.meta.env.VITE_HUB_URL || 'https://testnet.hub.snapshot.org';
 const relayerURL = import.meta.env.VITE_RELAYER_URL;
 const client = new Client(hubUrl, { relayerURL });
 

--- a/src/helpers/clientEIP712.ts
+++ b/src/helpers/clientEIP712.ts
@@ -1,6 +1,6 @@
 import Client from '@snapshot-labs/snapshot.js/src/sign';
 
-const hubUrl = import.meta.env.VITE_HUB_URL || 'https://testnet.snapshot.org';
+const hubUrl = import.meta.env.VITE_HUB_URL || 'https://testnet.hub.snapshot.org';
 const relayerURL = import.meta.env.VITE_RELAYER_URL;
 const client = new Client(hubUrl, { relayerURL });
 


### PR DESCRIPTION
Move to new URL 

TODO:
- [x] Update snapshot.js before merging this 
- [x] Merge after merging https://github.com/snapshot-labs/snapshot/pull/4370 
- [x] Update fleek
