### PR TITLE
Use AJV from snapshot.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@vueuse/core": "^10.6.1",
     "@vueuse/head": "^2.0.0",
     "ajv": "^8.12.0",
-    "ajv-formats": "^2.1.1",
     "autolinker": "^4.0.0",
     "bluebird": "^3.7.2",
     "graphql": "16.6.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@vue/apollo-composable": "4.0.0-beta.11",
     "@vueuse/core": "^10.6.1",
     "@vueuse/head": "^2.0.0",
-    "ajv": "^8.12.0",
     "autolinker": "^4.0.0",
     "bluebird": "^3.7.2",
     "graphql": "16.6.0",

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,9 +1,8 @@
-import type { ErrorObject } from 'ajv';
 import snapshot from '@snapshot-labs/snapshot.js';
 
 const { env } = useApp();
 
-function getErrorMessage(errorObject: ErrorObject): string {
+function getErrorMessage(errorObject): string {
   if (!errorObject.message) return 'Invalid field.';
 
   if (errorObject.keyword === 'format') {
@@ -55,7 +54,7 @@ function transformAjvErrors(errors): ValidationErrorOutput {
     };
   });
 
-  return errors.reduce((output: ValidationErrorOutput, error: ErrorObject) => {
+  return errors.reduce((output: ValidationErrorOutput, error) => {
     const path: string[] = extractPathFromError(error);
 
     // Skip the current error if the path is empty
@@ -73,7 +72,7 @@ function transformAjvErrors(errors): ValidationErrorOutput {
   }, {});
 }
 
-function extractPathFromError(error: ErrorObject): string[] {
+function extractPathFromError(error): string[] {
   if (!error.instancePath) {
     return [];
   }

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -33,7 +33,7 @@ export function validateForm(
   }
 ): Record<string, any> {
   const valid = snapshot.utils.validateSchema(schema, form, {
-    spaceType: options.spaceType,
+    spaceType: options.spaceType ? options.spaceType : 'default',
     snapshotEnv: env === 'production' ? 'mainnet' : 'default'
   });
   if (!Array.isArray(valid)) return {};

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,14 +1,5 @@
-import Ajv from 'ajv';
 import type { ErrorObject } from 'ajv';
-import addFormats from 'ajv-formats';
-import { parseUnits } from '@ethersproject/units';
-import { isAddress } from '@ethersproject/address';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
-
-const networksIds = Object.keys(networks);
-const mainnetNetworkIds = Object.keys(networks).filter(
-  id => !networks[id].testnet
-);
+import snapshot from '@snapshot-labs/snapshot.js';
 
 const { env } = useApp();
 
@@ -34,81 +25,26 @@ function getErrorMessage(errorObject: ErrorObject): string {
     .charAt(0)
     .toLocaleUpperCase()}${errorObject.message.slice(1).toLocaleLowerCase()}.`;
 }
-
 export function validateForm(
   schema: Record<string, any>,
-  form: Record<string, any>
+  form: Record<string, any>,
+  options = {
+    spaceType: 'default'
+  }
 ): Record<string, any> {
-  const ajv = new Ajv({ allErrors: true });
-
-  addFormats(ajv);
-
-  ajv.addFormat('address', {
-    validate: (value: string) => {
-      try {
-        return isAddress(value);
-      } catch (err) {
-        return false;
-      }
-    }
+  const valid = snapshot.utils.validateSchema(schema, form, {
+    spaceType: options.spaceType,
+    snapshotEnv: env === 'production' ? 'mainnet' : 'default'
   });
-
-  ajv.addFormat('long', {
-    validate: () => true
-  });
-
-  ajv.addFormat('ethValue', {
-    validate: (value: string) => {
-      if (!value.match(/^([0-9]|[1-9][0-9]+)(\.[0-9]+)?$/)) return false;
-
-      try {
-        parseUnits(value, 18);
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  });
-
-  ajv.addFormat('customUrl', {
-    type: 'string',
-    validate: (str: any) => {
-      if (!str.length) return true;
-      return (
-        str.startsWith('http://') ||
-        str.startsWith('https://') ||
-        str.startsWith('ipfs://') ||
-        str.startsWith('ipns://') ||
-        str.startsWith('snapshot://')
-      );
-    }
-  });
-
-  ajv.addKeyword({
-    keyword: 'snapshotNetwork',
-    validate: function (schema, data) {
-      if (env === 'production') return mainnetNetworkIds.includes(data);
-      return networksIds.includes(data);
-    },
-    error: {
-      message: 'testnet not allowed'
-    }
-  });
-
-  ajv.validate(schema, form);
-
-  return transformAjvErrors(ajv);
+  if (!Array.isArray(valid)) return {};
+  return transformAjvErrors(valid);
 }
 
 interface ValidationErrorOutput {
   [key: string]: ValidationErrorOutput | string;
 }
-function transformAjvErrors(ajv: Ajv): ValidationErrorOutput {
-  if (!ajv.errors) {
-    return {};
-  }
-
-  ajv.errors = ajv.errors.map(error => {
+function transformAjvErrors(errors): ValidationErrorOutput {
+  errors = errors.map(error => {
     if (error.instancePath) return error;
     const propertyName = error.params.missingProperty;
     if (!propertyName) return error;
@@ -119,25 +55,22 @@ function transformAjvErrors(ajv: Ajv): ValidationErrorOutput {
     };
   });
 
-  return ajv.errors.reduce(
-    (output: ValidationErrorOutput, error: ErrorObject) => {
-      const path: string[] = extractPathFromError(error);
+  return errors.reduce((output: ValidationErrorOutput, error: ErrorObject) => {
+    const path: string[] = extractPathFromError(error);
 
-      // Skip the current error if the path is empty
-      if (path.length === 0) {
-        return output;
-      }
-
-      const targetObject: ValidationErrorOutput = findOrCreateNestedObject(
-        output,
-        path
-      );
-
-      targetObject[path[path.length - 1]] = getErrorMessage(error);
+    // Skip the current error if the path is empty
+    if (path.length === 0) {
       return output;
-    },
-    {}
-  );
+    }
+
+    const targetObject: ValidationErrorOutput = findOrCreateNestedObject(
+      output,
+      path
+    );
+
+    targetObject[path[path.length - 1]] = getErrorMessage(error);
+    return output;
+  }, {});
 }
 
 function extractPathFromError(error: ErrorObject): string[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2508,7 +2508,7 @@ ajv@^6.12.3, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.11.0, ajv@^8.12.0:
+ajv@^8.0.0, ajv@^8.11.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==


### PR DESCRIPTION
This is blocking https://github.com/snapshot-labs/snapshot/issues/4488

### Summary
Every time there is some change in snapshot.js ajv (if we want to add a new format or new keyword) we have to redo it here in UI again, this PR will use snapshot.js 's ajv 


### How to test

1. Go to settings form or proposal creation form and try different inputs, those should still show error same as before