### PR TITLE
fix: Show validation errors for proposal validation

### DIFF
--- a/src/components/ModalValidation.vue
+++ b/src/components/ModalValidation.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 
 const DEFAULT_PARAMS: Record<string, any> = {};
 
-const emit = defineEmits(['add', 'close']);
+const emit = defineEmits(['add', 'close', 'resetMinScore']);
 
 const { open } = toRefs(props);
 const { t } = useI18n();
@@ -75,6 +75,7 @@ function handleSelect(n: string) {
 
   if (n === 'any') {
     handleSubmit();
+    emit('resetMinScore');
   }
 
   if (n === 'basic') {

--- a/src/components/SettingsStrategiesBlock.vue
+++ b/src/components/SettingsStrategiesBlock.vue
@@ -6,6 +6,7 @@ import schemas from '@snapshot-labs/snapshot.js/src/schemas';
 const props = defineProps<{
   context: 'setup' | 'settings';
   title?: string;
+  showErrors?: boolean;
   isViewOnly?: boolean;
 }>();
 
@@ -113,6 +114,7 @@ function handleSubmitStrategy(strategy) {
       </div>
 
       <StrategiesBlockWarning
+        v-if="showErrors"
         :error="validationErrors?.strategies"
         :context="context"
       />

--- a/src/components/SettingsValidationBlock.vue
+++ b/src/components/SettingsValidationBlock.vue
@@ -3,10 +3,11 @@ import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 
 const props = defineProps<{
   context: 'setup' | 'settings';
+  showErrors?: boolean;
   isViewOnly?: boolean;
 }>();
 
-const { form } = useFormSpaceSettings(props.context);
+const { form, validationErrors } = useFormSpaceSettings(props.context);
 
 const modalValidationOpen = ref(false);
 
@@ -23,16 +24,14 @@ function handleClickSelectValidation() {
 <template>
   <BaseBlock :title="$t('settings.proposalValidation')">
     <div class="space-y-2">
-      <ContainerParallelInput>
-        <TuneButtonSelect
-          class="w-full"
-          :label="$t(`proposalValidation.label`)"
-          :hint="$t(`proposalValidation.information`)"
-          :model-value="$t(`proposalValidation.${form.validation.name}.label`)"
-          :disabled="form.filters.onlyMembers || isViewOnly"
-          @select="handleClickSelectValidation"
-        />
-      </ContainerParallelInput>
+      <TuneButtonSelect
+        class="w-full"
+        :label="$t(`proposalValidation.label`)"
+        :hint="$t(`proposalValidation.information`)"
+        :model-value="$t(`proposalValidation.${form.validation.name}.label`)"
+        :disabled="form.filters.onlyMembers || isViewOnly"
+        @select="handleClickSelectValidation"
+      />
 
       <TuneSwitch
         v-model="form.filters.onlyMembers"
@@ -40,6 +39,13 @@ function handleClickSelectValidation() {
         :label="$t('settings.allowOnlyAuthors')"
       />
     </div>
+    <BaseMessageBlock
+      v-if="validationErrors.validation && showErrors"
+      level="warning-red"
+      class="mt-4"
+    >
+      {{ $t('missingProposalValidationError') }}
+    </BaseMessageBlock>
     <teleport to="#modal">
       <ModalValidation
         :open="modalValidationOpen"

--- a/src/components/SettingsValidationBlock.vue
+++ b/src/components/SettingsValidationBlock.vue
@@ -48,6 +48,7 @@ function handleClickSelectValidation() {
         :filter-min-score="form.filters.minScore"
         @close="modalValidationOpen = false"
         @add="handleSubmitAddValidation"
+        @reset-min-score="form.filters.minScore = 0"
       />
     </teleport>
   </BaseBlock>

--- a/src/components/SetupExtras.vue
+++ b/src/components/SetupExtras.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
 const { isGnosisSafe } = useClient();
+const { validationErrors } = useFormSpaceSettings('setup');
 
 defineProps<{
   creatingSpace: boolean;
 }>();
 
-const emit = defineEmits(['next', 'back']);
+const emit = defineEmits(['submit', 'back']);
+
+const showErrors = ref(false);
+
+function handleSubmit() {
+  if (validationErrors.value.validation) return (showErrors.value = true);
+  emit('submit');
+}
 </script>
 
 <template>
@@ -31,13 +39,14 @@ const emit = defineEmits(['next', 'back']);
       {{ $t('setup.validationTitle') }}
     </h4>
     <SettingsMembersBlock context="setup" />
+    <SettingsValidationBlock context="setup" :show-errors="showErrors" />
   </div>
 
   <div class="px-4 md:px-0">
     <SetupButtonCreate
       :creating-space="creatingSpace"
       class="mt-4"
-      @create="emit('next')"
+      @create="handleSubmit"
     />
     <SetupButtonBack @click="emit('back')" />
   </div>

--- a/src/components/SetupStrategyAdvanced.vue
+++ b/src/components/SetupStrategyAdvanced.vue
@@ -3,9 +3,11 @@ const { validationErrors } = useFormSpaceSettings('setup');
 
 const emit = defineEmits(['next']);
 
+const showErrors = ref(false);
+
 function nextStep() {
   if (validationErrors.value.strategies || validationErrors.value.symbol)
-    return;
+    return (showErrors.value = true);
   emit('next');
 }
 </script>
@@ -15,7 +17,7 @@ function nextStep() {
     <SettingsStrategiesBlock
       context="setup"
       :title="$t('setup.strategy.blockTitle')"
-      hide-error
+      :show-errors="showErrors"
     />
     <div class="mx-4 md:mx-0">
       <SetupButtonNext @click="nextStep" />

--- a/src/composables/useFormSpaceSettings.ts
+++ b/src/composables/useFormSpaceSettings.ts
@@ -180,10 +180,22 @@ export function useFormSpaceSettings(context: 'setup' | 'settings') {
     }
   }
 
+  function validateProposalValidation(errors: any) {
+    const hasProposalValidation =
+      (form.value.validation?.name && form.value.validation.name !== 'any') ||
+      !!form.value.filters?.minScore ||
+      !!form.value.filters?.onlyMembers;
+
+    if (!hasProposalValidation) {
+      errors.validation = 'missingProposalValidationError';
+    }
+  }
+
   const validationErrors = computed(() => {
     const errors = validateForm(schemas.space, prunedForm.value);
 
     validateStrategies(errors);
+    validateProposalValidation(errors);
 
     return errors;
   });

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -15,6 +15,7 @@
   "resultsError": "Results could not be calculated. This is often due to a misconfigured strategy or an unresponsive RPC node involved in the strategy.",
   "ticketWithAnyOrBasicError": "In order to use the \"ticket\" strategy you are required to set a voting validation strategy. This combination reduces the risk of spam and sybil attacks. {article}",
   "ticketWithAnyOrBasicErrorSetup": "Use of the ticket strategy requires setting a voting validation strategy. To continue go one step back and select the \"One person, one vote\" option. {article}",
+  "missingProposalValidationError": "Proposal validation is required to prevent unauthorized proposals and spam. If you don't want proposal validation you can toggle only the \"Allow only authors to submit a proposal\" option.",
   "resultsCalculating": "Final results are being calculated. If you still see this message after a few minutes contact the space admin.",
   "votingPowerFailedMessage": "Your voting power could not be calculated. This is often due to a misconfigured strategy or an unresponsive RPC node involved in the strategy. If the problem persists, consider contacting the space admin or our support team on {discord}",
   "votingValidationFailedMessage": "We were not able to validate your eligibility to vote. This is often due to a misconfigured vote validation setting or an unresponsive RPC node. If the problem persists, consider contacting the space admin or our support team on {discord}",

--- a/src/views/SetupView.vue
+++ b/src/views/SetupView.vue
@@ -142,7 +142,7 @@ onMounted(() => {
           v-if="currentStep === Step.EXTRAS && route.params.ens"
           :creating-space="creatingSpace"
           @back="previousStep"
-          @next="handleSubmit"
+          @submit="handleSubmit"
         />
       </template>
     </template>

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -241,6 +241,7 @@ onBeforeRouteLeave(async () => {
             <SettingsStrategiesBlock
               context="settings"
               :is-view-only="isViewOnly"
+              :show-errors="showFormErrors"
             />
           </template>
 
@@ -248,6 +249,7 @@ onBeforeRouteLeave(async () => {
             <SettingsValidationBlock
               context="settings"
               :is-view-only="isViewOnly"
+              :show-errors="showFormErrors"
             />
             <SettingsProposalBlock
               context="settings"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Add proposal validation field to space setup and set validation.

On space creation and settings page we need to show errors for the recently enforced proposal validation rules. Errors also only show now after clicking "Save" or "Create".

Space setup:
<img width="1185" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/51686767/300e6d86-446b-4104-be99-ea9aa9ec41e4">

Space settings:
<img width="1186" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/51686767/d06bfc0a-1cfd-4391-87c3-3c4dd7ef4561">


### How to test

1. Select "Anyone can create" on setup and settings page. See error

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
