### PR TITLE
fix: limit number of addresses sent to API

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -150,7 +150,10 @@ export async function lookupAddress(
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ method: 'lookup_addresses', params: addresses })
+      body: JSON.stringify({
+        method: 'lookup_addresses',
+        params: addresses.slice(0, 250)
+      })
     });
 
     return (await results.json()).result;


### PR DESCRIPTION
Stamp API only accepts 250 addresses maximum. 

This PR cap the max addresses sent to stamp to 250 addresses