### PR TITLE
fix: Validate space settings on proposal creation

### DIFF
--- a/src/components/SpaceCreateWarnings.vue
+++ b/src/components/SpaceCreateWarnings.vue
@@ -5,6 +5,7 @@ const props = defineProps<{
   space: ExtendedSpace;
   validationFailed: boolean;
   isValidAuthor: boolean;
+  isValidSpace: boolean;
   validationName: string;
   containsShortUrl: boolean;
 }>();
@@ -42,6 +43,12 @@ const strategySymbolsString = computed(() => {
 <template>
   <div class="mb-4 space-y-2">
     <MessageWarningHibernated v-if="space.hibernated" :space="space" />
+
+    <BaseMessageBlock v-else-if="!isValidSpace" level="warning">
+      Proposal creation is blocked due to invalid space settings. Please contact
+      a space admin or if you are an admin head over to the settings page and
+      save them again.
+    </BaseMessageBlock>
 
     <MessageWarningGnosisNetwork
       v-else-if="isGnosisAndNotSpaceNetwork"

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -47,6 +47,8 @@ const { isGnosisAndNotSpaceNetwork } = useGnosis(props.space);
 const { isSnapshotLoading } = useSnapshot();
 const { apolloQuery, queryLoading } = useApolloQuery();
 const { containsShortUrl } = useShortUrls();
+const { isValid: isValidSpaceSettings, populateForm } =
+  useFormSpaceSettings('settings');
 
 const {
   form,
@@ -405,6 +407,8 @@ onBeforeRouteLeave(async () => {
     resetForm();
   }
 });
+
+onMounted(() => populateForm(props.space));
 </script>
 
 <template>
@@ -425,6 +429,7 @@ onBeforeRouteLeave(async () => {
         :space="space"
         :validation-failed="hasAuthorValidationFailed"
         :is-valid-author="isValidAuthor"
+        :is-valid-space="isValidSpaceSettings"
         :validation-name="validationName"
         :contains-short-url="formContainsShortUrl"
         data-testid="create-proposal-connect-wallet-warning"
@@ -494,7 +499,8 @@ onBeforeRouteLeave(async () => {
             hasAuthorValidationFailed ||
             validationLoading ||
             isGnosisAndNotSpaceNetwork ||
-            space.hibernated
+            space.hibernated ||
+            !isValidSpaceSettings
           "
           primary
           :data-testid="


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Add check on proposal creation if space settings are valid and show message how to fix it

### How to test

1. Go to `testsnap.eth/create`
2. See message 

### To-Do

- [x] Enforce the same on sequencer @wa0x6e  (https://github.com/snapshot-labs/snapshot-sequencer/pull/256)

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
