### PR TITLE
fix: Ignore expired ENS domains on space creation

### DIFF
--- a/src/composables/useEns.ts
+++ b/src/composables/useEns.ts
@@ -25,8 +25,12 @@ export function useEns() {
 
     const domains = response.account?.domains || [];
     const wrappedDomains = response.account?.wrappedDomains || [];
-    const allDomains = [...domains, ...wrappedDomains];
-
+    let allDomains = [...domains, ...wrappedDomains];
+    // Filter out expired domains
+    const now = (Date.now() / 1000).toFixed(0);
+    allDomains = allDomains.filter(
+      domain => !domain.expiryDate || domain.expiryDate > now
+    );
     ownedEnsDomains.value = await fetchAllDomainData(allDomains);
   };
 

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -202,9 +202,11 @@ export const ENS_DOMAINS_BY_ACCOUNT_QUERY = gql`
     account(id: $id) {
       domains {
         name
+        expiryDate
       }
       wrappedDomains {
         name
+        expiryDate
       }
     }
   }


### PR DESCRIPTION
### Issue:

Right now we show expired domains while space creation, it is confusing

### How to test:

- Go to https://snapshot.org/#/setup?step=1 
- Login with https://guest.on.fleek.co/#/0x9c3aC02Cd616a82C83830e40D45c9534b32c4934
- You will see expired domains before fix
  <img width="726" alt="Untitled 3" src="https://github.com/snapshot-labs/snapshot/assets/15967809/063ca2a3-1e73-41ae-a3fb-ec35b91849c2">

