### PR TITLE
fix: Proposal validation error is not shown to Safe space creators

### DIFF
--- a/src/components/SetupExtras.vue
+++ b/src/components/SetupExtras.vue
@@ -24,8 +24,6 @@ function handleSubmit() {
 
     <SettingsVotingBlock context="setup" />
 
-    <SettingsValidationBlock context="setup" />
-
     <SettingsDomainBlock context="setup" />
 
     <SettingsSubSpacesBlock context="setup" />
@@ -33,6 +31,8 @@ function handleSubmit() {
     <SettingsTreasuriesBlock context="setup" />
 
     <SettingsPluginsBlock context="setup" />
+
+    <SettingsValidationBlock context="setup" :show-errors="showErrors" />
   </div>
   <div v-else class="space-y-4">
     <h4 class="-mb-2 px-4 md:px-0">


### PR DESCRIPTION
### Summary

While creating a space, "Proposal validation" is shown under  "Members"

But on safe it is entirely different as shown in screenshot 🤔  this is preventing Safes from creating spaces
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/62a3b333-feb3-4341-a03d-43346317423e)
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/c91be9a3-eff8-4edf-9f60-8b0a20a9e94b)


This is because we have different space creation flow for safe 
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/28384832-d744-421e-b31a-3a5dc35b2efd)
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/036e76bd-b023-4495-929e-b20485fba6c5)


### How to test
Easiest way to test this is: Replace these https://github.com/snapshot-labs/snapshot/blob/fix-validation-block-errors/src/composables/useGnosis.ts#L46-L50 with `true`
This will make your wallet look like a safe wallet
- Try creating a space, at the end click the "Create" button without adding proposal validation
- without fix: clicking on "create" will not do anything
- with fix: click on "Create" will show an error on the proposal validation block