### PR TITLE
chore: reduce proposal body limit to 10k chars

### DIFF
--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -14,7 +14,7 @@ enum Step {
   PLUGINS
 }
 
-const BODY_LIMIT_CHARACTERS = 20000;
+const BODY_LIMIT_CHARACTERS = 10000;
 
 const props = defineProps<{
   space: ExtendedSpace;


### PR DESCRIPTION
Reducing the proposal body limit from 20k to 10k chars. We will later propose extra limit with Turbo.