### PR TITLE
fix(ui): do not show empty error container

### DIFF
--- a/src/components/SpaceCreateContent.vue
+++ b/src/components/SpaceCreateContent.vue
@@ -159,7 +159,7 @@ const handleDrop = e => {
           </label>
         </div>
         <TuneErrorInput
-          v-if="visitedBodyInput"
+          v-if="visitedBodyInput && validationErrors?.body"
           :error="validationErrors?.body"
         />
       </div>


### PR DESCRIPTION
### Summary

On proposal creation page, the error container error is show even though it is empty, when focusing on the proposal body textarea.

As the error container has a margin top of 2px, it shift all content below slightly, see video

https://www.loom.com/share/fd6a24b49e6a414ebf13f30a912472c5?sid=35d0ef71-a6f3-4698-ab90-0c54ae69fc4b

This PR will show the error container only if does contain an error

### How to test

1. Go to the proposal creation page
2. Before, focusing the textarea will shift the discussion form by 2px
3. After, no more shifting


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
