### PR TITLE
fix: decrease max number of addresses

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -152,7 +152,7 @@ export async function lookupAddress(
       },
       body: JSON.stringify({
         method: 'lookup_addresses',
-        params: addresses.slice(0, 250)
+        params: addresses.slice(0, 50)
       })
     });
 


### PR DESCRIPTION
Following https://github.com/snapshot-labs/stamp/pull/134

Decrease the max number of addresses sent to stamp `lookupAddresses` endpoint