### PR TITLE
fix: Space deletion not working

### DIFF
--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -113,7 +113,7 @@ const settingsPages = computed(() => [
 async function handleDelete() {
   modalDeleteSpaceConfirmation.value = '';
 
-  const result = await send(props.space, 'delete-space', null);
+  const result = await send(props.space, 'delete-space', {});
   console.log(':handleDelete result', result);
 
   if (result && result.id) {


### PR DESCRIPTION
Users are getting the following error while deleting a space
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/906c9c6a-f357-409c-891e-fc1be82fa60c)

This is because we assume `payload` param to be a object and not null in `useClient.ts`


### How to test: 
- Go to space settings
- Go to `Advanced` -> Click on delete space -> Enter your space name name to confirm
- Before fix: you should see the error
- After fix: you should see the sign modal open (don't click on "sign" :D it is hard to recover your space)


Originally reported here https://discord.com/channels/707079246388133940/1178307743833133086/1178313172722126899