### PR TITLE
fix: fix osnap site and icon links in manifest

### DIFF
--- a/src/plugins/oSnap/plugin.json
+++ b/src/plugins/oSnap/plugin.json
@@ -2,8 +2,8 @@
   "name": "oSnap by UMA",
   "version": "1.0.0",
   "author": "UMA",
-  "website": "https://safe.global",
-  "icon": "ipfs://QmQjZaheMTLRrk22mrGCkGk2LNoNqqYMR8Bxtwa8mBHyc9",
+  "website": "https://uma.xyz/osnap",
+  "icon": "https://osnap.uma.xyz/osnap-icon.svg",
   "defaults": {
     "proposal": {
       "safe": null


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->
We recently added a new osnap plugin to snapshot, but forgot to update the manifest with website link and correct icon

Currently we use the safesnap plugin, which is not correctl
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/fd3dfec2-c7d5-48c7-b976-6815ffcd3cb9)

This is the new icon 
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/274c3908-f8a7-4108-99f9-3d80ca4b7ad6)
Closes: #

### How to test

1. go into a space you can edit
2. add the new osnap plugin, see the new icon 



### To-Do

- [ ]

<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
