### PR TITLE
fix: fix missing keys in profiles

### DIFF
--- a/src/composables/useProfiles.ts
+++ b/src/composables/useProfiles.ts
@@ -53,7 +53,7 @@ export function useProfiles() {
         )
       ]);
       // add ens from profilesRes to corresponding address in profilesObj
-      Object.keys(profilesRes[0] ?? {}).forEach(address => {
+      addresses.forEach(address => {
         profilesRes[0][address] = {
           ...{ ens: profilesRes[0][address] },
           ...profilesRes[1]?.find(p => p.id === address)

--- a/src/composables/useProfiles.ts
+++ b/src/composables/useProfiles.ts
@@ -53,7 +53,7 @@ export function useProfiles() {
         )
       ]);
       // add ens from profilesRes to corresponding address in profilesObj
-      addresses.forEach(address => {
+      Object.keys(profilesRes[0] ?? {}).forEach(address => {
         profilesRes[0][address] = {
           ...{ ens: profilesRes[0][address] },
           ...profilesRes[1]?.find(p => p.id === address)

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -145,7 +145,7 @@ export async function lookupAddress(
   }
 
   try {
-    const results = await fetch(import.meta.env.VITE_STAMP_URL, {
+    const response = await fetch(import.meta.env.VITE_STAMP_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -153,7 +153,11 @@ export async function lookupAddress(
       body: JSON.stringify({ method: 'lookup_addresses', params: addresses })
     });
 
-    return (await results.json()).result;
+    const results = (await response.json()).result;
+
+    return Object.fromEntries(
+      addresses.map(address => [address, results[address] || ''])
+    );
   } catch (e) {
     console.error('Error resolving addresses:', e);
     return {};


### PR DESCRIPTION
Fix profile page such as https://snapshot.org/#/profile/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3 where the `useProfile` does not have the current profile address, thus the missing profile details.

This was due to stamp API not returning addresses without any associated domains.

After fix, profile should work https://snapshot-git-fix-profile-loading-snapshot.vercel.app/#/profile/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3