### PR TITLE
fix: approval loading after approve and some wording

### DIFF
--- a/src/components/SpaceCreateOsnap.vue
+++ b/src/components/SpaceCreateOsnap.vue
@@ -17,13 +17,16 @@ defineEmits<{
       <h6>Warning</h6>
       <p class="mb-3">
         You currently have both the oSnap plugin and the SafeSnap plugin
-        installed in your space. You will continue using SafeSnap for now. If
-        you would like to use the oSnap plugin please see the oSnap
+        installed in your space. You can continue using oSnap with SafeSnap
+        without any changes to your space. If you would like to use the oSnap
+        plugin instead, please see the
         <a
           target="_blank"
           href="https://docs.uma.xyz/developers/osnap/osnap-configuration-parameters-1"
-          >migration docs.</a
+          >oSnap plugin migration docs.</a
         >
+        Otherwise please remove the oSnap plugin from your space settings for
+        the best experience with SafeSnap.
       </p>
     </div>
     <div v-else>

--- a/src/plugins/oSnap/components/HandleOutcome/HandleOutcome.vue
+++ b/src/plugins/oSnap/components/HandleOutcome/HandleOutcome.vue
@@ -143,8 +143,14 @@ async function onApproveBond() {
     if (step.value) {
       txPendingId = createPendingTransaction(step.value.hash);
       await approvingBond.next();
-      notify('Successfully approved bond');
       await sleep(3e3);
+      notify('Successfully approved bond');
+      // update our knowledge of users approval
+      userCollateralAllowance.value = await getUserCollateralAllowance(
+        collateralDetails.value.erc20Contract,
+        web3.value.account,
+        props.moduleAddress
+      );
       await updateOgProposalState();
     }
   } catch (e) {

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -404,7 +404,7 @@ export async function getOGModuleDetails(params: {
   ] = await multicall(network, provider, OPTIMISTIC_GOVERNOR_ABI as any, [
     [moduleAddress, 'optimisticOracleV3'],
     [moduleAddress, 'rules'],
-    [moduleAddress, 'bondAmount'],
+    [moduleAddress, 'getProposalBond'],
     [moduleAddress, 'liveness']
   ]);
 


### PR DESCRIPTION
### Summary

We had a bug report when using osnap and approving a bond, the approval button would not change to reflect the state of approvals on the user account, preventing them from executing the proposal. 

Secondarily we wanted to update wording around an unrelated warning when both osnap plugin and safe snap plugins are installed.

### How to test

1.  in the staging link go to this proposal: #/the-co-dao.eth/proposal/0xd6ca97171b16f6927d2d196d01bbceb69db999d808430edc5b9662052e9c9527
2. make sure you have enough eth for bond
3.  see that theres a button to approve bond. if not you may need to revoke 
4. once bond is approved, see that the buton changes to allow execution ( previously this would not change) 
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/5541d5d2-3f50-4615-b2b2-8a0eeab919a1)


Also for the wording of warning:
1. go to uma space and create a proposal
2. on second page, see that the warning matches this text:
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/80f6511e-db76-4783-9f66-4bc32084497d)


<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
