### PR TITLE
chore: replace demo banner with testnet tag

### DIFF
--- a/src/components/TheNavbar.vue
+++ b/src/components/TheNavbar.vue
@@ -25,14 +25,13 @@ watch(
             <i-ho-menu class="text-skin-link" />
           </BaseButtonRound>
           <router-link
-            v-if="env === 'demo'"
             :to="{ path: '/' }"
             class="hidden items-center sm:block"
             style="font-size: 24px"
           >
             snapshot
           </router-link>
-          <span class="ml-1">testnet</span>
+          <span v-if="env === 'demo'" class="ml-1">testnet</span>
         </div>
         <div :key="web3Account" class="flex space-x-2">
           <NavbarAccount />

--- a/src/components/TheNavbar.vue
+++ b/src/components/TheNavbar.vue
@@ -3,7 +3,6 @@ const { pendingTransactions, pendingTransactionsWithHash } = useTxStatus();
 const { env, showSidebar, domain } = useApp();
 const { web3Account } = useWeb3();
 
-const showDemoBanner = ref(true);
 const showPendingTransactionsModal = ref(false);
 
 watch(
@@ -15,19 +14,6 @@ watch(
 </script>
 
 <template>
-  <div
-    v-if="env === 'demo' && showDemoBanner"
-    class="relative bg-skin-primary p-3 text-center"
-    style="color: white; font-size: 20px"
-  >
-    {{ $t('demoSite') }}
-    <BaseButtonIcon
-      class="absolute right-3 top-[10px]"
-      @click="showDemoBanner = false"
-    >
-      <i-ho-x />
-    </BaseButtonIcon>
-  </div>
   <div>
     <div class="px-3 sm:px-4">
       <div class="flex items-center py-[12px]">
@@ -39,12 +25,14 @@ watch(
             <i-ho-menu class="text-skin-link" />
           </BaseButtonRound>
           <router-link
+            v-if="env === 'demo'"
             :to="{ path: '/' }"
             class="hidden items-center sm:block"
             style="font-size: 24px"
           >
             snapshot
           </router-link>
+          <span class="ml-1">testnet</span>
         </div>
         <div :key="web3Account" class="flex space-x-2">
           <NavbarAccount />


### PR DESCRIPTION
I've removed the demo banner, it's too much highlighted, we have some users who use demo. to do production vote on testnet. I changed to a simple "testnet" label next to logo:

<img width="1469" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/16245250/6f7c3912-1128-44de-bbea-679ffaf788f1">
