### PR TITLE
fix: Add tooltip to vote button

### DIFF
--- a/src/assets/css/tune.scss
+++ b/src/assets/css/tune.scss
@@ -52,7 +52,7 @@
     @apply border-skin-primary bg-skin-primary text-white hover:brightness-95;
 
     &:disabled {
-      @apply border-skin-border bg-skin-border text-skin-link;
+      @apply border-skin-primary bg-skin-primary text-white opacity-40;
     }
   }
 

--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -34,6 +34,23 @@ const validatedUserChoice = computed(() => {
   return null;
 });
 
+const buttonTooltip = computed(() => {
+  if (
+    props.proposal.type === 'ranked-choice' &&
+    selectedChoices.value < props.proposal.choices.length
+  )
+    return 'Please rank all choices';
+
+  if (
+    props.proposal.type !== 'approval' &&
+    props.proposal.type !== 'ranked-choice' &&
+    selectedChoices.value < 1
+  )
+    return 'Please select at least one choice';
+
+  return '';
+});
+
 function emitChoice(c) {
   emit('update:modelValue', c);
 }
@@ -77,19 +94,25 @@ watch(validatedUserChoice, () => {
         @select-choice="emitChoice"
       />
     </div>
-    <TuneButton
-      :disabled="
-        web3.authLoading ||
-        (selectedChoices < 1 && proposal.type !== 'approval') ||
-        (selectedChoices < proposal.choices.length &&
-          proposal.type === 'ranked-choice')
-      "
-      class="block w-full"
-      primary
-      data-testid="proposal-vote-button"
-      @click="$emit('clickVote')"
+    <div
+      v-tippy="{
+        content: buttonTooltip
+      }"
     >
-      {{ $t('proposal.vote') }}
-    </TuneButton>
+      <TuneButton
+        :disabled="
+          web3.authLoading ||
+          (selectedChoices < 1 && proposal.type !== 'approval') ||
+          (selectedChoices < proposal.choices.length &&
+            proposal.type === 'ranked-choice')
+        "
+        class="block w-full"
+        primary
+        data-testid="proposal-vote-button"
+        @click="$emit('clickVote')"
+      >
+        {{ $t('proposal.vote') }}
+      </TuneButton>
+    </div>
   </BaseBlock>
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

It might not be clear to the user that ranked choice voting requires all choices to be selected. To fix this I've added a tooltip to the disabled button.
<img width="732" alt="Screenshot 2023-12-13 at 2 20 19 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/38463448-3d28-4e77-976e-31e90369b598">

Also added one for other voting types while at it
<img width="683" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/51686767/b39f2d65-394e-4171-895c-fb580f261e36">


Also changes the disabled style of the primary button to fix the design on figma
<img width="717" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/51686767/b99be647-7d12-4e6c-87d9-21e306b32e84">



<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
