### PR TITLE
feat: Show user vote in vote section 

### DIFF
--- a/src/components/ModalVote.vue
+++ b/src/components/ModalVote.vue
@@ -162,6 +162,17 @@ watch(
           <div class="flex">
             <span class="mr-1 flex-auto text-skin-text" v-text="$t('choice')" />
             <span
+              v-if="
+                proposal.type === 'approval' &&
+                Array.isArray(selectedChoices) &&
+                selectedChoices?.length === 0
+              "
+              class="text-right"
+            >
+              Blank vote
+            </span>
+            <span
+              v-else
               v-tippy="{
                 content:
                   format(proposal, selectedChoices).length > 30

--- a/src/components/SpaceProposalPage.vue
+++ b/src/components/SpaceProposalPage.vue
@@ -179,7 +179,6 @@ onMounted(() => setMessageVisibility(props.proposal.flagged));
             </BlockLink>
           </div>
           <SpaceProposalVote
-            v-if="proposal?.state === 'active'"
             v-model="selectedChoices"
             :proposal="proposal"
             @open="modalOpen = true"

--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -66,7 +66,7 @@ watch(web3Account, loadUserVote, { immediate: true });
 
 <template>
   <BaseBlock
-    v-if="!loadingUserVote"
+    v-if="!loadingUserVote && (userVote || proposal.state === 'active')"
     class="mb-4"
     :title="
       isEditing ? 'Change your vote' : userVote ? 'Your vote' : 'Cast your vote'
@@ -74,7 +74,7 @@ watch(web3Account, loadUserVote, { immediate: true });
   >
     <template #button>
       <button
-        v-if="!isEditing && userVote"
+        v-if="!isEditing && userVote && proposal.state === 'active'"
         type="button"
         class="flex items-center gap-1"
         @click="isEditing = true"

--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -83,10 +83,12 @@ watch(web3Account, loadUserVote, { immediate: true });
         Change vote
       </button>
     </template>
-    <div v-if="votedAndShutter && !isEditing && proposal.state === 'active'">
+    <div
+      v-if="votedAndShutter && !isEditing && proposal.scores_state !== 'final'"
+    >
       <i-ho-lock-closed class="inline-block text-sm" />
-      Your vote is encrypted with Shutter privacy until the proposal ends. You
-      can still change it until then.
+      Your vote is encrypted with Shutter privacy until the proposal ends and
+      the final score is calculated. You can still change your vote until then.
     </div>
     <BaseMessage
       v-else-if="userVote && !validatedUserChoice && !isEditing"

--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -83,19 +83,19 @@ watch(web3Account, loadUserVote, { immediate: true });
         Change vote
       </button>
     </template>
-    <div v-if="votedAndShutter && !isEditing">
+    <div v-if="votedAndShutter && !isEditing && proposal.state === 'active'">
       <i-ho-lock-closed class="inline-block text-sm" />
       Your vote is encrypted with Shutter privacy until the proposal ends. You
       can still change it until then.
     </div>
-    <BaseMessageBlock
+    <BaseMessage
       v-else-if="userVote && !validatedUserChoice && !isEditing"
       level="info"
     >
       Oops, we were unable to validate your vote. Please try voting again or
       consider opening a ticket with our support team on
       <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
-    </BaseMessageBlock>
+    </BaseMessage>
     <div v-else>
       <SpaceProposalVoteSingleChoice
         v-if="proposal.type === 'single-choice' || proposal.type === 'basic'"

--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -20,8 +20,8 @@ const selectedChoices = computed(() => {
   if (Array.isArray(props.modelValue)) return props.modelValue.length;
   if (typeof props.modelValue === 'object' && props.modelValue !== null)
     return Object.keys(props.modelValue).length;
-  return props.modelValue;
-}) as ComputedRef<number>;
+  return props.modelValue ?? 0;
+});
 
 const validatedUserChoice = computed(() => {
   if (!userVote.value?.choice) return null;

--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -61,7 +61,14 @@ function emitChoice(c) {
   emit('update:modelValue', c);
 }
 
-watch(web3Account, loadUserVote, { immediate: true });
+watch(
+  web3Account,
+  () => {
+    isEditing.value = false;
+    loadUserVote(web3Account.value);
+  },
+  { immediate: true }
+);
 </script>
 
 <template>

--- a/src/components/SpaceProposalVoteApproval.vue
+++ b/src/components/SpaceProposalVoteApproval.vue
@@ -33,26 +33,34 @@ watch(
 </script>
 
 <template>
-  <div data-testid="approval-choice-list">
-    <template v-for="(choice, i) in proposal.choices" :key="i">
-      <TuneButton
-        v-if="isEditing ? true : userChoice?.includes(i + 1) || !userChoice"
-        class="relative mb-2 last:mb-0 block w-full text-left"
-        :class="{
-          '!border-skin-link': selectedChoices.includes(i + 1),
-          'border-skin-border hover:border-skin-link':
-            !selectedChoices.includes(i + 1),
-          '!cursor-default': !isEditing
-        }"
-        :data-testid="`approval-choice-button-${i}`"
-        @click="isEditing && selectChoice(i + 1)"
-      >
-        <i-ho-check
-          v-if="selectedChoices.includes(i + 1)"
-          class="absolute right-[20px]"
-        />
-        {{ shorten(choice, 32) }}
-      </TuneButton>
-    </template>
+  <div>
+    <div v-if="userChoice?.length === 0 && !isEditing">
+      <BaseMessage level="info">
+        You voted without selecting a choice. Your vote will be counted as a
+        <strong>blank vote</strong>.
+      </BaseMessage>
+    </div>
+    <div data-testid="approval-choice-list">
+      <template v-for="(choice, i) in proposal.choices" :key="i">
+        <TuneButton
+          v-if="isEditing ? true : userChoice?.includes(i + 1) || !userChoice"
+          class="relative mb-2 last:mb-0 block w-full text-left"
+          :class="{
+            '!border-skin-link': selectedChoices.includes(i + 1),
+            'border-skin-border hover:border-skin-link':
+              !selectedChoices.includes(i + 1),
+            '!cursor-default': !isEditing
+          }"
+          :data-testid="`approval-choice-button-${i}`"
+          @click="isEditing && selectChoice(i + 1)"
+        >
+          <i-ho-check
+            v-if="selectedChoices.includes(i + 1)"
+            class="absolute right-[20px]"
+          />
+          {{ shorten(choice, 32) }}
+        </TuneButton>
+      </template>
+    </div>
   </div>
 </template>

--- a/src/components/SpaceProposalVoteApproval.vue
+++ b/src/components/SpaceProposalVoteApproval.vue
@@ -6,6 +6,7 @@ import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 const props = defineProps<{
   proposal: Proposal;
   userChoice: number[] | null;
+  isEditing: boolean;
 }>();
 
 const emit = defineEmits(['selectChoice']);
@@ -32,22 +33,26 @@ watch(
 </script>
 
 <template>
-  <div class="mb-3" data-testid="approval-choice-list">
-    <TuneButton
-      v-for="(choice, i) in proposal.choices"
-      :key="i"
-      class="relative mb-2 block w-full"
-      :class="{
-        '!border-skin-link': selectedChoices.includes(i + 1),
-        'border-skin-border hover:border-skin-link': !selectedChoices.includes(
-          i + 1
-        )
-      }"
-      :data-testid="`approval-choice-button-${i}`"
-      @click="selectChoice(i + 1)"
-    >
-      <i-ho-check v-if="selectedChoices.includes(i + 1)" class="absolute" />
-      {{ shorten(choice, 32) }}
-    </TuneButton>
+  <div data-testid="approval-choice-list">
+    <template v-for="(choice, i) in proposal.choices" :key="i">
+      <TuneButton
+        v-if="isEditing ? true : userChoice?.includes(i + 1) || !userChoice"
+        class="relative mb-2 last:mb-0 block w-full text-left"
+        :class="{
+          '!border-skin-link': selectedChoices.includes(i + 1),
+          'border-skin-border hover:border-skin-link':
+            !selectedChoices.includes(i + 1),
+          '!cursor-default': !isEditing
+        }"
+        :data-testid="`approval-choice-button-${i}`"
+        @click="isEditing && selectChoice(i + 1)"
+      >
+        <i-ho-check
+          v-if="selectedChoices.includes(i + 1)"
+          class="absolute right-[20px]"
+        />
+        {{ shorten(choice, 32) }}
+      </TuneButton>
+    </template>
   </div>
 </template>

