### PR TITLE
fix: Explore page is not using cached image

### DIFF
--- a/src/components/AvatarSpace.vue
+++ b/src/components/AvatarSpace.vue
@@ -15,7 +15,7 @@ const props = withDefaults(
 
 const avatarHash = computed(() => {
   if (!props.space?.avatar) return '';
-  const hash = sha256(props.space.avatar).slice(-32);
+  const hash = sha256(props.space.avatar).slice(0, 16);
   return `&cb=${hash}`;
 });
 </script>

--- a/src/components/AvatarSpace.vue
+++ b/src/components/AvatarSpace.vue
@@ -15,7 +15,7 @@ const props = withDefaults(
 
 const avatarHash = computed(() => {
   if (!props.space?.avatar) return '';
-  const hash = sha256(props.space.avatar).slice(0, 16);
+  const hash = sha256(props.space.avatar).slice(-32);
   return `&cb=${hash}`;
 });
 </script>

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -379,6 +379,7 @@ export const SPACES_RANKING_QUERY = gql`
       items {
         id
         name
+        avatar
         private
         verified
         categories


### PR DESCRIPTION
### Summary
You will see different image if you go to:
- https://snapshot.org/#/wen%F0%9F%8C%95.eth 
- https://snapshot.org/#/?q=volta+club+

This is because of a Stamp issue https://github.com/snapshot-labs/stamp/issues/119 - Not sure about the reason yet,

But the explore page is not using this cache because it is not querying the `avatar` param, It should be using the cached one like everywhere else


# How to test:

- Go to https://snapshot.org/#/?q=volta+club+
- Notice that space image will not contain a `cb` query, for example: https://cdn.stamp.fyi/space/stgdao.eth?s=164
- Go to https://snapshot-git-fix-avatar-issues-snapshot.vercel.app/#/
- Space Image will contain a query param `cb` like https://cdn.stamp.fyi/space/stgdao.eth?s=164&cb=7faee6797e3d57e7 