### PR TITLE
fix: hide hamburger menu on custom domain

### DIFF
--- a/src/components/TheNavbar.vue
+++ b/src/components/TheNavbar.vue
@@ -19,6 +19,7 @@ watch(
       <div class="flex items-center py-[12px]">
         <div class="flex flex-auto items-center">
           <BaseButtonRound
+            v-if="!domain"
             class="sm:hidden"
             @click="showSidebar = !showSidebar"
           >


### PR DESCRIPTION
### Summary

Closes: #4427

### How to test

1. Go to a custom domain
2. The hambuger menu should not appear anymore

### To-Do

- [ ] The space left by the hidden menu seems weird, and should be filled by something else, like the snapshot logo, or the space name/icon

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