--- a/src/components/SpaceProposalVoteQuadratic.vue
+++ b/src/components/SpaceProposalVoteQuadratic.vue
@@ -7,6 +7,7 @@ import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 const props = defineProps<{
   proposal: Proposal;
   userChoice: Record<string, any> | null;
+  isEditing: boolean;
 }>();
 
 const emit = defineEmits(['selectChoice']);
@@ -62,60 +63,70 @@ watch(
 </script>
 
 <template>
-  <div class="mb-3" data-testid="quadratic-choice-list">
-    <TuneButton
-      v-for="(choice, i) in proposal.choices"
-      :key="i"
-      class="mb-2 flex w-full items-center justify-between overflow-hidden"
-      :class="selectedChoices[i + 1] > 0 && '!border-skin-link'"
-      :data-testid="`quadratic-choice-button-${i}`"
-    >
-      <div
-        v-tippy="{
-          content: choice.length > 20 && isSmallScreen ? choice : null
-        }"
-        class="truncate pr-3 text-left"
+  <div data-testid="quadratic-choice-list">
+    <template v-for="(choice, i) in proposal.choices" :key="i">
+      <TuneButton
+        v-if="
+          isEditing ? true : (userChoice && userChoice[i + 1]) || !userChoice
+        "
+        class="mb-2 last:mb-0 flex w-full items-center justify-between overflow-hidden"
+        :class="[
+          selectedChoices[i + 1] > 0 && '!border-skin-link',
+          {
+            '!cursor-default': !isEditing
+          }
+        ]"
+        :data-testid="`quadratic-choice-button-${i}`"
       >
