### PR TITLE
fix: Don't run votes query for default value

### DIFF
--- a/src/composables/useProposals.ts
+++ b/src/composables/useProposals.ts
@@ -54,7 +54,7 @@ export function useProposals() {
 
   const { apolloQuery } = useApolloQuery();
   async function getUserVotedProposalIds(voter: string, proposals: string[]) {
-    if (!voter || !proposals) return;
+    if (!voter || !proposals?.length) return;
     const votes = await apolloQuery(
       {
         query: USER_VOTED_PROPOSAL_IDS_QUERY,


### PR DESCRIPTION
## Issue 
Whenever we go to any [proposals page](https://snapshot.org/#/stgdao.eth) Notice that we are sending two queries to `votes` 

![image](https://github.com/snapshot-labs/snapshot/assets/15967809/5e4bf7eb-bf47-4f24-b047-d3dc1f0e099d)

this is because `getUserVotedProposalIds` is being called twice, once when proposals are loaded and once when the user account is changed, and here both are loaded at the same time so one request has empty array `[]`

Due to this, You may also notice this error 
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/503b91af-9927-48c3-9d46-72eb5227790b)
But it is related to https://github.com/snapshot-labs/snapshot-hub/issues/760
