### PR TITLE
fix: Subdomains expiry is '0' sometimes

### DIFF
--- a/src/composables/useEns.ts
+++ b/src/composables/useEns.ts
@@ -29,7 +29,10 @@ export function useEns() {
     // Filter out expired domains
     const now = (Date.now() / 1000).toFixed(0);
     allDomains = allDomains.filter(
-      domain => !domain.expiryDate || domain.expiryDate > now
+      domain =>
+        !domain.expiryDate ||
+        domain.expiryDate === '0' ||
+        domain.expiryDate > now
     );
     ownedEnsDomains.value = await fetchAllDomainData(allDomains);
   };


### PR DESCRIPTION
### Summary
Subdomains are not visible sometimes, because someone them has `0` expiry 
for example https://app.ens.domains/two.serebryakovpavel.eth in such cases we should check the parent's expiry but this is a temporary fix to show subdomains for space creation

### How to test

1. Connect wallet with `0x2A54FbCb3e916Bb07F25c50093b9290173ef5248` using guest
2. Go to https://snapshot.org/#/setup?step=1
3. Before fix you should see only one domain
<img width="732" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/6ad50bff-8305-4c0d-a56e-54db61c48024">
4. After fix you should see two domains 
<img width="705" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/4da3577a-5552-4dce-b652-f6684f45a1ff">


#### To Do:
- [ ] https://discord.com/channels/707079246388133940/1184954967623209151/1184955414060740670 Tell them issue is fixed