-        {{ choice }}
-      </div>
-      <div class="flex items-center justify-end">
-        <button
-          :disabled="!selectedChoices[i + 1]"
-          class="btn-choice"
-          :data-testid="`quadratic-remove-button-${i}`"
-          @click="removeVote(i + 1)"
-        >
-          -
-        </button>
-        <input
-          v-if="!isSmallScreen"
-          v-model.number="selectedChoices[i + 1]"
-          class="input text-center"
-          :class="{ 'btn-choice': isSmallScreen }"
-          style="width: 40px; height: 44px"
-          placeholder="0"
-          type="number"
-          :data-testid="`quadratic-input-${i}`"
-        />
-        <div v-if="isSmallScreen" style="min-width: 56px">
-          {{ percentage(i) }}%
-        </div>
-        <button
-          class="btn-choice"
-          :data-testid="`quadratic-add-button-${i}`"
-          @click="addVote(i + 1)"
-        >
-          +
-        </button>
         <div
-          v-if="!isSmallScreen"
-          style="min-width: 52px; margin-right: -5px"
-          class="text-right"
+          v-tippy="{
+            content: choice.length > 20 && isSmallScreen ? choice : null
+          }"
+          class="truncate pr-3 text-left"
         >
-          {{ percentage(i) }}%
+          {{ choice }}
         </div>
-      </div>
-    </TuneButton>
+        <div class="flex items-center justify-end">
+          <template v-if="isEditing || !userChoice">
+            <button
+              :disabled="!selectedChoices[i + 1]"
+              class="btn-choice"
+              :data-testid="`quadratic-remove-button-${i}`"
+              @click="removeVote(i + 1)"
+            >
+              -
+            </button>
+            <input
+              v-if="!isSmallScreen"
+              v-model.number="selectedChoices[i + 1]"
+              class="input text-center"
+              :class="{ 'btn-choice': isSmallScreen }"
+              style="width: 40px; height: 44px"
+              placeholder="0"
+              type="number"
+              :data-testid="`quadratic-input-${i}`"
+            />
+            <div v-if="isSmallScreen" style="min-width: 56px">
+              {{ percentage(i) }}%
+            </div>
+            <button
+              class="btn-choice"
+              :data-testid="`quadratic-add-button-${i}`"
+              @click="addVote(i + 1)"
+            >
+              +
+            </button>
+          </template>
+          <div
+            v-if="!isSmallScreen || !isEditing"
+            style="min-width: 52px; margin-right: -5px"
+            class="text-right"
+          >
+            {{ percentage(i) }}%
+          </div>
+        </div>
+      </TuneButton>
+    </template>
   </div>
 </template>
 

