### PR TITLE
fix: Change link preview modal title and text

### DIFF
--- a/src/components/ModalLinkPreview.vue
+++ b/src/components/ModalLinkPreview.vue
@@ -14,7 +14,7 @@ defineEmits<{
   <!-- eslint-disable vue/no-v-html -->
   <ModalConfirmAction
     :open="open"
-    title="Link preview"
+    title="Proceed with caution!"
     show-cancel
     @close="$emit('close')"
     @confirm="$emit('confirm')"

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -47,7 +47,7 @@
   "warningFlaggedProposal": "This proposal might contain scams, offensive material, or be malicious in nature. Please proceed with caution.",
   "warningFlaggedSpace": "This space might contain scams, offensive material, or be malicious in nature. Please proceed with caution.",
   "warningFlaggedActionShow": "Show",
-  "linkPreview": "This link will take you to {url}.</br> Are you sure you want to continue?",
+  "linkPreview": "This link will take you to {url}.</br> Be careful, this link could be malicious. Are you sure you want to continue? ",
   "version": "Version",
   "timeline": "Timeline",
   "ended": "ended",


### PR DESCRIPTION
Right now we display this 
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/933f460a-be5f-4eff-ae00-1f36c601990d)

With this change 

![image](https://github.com/snapshot-labs/snapshot/assets/15967809/42cbaf89-a3e3-4f38-a22f-e738ad022cf4)


### How to test?

Click on any link in any proposal