### PR TITLE
fix: trigger vote's reason tooltip on click

### DIFF
--- a/src/components/SpaceProposalVotesListItem.vue
+++ b/src/components/SpaceProposalVotesListItem.vue
@@ -30,7 +30,8 @@ const balanceFormatted = computed(() => {
 useTippy(refReasonTooltip, {
   content: h(TextAutolinker, { text: props.vote.reason }),
   interactive: true,
-  theme: 'urlified'
+  theme: 'urlified',
+  trigger: 'mouseenter focus click'
 });
 </script>
 


### PR DESCRIPTION
### Summary

Clocking on a vote's reason icon should trigger the tooltip, additionally to just hovering over it.

This also fix the issue with keyboard navigation where the tooltip previously does not show when just focused. With this PR, we can click ENTER or SPACEBAR after focusing on the reason icon, to show the tooltip.

Closes: #4426

### How to test

1. Go to a votes list with reason
2. Click on the reason icon
3. It should toggle the tooltip
4. Hover on a reason icon
5. It should also trigger the tooltip
6. Use keyboard to navigate and focus on a reason icon
7. Clicking SPACEBAR or ENTER should show the tooltip


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