--- a/src/components/SpaceProposalVoteRankedChoice.vue
+++ b/src/components/SpaceProposalVoteRankedChoice.vue
@@ -43,35 +43,27 @@ watch(
     <div v-if="selectedChoices.length">
       <draggable
         v-model="selectedChoices"
-        :component-data="{ name: 'list' }"
+        :component-data="{ name: 'list', type: 'transition-group' }"
         item-key="id"
         data-testid="ranked-choice-selected-list"
+        v-bind="{ animation: 200 }"
         :disabled="userChoice?.length && !isEditing"
         @change="updateChoices"
       >
         <template #item="{ element, index }">
           <TuneButton
             class="!mb-2 last:!mb-0 flex w-full items-center justify-between !border-skin-link !px-3"
-            :class="{
-              '!cursor-default': !isEditing
-            }"
+            :class="[!isEditing ? '!cursor-default' : 'cursor-grabbing']"
           >
-            <div class="min-w-[60px] text-left">
-              ({{ getNumberWithOrdinal(index + 1) }})
+            <div class="pl-1 flex truncate">
+              <div>#{{ index + 1 }}</div>
+
+              <div class="truncate pl-1">
+                {{ proposal.choices[element - 1] }}
+              </div>
             </div>
-            <div class="mx-2 w-full truncate text-center">
-              {{ proposal.choices[element - 1] }}
-            </div>
-            <div
-              class="ml-[40px] min-w-[20px] text-right"
-              :data-testid="`ranked-choice-selected-delete-${index}`"
-              @click="removeChoice(index)"
-            >
-              <BaseIcon
-                v-if="!userChoice || isEditing"
-                name="close"
-                size="12"
-              />
+            <div class="pl-6">
+              <i-ho-menu-alt-4 class="text-sm" />
             </div>
           </TuneButton>
         </template>

--- a/src/components/SpaceProposalVoteRankedChoice.vue
+++ b/src/components/SpaceProposalVoteRankedChoice.vue
@@ -7,6 +7,7 @@ import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 const props = defineProps<{
   proposal: Proposal;
   userChoice: number[] | null;
+  isEditing: boolean;
 }>();
 
 const emit = defineEmits(['selectChoice']);
@@ -38,18 +39,22 @@ watch(
 </script>
 
 <template>
-  <div class="mb-3">
-    <div :class="{ 'mb-5': selectedChoices.length > 0 }">
+  <div class="space-y-3">
+    <div v-if="selectedChoices.length">
       <draggable
         v-model="selectedChoices"
         :component-data="{ name: 'list' }"
         item-key="id"
         data-testid="ranked-choice-selected-list"
+        :disabled="userChoice?.length && !isEditing"
         @change="updateChoices"
       >
         <template #item="{ element, index }">
           <TuneButton
-            class="!mb-2 flex w-full items-center justify-between !border-skin-link !px-3"
+            class="!mb-2 last:!mb-0 flex w-full items-center justify-between !border-skin-link !px-3"
+            :class="{
+              '!cursor-default': !isEditing
+            }"
           >
             <div class="min-w-[60px] text-left">
               ({{ getNumberWithOrdinal(index + 1) }})
