### PR TITLE
fix: Profiles not loading with custom domain

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,5 @@
 <script setup>
-const { domain } = useApp();
-const { init, isReady, showSidebar } = useApp();
+const { domain, init, isReady, showSidebar } = useApp();
 const route = useRoute();
 const { restorePendingTransactions } = useTxStatus();
 

--- a/src/components/NavbarAccount.vue
+++ b/src/components/NavbarAccount.vue
@@ -18,10 +18,11 @@ async function handleLogin(connector) {
 }
 
 const profile = computed(() => profiles.value[web3Account.value]);
-
-watch(web3Account, () => {
-  loadProfiles([web3Account.value]);
-});
+watch(
+  () => web3Account,
+  () => loadProfiles([web3Account.value]),
+  { immediate: true }
+);
 </script>
 
 <template>


### PR DESCRIPTION
### Summary
With custom domains `loadProfiles` is not being called on the initial load, but without a custom domain `web3Account` is being updated 

Closes https://github.com/snapshot-labs/snapshot/issues/4352