### PR TITLE
fix: defer email subscription state fetching

### DIFF
--- a/src/components/MenuAccount.vue
+++ b/src/components/MenuAccount.vue
@@ -6,9 +6,8 @@ const props = defineProps<{
 const emit = defineEmits(['switchWallet']);
 const { domain } = useApp();
 const { logout } = useWeb3();
+const { modalEmailOpen } = useModal();
 const router = useRouter();
-
-const showModalEmail = ref(false);
 
 function handleAction(e) {
   if (e === 'viewProfile')
@@ -21,7 +20,7 @@ function handleAction(e) {
         });
   if (e === 'switchWallet') return emit('switchWallet');
   if (e === 'subscribeEmail') {
-    showModalEmail.value = true;
+    modalEmailOpen.value = true;
     return true;
   }
 
@@ -82,6 +81,6 @@ function handleAction(e) {
   </div>
 
   <teleport to="#modal">
-    <ModalEmail :open="showModalEmail" @close="showModalEmail = false" />
+    <ModalEmail :open="modalEmailOpen" @close="modalEmailOpen = false" />
   </teleport>
 </template>

--- a/src/components/MenuAccount.vue
+++ b/src/components/MenuAccount.vue
@@ -7,16 +7,8 @@ const emit = defineEmits(['switchWallet']);
 const { domain } = useApp();
 const { logout } = useWeb3();
 const router = useRouter();
-const { userState, loadEmailSubscriptions } = useEmailSubscription();
 
 const showModalEmail = ref(false);
-
-onMounted(loadEmailSubscriptions);
-watch(showModalEmail, () => {
-  if (!showModalEmail.value) {
-    loadEmailSubscriptions();
-  }
-});
 
 function handleAction(e) {
   if (e === 'viewProfile')
@@ -90,20 +82,6 @@ function handleAction(e) {
   </div>
 
   <teleport to="#modal">
-    <ModalEmailSubscription
-      v-if="userState === 'NOT_SUBSCRIBED'"
-      :open="showModalEmail"
-      @close="showModalEmail = false"
-    />
-    <ModalEmailResend
-      v-else-if="userState === 'UNVERIFIED'"
-      :open="showModalEmail"
-      @close="showModalEmail = false"
-    />
-    <ModalEmailManagement
-      v-else-if="userState === 'VERIFIED'"
-      :open="showModalEmail"
-      @close="showModalEmail = false"
-    />
+    <ModalEmail :open="showModalEmail" @close="showModalEmail = false" />
   </teleport>
 </template>

--- a/src/components/ModalEmail.vue
+++ b/src/components/ModalEmail.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+const props = defineProps<{
+  open: boolean;
+}>();
+const emit = defineEmits(['close']);
+
+const { initialized, userState, loadEmailSubscriptions } =
+  useEmailSubscription();
+
+watch(
+  () => props.open,
+  () => {
+    if (
+      (props.open && !initialized.value) ||
+      userState.value === 'UNVERIFIED'
+    ) {
+      loadEmailSubscriptions();
+    }
+  }
+);
+</script>
+
+<template>
+  <BaseModal max-height="510px" :open="open" @close="emit('close')">
+    <template #header>
+      <h3 v-if="userState === 'NOT_SUBSCRIBED'">
+        {{ $t('emailSubscription.title') }}
+      </h3>
+      <h3 v-else-if="userState === 'UNVERIFIED'">
+        {{ $t('emailResend.title') }}
+      </h3>
+      <h3 v-else-if="userState === 'VERIFIED'">
+        {{ $t('emailManagement.title') }}
+      </h3>
+    </template>
+
+    <LoadingRow v-if="!initialized" />
+    <ModalEmailSubscription
+      v-else-if="userState === 'NOT_SUBSCRIBED'"
+      @close="emit('close')"
+    />
+    <ModalEmailResend
+      v-else-if="userState === 'UNVERIFIED'"
+      @close="emit('close')"
+    />
+    <ModalEmailManagement
+      v-else-if="userState === 'VERIFIED'"
+      @close="emit('close')"
+    />
+  </BaseModal>
+</template>

--- a/src/components/ModalEmailManagement.vue
+++ b/src/components/ModalEmailManagement.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-defineProps<{
-  open: boolean;
-}>();
-
 const emit = defineEmits(['close']);
 
 const { loading, error, clientSubscriptions, updateSubscriptions } =
@@ -32,20 +28,12 @@ const submit = async () => {
 </script>
 
 <template>
-  <BaseModal :open="open" max-height="510px" @close="emit('close')">
-    <template #header>
-      <div class="flex flex-row items-center justify-center">
-        <h3>{{ $t('emailManagement.title') }}</h3>
-      </div>
-    </template>
+  <div class="m-4 flex flex-col gap-4">
+    <p class="text-sm text-skin-text opacity-60">
+      {{ t('emailManagement.subtitle') }}
+    </p>
 
-    <div class="mx-4 mb-4 mt-2 text-center">
-      <p class="text-sm text-skin-text opacity-60">
-        {{ t('emailManagement.subtitle') }}
-      </p>
-    </div>
-
-    <form class="mx-6 my-4 flex flex-col space-y-4" @submit.prevent="submit">
+    <form class="flex flex-col space-y-4" @submit.prevent="submit">
       <TuneSwitch
         :model-value="clientSubscriptions.summary"
         :label="t('emailManagement.optionSummary')"
@@ -67,9 +55,9 @@ const submit = async () => {
         @update:model-value="updateSubscriptionKeys('closedProposal', $event)"
       />
 
-      <TuneButton class="mt-6 w-full" primary type="submit" :loading="loading">
+      <TuneButton class="w-full" primary type="submit" :loading="loading">
         {{ t('emailManagement.updatePreferences') }}
       </TuneButton>
     </form>
-  </BaseModal>
+  </div>
 </template>

--- a/src/components/ModalEmailResend.vue
+++ b/src/components/ModalEmailResend.vue
@@ -1,23 +1,13 @@
 <script setup lang="ts">
-defineProps<{
-  open: boolean;
-}>();
 const emit = defineEmits(['close']);
 </script>
 
 <template>
-  <BaseModal :open="open" @close="emit('close')">
-    <template #header>
-      <div class="flex flex-row items-center justify-center">
-        <h3>{{ $t('emailResend.title') }}</h3>
-      </div>
-    </template>
-    <div class="m-4 mb-6 text-center">
-      {{ $t('emailResend.description') }}
+  <div class="m-4 flex flex-col gap-4 text-center">
+    {{ $t('emailResend.description') }}
 
-      <TuneButton class="mt-4 w-full" primary @click="emit('close')">
-        {{ $t('close') }}
-      </TuneButton>
-    </div>
-  </BaseModal>
+    <TuneButton class="w-full" primary @click="emit('close')">
+      {{ $t('close') }}
+    </TuneButton>
+  </div>
 </template>

--- a/src/components/ModalEmailSubscription.vue
+++ b/src/components/ModalEmailSubscription.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-defineProps<{
-  open: boolean;
-}>();
-
 const emit = defineEmits(['close']);
 
 type ModalView = 'SUBSCRIBE' | 'SUCCESS';
@@ -40,19 +36,13 @@ async function submit() {
 </script>
 
 <template>
-  <BaseModal :open="open" @close="close">
-    <template #header>
-      <div class="flex flex-row items-center justify-center">
-        <h3>{{ $t('emailSubscription.title') }}</h3>
-      </div>
-    </template>
-
-    <template v-if="modalView === 'SUBSCRIBE'">
-      <div class="m-4">
+  <template v-if="modalView === 'SUBSCRIBE'">
+    <div class="m-4 flex flex-col gap-4">
+      <p>
         {{ $t('emailSubscription.description') }}
-      </div>
+      </p>
 
-      <form class="m-4" @submit.prevent="submit">
+      <form @submit.prevent="submit">
         <BaseInput
           v-model="email"
           :placeholder="$t('emailSubscription.inputPlaceholder')"
@@ -78,24 +68,23 @@ async function submit() {
           {{ $t('emailSubscription.subscribe') }}
         </TuneButton>
       </form>
-    </template>
-
-    <div v-if="modalView === 'SUCCESS'" class="m-4 text-center">
-      <i-ho-check-circle
-        class="mx-auto my-4 text-center text-[3em] text-green"
-      />
-      <h3>
-        {{ $t('emailSubscription.postSubscribeMessage.successThanks') }}
-      </h3>
-      <p class="mt-3 italic">
-        {{ $t('emailSubscription.postSubscribeMessage.successConfirmation') }}
-      </p>
     </div>
+  </template>
 
-    <template v-if="modalView === 'SUCCESS'" #footer>
+  <template v-if="modalView === 'SUCCESS'">
+    <div class="m-4 gap-4 flex flex-col text-center">
+      <i-ho-check-circle class="mx-auto text-center text-[3em] text-green" />
+      <div>
+        <h3>
+          {{ $t('emailSubscription.postSubscribeMessage.successThanks') }}
+        </h3>
+        <p class="mt-3 italic">
+          {{ $t('emailSubscription.postSubscribeMessage.successConfirmation') }}
+        </p>
+      </div>
       <TuneButton class="w-full" primary @click="close">
         {{ $t('close') }}
       </TuneButton>
-    </template>
-  </BaseModal>
+    </div>
+  </template>
 </template>

--- a/src/components/ModalPostVote.vue
+++ b/src/components/ModalPostVote.vue
@@ -4,7 +4,8 @@ import { ExtendedSpace, Proposal } from '@/helpers/interfaces';
 
 const { shareVote, shareProposalTwitter, shareProposalHey } = useSharing();
 const { web3Account } = useWeb3();
-const { userState } = useEmailSubscription();
+const { userState, loadEmailSubscriptions, initialized } =
+  useEmailSubscription();
 
 const props = defineProps<{
   open: boolean;
@@ -34,6 +35,12 @@ function share(shareTo: 'twitter' | 'hey') {
     choices: getChoiceString(props.proposal, props.selectedChoices)
   });
 }
+
+onMounted(() => {
+  if (!initialized.value) {
+    loadEmailSubscriptions();
+  }
+});
 </script>
 
 <template>
@@ -87,7 +94,7 @@ function share(shareTo: 'twitter' | 'hey') {
         </TuneButton>
 
         <TuneButton
-          v-if="userState !== 'VERIFIED'"
+          v-if="userState !== 'VERIFIED' && initialized"
           class="flex !h-[42px] w-full items-center justify-center gap-2"
           @click="subscribeEmail"
         >

--- a/src/components/SpaceProposalPage.vue
+++ b/src/components/SpaceProposalPage.vue
@@ -23,6 +23,7 @@ useMeta({
 
 const route = useRoute();
 const { web3, web3Account } = useWeb3();
+const { modalEmailOpen } = useModal();
 const { isMessageVisible, setMessageVisibility } = useFlaggedMessageStatus(
   route.params.id as string
 );
@@ -30,7 +31,6 @@ const { isMessageVisible, setMessageVisibility } = useFlaggedMessageStatus(
 const proposalId: string = route.params.id as string;
 
 const modalOpen = ref(false);
-const modalEmailSubscriptionOpen = ref(false);
 const selectedChoices = ref<any>(null);
 const loadedResults = ref(false);
 const results = ref<Results | null>(null);
@@ -240,12 +240,7 @@ onMounted(() => setMessageVisibility(props.proposal.flagged));
       :selected-choices="selectedChoices"
       :waiting-for-signers="waitingForSigners"
       @close="isModalPostVoteOpen = false"
-      @subscribe-email="modalEmailSubscriptionOpen = true"
-    />
-    <ModalEmailSubscription
-      :open="modalEmailSubscriptionOpen"
-      :address="web3Account"
-      @close="modalEmailSubscriptionOpen = false"
+      @subscribe-email="modalEmailOpen = true"
     />
   </teleport>
 </template>

--- a/src/composables/useEmailSubscription.ts
+++ b/src/composables/useEmailSubscription.ts
@@ -14,6 +14,7 @@ function useEmailSubscriptionComposable() {
 
   const userState = ref<SubscriptionStatus>('NOT_SUBSCRIBED');
   const error = ref('');
+  const initialized = ref(false);
   const loading = ref(false);
   const apiSubscriptions = ref<SubscriptionType[]>([]);
 
@@ -50,6 +51,7 @@ function useEmailSubscriptionComposable() {
     userState.value = usrState;
     apiSubscriptions.value = subscriptions || [];
     loading.value = false;
+    initialized.value = true;
   };
 
   const subscribe = async (email: string) => {
@@ -88,7 +90,8 @@ function useEmailSubscriptionComposable() {
     subscribe,
     updateSubscriptions,
     loadEmailSubscriptions,
-    loading
+    loading,
+    initialized
   };
 }
 

--- a/src/composables/useModal.ts
+++ b/src/composables/useModal.ts
@@ -1,6 +1,7 @@
 const modalAccountOpen = ref(false);
-const isModalPostVoteOpen = ref(false);
+const isModalPostVoteOpen = ref(true);
+const modalEmailOpen = ref(false);
 
 export function useModal() {
-  return { modalAccountOpen, isModalPostVoteOpen };
+  return { modalAccountOpen, isModalPostVoteOpen, modalEmailOpen };
 }

--- a/src/composables/useModal.ts
+++ b/src/composables/useModal.ts
@@ -1,5 +1,5 @@
 const modalAccountOpen = ref(false);
-const isModalPostVoteOpen = ref(true);
+const isModalPostVoteOpen = ref(false);
 const modalEmailOpen = ref(false);
 
 export function useModal() {


### PR DESCRIPTION
### Summary

A request is sent to the envelop API on page load, to retrieve whether the current user is already subscribed or not. This was made so that when the user click on the "Email subscription" menu, it open the correct modal.

This PR introduces a change, to defer this request to only triggered when the user click on the "Email subscription" menu, thus saving a request on each page load, for user not interested in the email subscription.

This change introduces a change on the UI:
- Since we don't know the user subscription state when he open "Email subscription" modal, a loading skeleton will be show until we get the state from envelop API, before showing the correct modal content.
- In the PostVoteModal, we will charge the user subscription status on mounting, so there will be a UI flash, where the "Subscribe to email" button will first not exist, then appear after status fetching
- Some minor margin adjustment for consistency: use `m-4` and `gap-4` everywhere

Closes: #4501

### How to test

1. Load any page 
2. It should not trigger any request to https://core.envelop.fyi/subscriber
3. Connect your wallet
4. Go to the user menu, and click on "Email subscription"
5. It should open a placeholder modal, and trigger a request to https://core.envelop.fyi/subscriber
6. Once the request succeed, it should show the correct modal content, depending on your subscription state
7. Closing the menu will trigger a request to https://core.envelop.fyi/subscriber, if you're already subscribed, or pending email verification (so next modal opening have correct state)
8. Reopening the email subscription modal should not trigger any request to https://core.envelop.fyi/subscriber, and should remember the previous state (so no placeholder modal anymore)


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