@@ -62,25 +67,35 @@ watch(
               :data-testid="`ranked-choice-selected-delete-${index}`"
               @click="removeChoice(index)"
             >
-              <BaseIcon name="close" size="12" />
+              <BaseIcon
+                v-if="!userChoice || isEditing"
+                name="close"
+                size="12"
+              />
             </div>
           </TuneButton>
         </template>
       </draggable>
     </div>
+
     <div
-      v-for="(choice, i) in proposal.choices"
-      :key="i"
-      data-testid="ranked-choice-select-list"
+      v-if="selectedChoices.length !== proposal.choices.length"
+      class="space-y-2"
     >
-      <TuneButton
-        v-if="!selectedChoices.includes(i + 1)"
-        class="mb-2 block w-full"
-        :class="selectedChoices.includes(i + 1) && 'border-skin-link'"
-        @click="selectChoice(i + 1)"
+      <div
+        v-for="(choice, i) in proposal.choices"
+        :key="i"
+        data-testid="ranked-choice-select-list"
       >
-        <span class="truncate">{{ choice }}</span>
-      </TuneButton>
+        <TuneButton
+          v-if="!selectedChoices.includes(i + 1)"
+          class="block w-full"
+          :class="selectedChoices.includes(i + 1) && 'border-skin-link'"
+          @click="selectChoice(i + 1)"
+        >
+          <span class="truncate">{{ choice }}</span>
+        </TuneButton>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/SpaceProposalVoteRankedChoice.vue
+++ b/src/components/SpaceProposalVoteRankedChoice.vue
@@ -58,7 +58,7 @@ watch(
               </div>
             </div>
             <div class="pl-6">
-              <i-ho-menu-alt-4 class="text-sm" />
+              <i-ho-menu-alt-4 v-if="isEditing" class="text-sm" />
             </div>
           </TuneButton>
         </template>

--- a/src/components/SpaceProposalVoteRankedChoice.vue
+++ b/src/components/SpaceProposalVoteRankedChoice.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import draggable from 'vuedraggable';
-import { getNumberWithOrdinal } from '@/helpers/utils';
 import { Proposal } from '@/helpers/interfaces';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 
@@ -17,10 +16,6 @@ const selectedChoices = ref<number[]>([]);
 function selectChoice(i) {
   selectedChoices.value.push(i);
   emit('selectChoice', selectedChoices.value);
-}
-
-function removeChoice(i) {
-  selectedChoices.value.splice(i, 1);
 }
 
 function updateChoices() {

--- a/src/components/SpaceProposalVoteSingleChoice.vue
+++ b/src/components/SpaceProposalVoteSingleChoice.vue
@@ -6,6 +6,7 @@ import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 const props = defineProps<{
   proposal: Proposal;
   userChoice: number | null;
+  isEditing: boolean;
 }>();
 
 const emit = defineEmits(['selectChoice']);
@@ -13,6 +14,7 @@ const emit = defineEmits(['selectChoice']);
 const selectedChoice = ref<number | null>(null);
 
 function selectChoice(i: number) {
+  if (props.userChoice && !props.isEditing) return;
   selectedChoice.value = i;
   emit('selectChoice', i);
 }
@@ -29,17 +31,26 @@ watch(
 </script>
 
 <template>
-  <div class="mb-3">
-    <TuneButton
-      v-for="(choice, i) in proposal.choices"
-      :key="i"
-      class="relative mb-2 block w-full"
-      :class="selectedChoice === i + 1 && '!border-skin-link'"
-      :data-testid="`sc-choice-button-${i}`"
-      @click="selectChoice(i + 1)"
-    >
-      <i-ho-check v-if="selectedChoice === i + 1" class="absolute" />
-      {{ shorten(choice, 32) }}
-    </TuneButton>
+  <div>
+    <template v-for="(choice, i) in proposal.choices" :key="i">
+      <TuneButton
+        v-if="isEditing ? true : userChoice === i + 1 || !userChoice"
+        class="relative mb-2 last:mb-0 block w-full text-left"
+        :class="[
+          selectedChoice === i + 1 && '!border-skin-link',
+          {
+            '!cursor-default': !isEditing
+          }
+        ]"
+        :data-testid="`sc-choice-button-${i}`"
+        @click="selectChoice(i + 1)"
+      >
+        <i-ho-check
+          v-if="selectedChoice === i + 1"
+          class="absolute right-[20px]"
+        />
+        {{ shorten(choice, 32) }}
+      </TuneButton>
+    </template>
   </div>
 </template>

--- a/src/components/SpaceProposalVotesList.vue
+++ b/src/components/SpaceProposalVotesList.vue
@@ -9,11 +9,12 @@ const props = defineProps<{
 
 const VOTES_LIMIT = 6;
 
-const { web3Account } = useWeb3();
-const { profiles, votes, loadingVotes, loadVotes, loadUserVote } =
-  useProposalVotes(props.proposal, VOTES_LIMIT);
+const { profiles, votes, loadingVotes, loadVotes } = useProposalVotes(
+  props.proposal,
+  VOTES_LIMIT
+);
 
-const modalVotesmOpen = ref(false);
+const modalVotesOpen = ref(false);
 
 const voteCount = computed(() => props.proposal.votes);
 
@@ -28,7 +29,7 @@ async function downloadReport(proposalId: string) {
   }
 }
 
-const errorMessagekeyPrefix = computed(() => {
+const errorMessageKeyPrefix = computed(() => {
   const knownErrors = ['PENDING_GENERATION', 'UNSUPPORTED_ENV'];
 
   return `proposal.downloadCsvVotes.postDownloadModal.message.${camelCase(
@@ -41,8 +42,6 @@ const errorMessagekeyPrefix = computed(() => {
 onMounted(async () => {
   await loadVotes();
 });
-
-watch(web3Account, loadUserVote, { immediate: true });
 </script>
 
 <template>
@@ -83,10 +82,10 @@ watch(web3Account, loadUserVote, { immediate: true });
             class="mx-auto my-4 text-center text-[3em] text-red"
           />
           <h3>
-            {{ $t(`${errorMessagekeyPrefix}.title`) }}
+            {{ $t(`${errorMessageKeyPrefix}.title`) }}
           </h3>
           <p class="mt-3 italic">
-            {{ $t(`${errorMessagekeyPrefix}.description`) }}
+            {{ $t(`${errorMessageKeyPrefix}.description`) }}
           </p>
         </div>
 
@@ -116,8 +115,8 @@ watch(web3Account, loadUserVote, { immediate: true });
       v-if="votes.length > VOTES_LIMIT"
       tabindex="0"
       class="block rounded-b-none border-t px-4 py-3 text-center md:rounded-b-md"
-      @click="modalVotesmOpen = true"
-      @keypress="modalVotesmOpen = true"
+      @click="modalVotesOpen = true"
+      @keypress="modalVotesOpen = true"
     >
       <span v-text="$t('seeMore')" />
     </a>
@@ -125,8 +124,8 @@ watch(web3Account, loadUserVote, { immediate: true });
       <SpaceProposalVotesModal
         :space="space"
         :proposal="proposal"
-        :open="modalVotesmOpen"
-        @close="modalVotesmOpen = false"
+        :open="modalVotesOpen"
+        @close="modalVotesOpen = false"
       />
     </teleport>
   </BaseBlock>

--- a/src/components/SpaceProposalVotesList.vue
+++ b/src/components/SpaceProposalVotesList.vue
@@ -7,14 +7,11 @@ const props = defineProps<{
   proposal: Proposal;
 }>();
 
+const VOTES_LIMIT = 6;
+
 const { web3Account } = useWeb3();
-const {
-  profiles,
-  userPrioritizedVotes,
-  loadingVotes,
-  loadVotes,
-  loadUserVote
-} = useProposalVotes(props.proposal, 6);
+const { profiles, votes, loadingVotes, loadVotes, loadUserVote } =
+  useProposalVotes(props.proposal, VOTES_LIMIT);
 
 const modalVotesmOpen = ref(false);
 
@@ -105,7 +102,7 @@ watch(web3Account, loadUserVote, { immediate: true });
       </BaseModal>
     </template>
     <SpaceProposalVotesListItem
-      v-for="(vote, i) in userPrioritizedVotes.slice(0, 6)"
+      v-for="(vote, i) in votes"
       :key="i"
       :vote="vote"
       :profiles="profiles"
@@ -113,9 +110,10 @@ watch(web3Account, loadUserVote, { immediate: true });
       :proposal="proposal"
       :class="{ '!border-0': i === 0 }"
       :data-testid="`proposal-votes-list-item-${i}`"
+      class="!px-4"
     />
     <a
-      v-if="userPrioritizedVotes.length < voteCount"
+      v-if="votes.length > VOTES_LIMIT"
       tabindex="0"
       class="block rounded-b-none border-t px-4 py-3 text-center md:rounded-b-md"
       @click="modalVotesmOpen = true"

--- a/src/components/SpaceProposalVotesModal.vue
+++ b/src/components/SpaceProposalVotesModal.vue
@@ -101,7 +101,7 @@ watch(filters, value => {
           :placeholder="$t('searchPlaceholderVotes')"
           modal
           focus-on-mount
-          class="max-h-[56px] w-full px-3 pb-3"
+          class="max-h-[56px] w-full !px-3 pb-3"
         >
           <template #after>
             <SpaceProposalVotesFilters

--- a/src/composables/useProposalVotes.ts
+++ b/src/composables/useProposalVotes.ts
@@ -106,6 +106,10 @@ export function useProposalVotes(proposal: Proposal, loadBy = 6) {
   }
 
   async function loadUserVote(voter: string) {
+    if (!voter) {
+      userVote.value = null;
+      return;
+    }
     try {
       loadingUserVote.value = true;
       const response = await _fetchVote({ voter });

--- a/src/composables/useProposalVotes.ts
+++ b/src/composables/useProposalVotes.ts
@@ -1,6 +1,5 @@
 import { Proposal, Vote, VoteFilters } from '@/helpers/interfaces';
 import { VOTES_QUERY } from '@/helpers/queries';
-import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 
 type QueryParams = {
   voter?: string;
@@ -13,23 +12,9 @@ export function useProposalVotes(proposal: Proposal, loadBy = 6) {
 
   const loadingVotes = ref(false);
   const loadingMoreVotes = ref(false);
+  const loadingUserVote = ref(false);
   const votes = ref<Vote[]>([]);
   const userVote = ref<Vote | null>(null);
-
-  const userPrioritizedVotes = computed(() => {
-    const votesClone = clone(votes.value);
-    if (userVote.value) {
-      const index = votesClone.findIndex(
-        vote => vote.ipfs === userVote.value?.ipfs
-      );
-      if (index !== -1) {
-        votesClone.splice(index, 1);
-      }
-      votesClone.unshift(userVote.value);
-    }
-
-    return votesClone;
-  });
 
   async function _fetchVotes(queryParams: QueryParams, skip = 0) {
     const response = await apolloQuery(
@@ -122,19 +107,22 @@ export function useProposalVotes(proposal: Proposal, loadBy = 6) {
 
   async function loadUserVote(voter: string) {
     try {
+      loadingUserVote.value = true;
       const response = await _fetchVote({ voter });
       userVote.value = formatProposalVotes(response)[0];
     } catch (e) {
       console.log(e);
+    } finally {
+      loadingUserVote.value = false;
     }
   }
 
   return {
     votes,
-    userPrioritizedVotes,
     profiles,
     loadingVotes,
     loadingMoreVotes,
+    loadingUserVote: computed(() => loadingUserVote.value),
     userVote,
     formatProposalVotes,
     loadVotes,

--- a/src/views/SpaceProposal.vue
+++ b/src/views/SpaceProposal.vue
@@ -47,11 +47,7 @@ onMounted(() => {
 
 <template>
   <div>
-    <TheLayout v-if="loadingProposal" :slim="false">
-      <template #content-left>
-        <LoadingPage />
-      </template>
-    </TheLayout>
+    <LoadingSpinner v-if="loadingProposal" class="overlay big" />
 
     <SpaceProposalPage
       v-else-if="proposal && space"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

When a user has already voted we show the selected choices and hide the other ones. We also add a "Change vote" button for the user to change their vote. When shutter privacy in enabled we show a message.

<img width="665" alt="Screenshot 2024-01-04 at 3 17 14 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/87e542af-e72f-4c63-a399-e26f7fe0c798">
<img width="683" alt="Screenshot 2024-01-04 at 3 17 25 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/b8999b68-592a-47c9-a57e-f410a419c6f7">
<img width="689" alt="Screenshot 2024-01-04 at 3 17 34 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/2932d64a-4c3a-49f0-8196-6e8abca95d68">

### How to test

Use `pistachiodao.eth` space which has proposals for all voting types

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
