### PR TITLE
fix: quorum placeholder in read-only mode is confusing

### DIFF
--- a/src/components/SettingsVotingBlock.vue
+++ b/src/components/SettingsVotingBlock.vue
@@ -32,7 +32,7 @@ const { form } = useFormSpaceSettings(props.context);
           :label="$t('settings.quorum.label')"
           :hint="$t('settings.quorum.information')"
           :disabled="isViewOnly"
-          placeholder="1000"
+          placeholder="0"
           type="number"
           @update:model-value="value => (form.voting.quorum = Number(value))"
         />


### PR DESCRIPTION
The placeholder on space settings (read-only mode) is confusing, It looks it got 1000 quorum 

Got to any space settings https://snapshot.org/#/stgdao.eth/settings got to voting -> quorum 
Before:
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/6a79de19-938e-4115-bf9b-3c196fa3690f)


After:
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/3cc34066-1d27-41e4-b014-2913888cdf88)
