### PR TITLE
improve: adjust wording about osnap vs safesnap plugins

### DIFF
--- a/src/components/SpaceCreateOsnap.vue
+++ b/src/components/SpaceCreateOsnap.vue
@@ -16,9 +16,14 @@ defineEmits<{
     <div v-if="legacyOsnap.enabled">
       <h6>Warning</h6>
       <p class="mb-3">
-        The new oSnap plugin is not compatible with the legacy safeSnap plugin.
-        Please remove the safeSnap plugin in your space settings to enable
-        oSnap.
+        You currently have both the oSnap plugin and the SafeSnap plugin
+        installed in your space. You will continue using SafeSnap for now. If
+        you would like to use the oSnap plugin please see the oSnap
+        <a
+          target="_blank"
+          href="https://docs.uma.xyz/developers/osnap/osnap-configuration-parameters-1"
+          >migration docs.</a
+        >
       </p>
     </div>
     <div v-else>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->
We had feedback around the wording of oSnap vs SafeSnap

Original wording:
>    The new oSnap plugin is not compatible with the legacy safeSnap plugin.
        Please remove the safeSnap plugin in your space settings to enable
        oSnap.

new wording
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/567e0092-c087-4a60-9daa-bf73c3b9bbe5)

Closes: #

### How to test

1. Add both oSnap and SafeSnap plugins to a space you control
2. You may need to configure the safesnap plugin wiht a valid module addresrs. Or use our test space umadev.eth
3. make a proposal, and go to the second page where this warning shows.
4. see that it doesnt show when only 1 of the plugins are installed ( should only show when both are installed ) 

<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
