### PR TITLE
feat: add new checkbox to confirm inability to recreate space with same name

### DIFF
--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -372,7 +372,7 @@
   "settings": {
     "header": "Settings",
     "confirmLeaveMessage": " Do you really want to leave? You have unsaved changes that will be lost.",
-    "confirmDeleteSpace": " Do you really want to delete this space? This action cannot be undone and you will not be able to create a new space with the same ENS domain name.",
+    "confirmDeleteSpace": " Do you really want to delete this space? This action cannot be undone and you will not be able to use {name} again to create another space.",
     "validationErrorsMessage": "Please fix the following fields before saving:",
     "confirmInputDeleteSpace": "Enter {space} to continue:",
     "noticeSavedTitle": "Settings saved",

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -69,6 +69,7 @@ const loaded = ref(false);
 const modalControllerEditOpen = ref(false);
 const currentPage = ref(Page.GENERAL);
 const modalDeleteSpaceConfirmation = ref('');
+const modalDeleteSpaceAcknowledge = ref(false);
 const modalSettingsSavedOpen = ref(false);
 const modalSettingsSavedIgnore = useStorage(
   'snapshot.settings.saved.ignore',
@@ -115,11 +116,12 @@ const settingsPages = computed(() => [
 
 async function handleDelete() {
   modalDeleteSpaceConfirmation.value = '';
+  modalDeleteSpaceAcknowledge.value = false;
 
   const result = await send(props.space, 'delete-space', {});
   console.log(':handleDelete result', result);
 
-  if (result && result.id) {
+  if (result?.id) {
     if (domain) {
       return window.open(`https://snapshot.org/#/`, '_self');
     } else {
@@ -399,12 +401,15 @@ onBeforeRouteLeave(async () => {
     />
     <ModalConfirmAction
       :open="isConfirmDeleteOpen"
-      :disabled="modalDeleteSpaceConfirmation !== space.id"
+      :disabled="
+        modalDeleteSpaceConfirmation !== space.id ||
+        !modalDeleteSpaceAcknowledge
+      "
       show-cancel
       @close="cancelDelete"
       @confirm="handleDelete"
     >
-      <BaseMessageBlock level="warning" class="m-4">
+      <BaseMessageBlock level="warning-red" class="m-4">
         {{ $t('settings.confirmDeleteSpace') }}
       </BaseMessageBlock>
       <div class="px-4 pb-4">
@@ -414,6 +419,12 @@ onBeforeRouteLeave(async () => {
           focus-on-mount
         >
         </BaseInput>
+        <TuneCheckbox
+          id="space-delete-acknowledge"
+          v-model="modalDeleteSpaceAcknowledge"
+          hint="I acknowledge that I can not create a new space with the same name ENS domain name"
+          class="mt-3"
+        />
       </div>
     </ModalConfirmAction>
     <ModalNotice

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -422,7 +422,7 @@ onBeforeRouteLeave(async () => {
         <TuneCheckbox
           id="space-delete-acknowledge"
           v-model="modalDeleteSpaceAcknowledge"
-          hint="I acknowledge that I can not create a new space with the same name ENS domain name"
+          :hint="`I acknowledge that I will not be able to use ${space.id} again to create a new space.`"
           class="mt-3"
         />
       </div>

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -410,7 +410,7 @@ onBeforeRouteLeave(async () => {
       @confirm="handleDelete"
     >
       <BaseMessageBlock level="warning-red" class="m-4">
-        {{ $t('settings.confirmDeleteSpace') }}
+        {{ $t('settings.confirmDeleteSpace', { name: space.id }) }}
       </BaseMessageBlock>
       <div class="px-4 pb-4">
         <BaseInput


### PR DESCRIPTION
### Summary

Add additional checkbox on delete space modal, to make user confirm that it's impossible to re-create a space with the same name.

The goal will be to raise user awareness in case he misses the first and second warning message, as ticking a checkbox is get more attention

Closes: #4513 

### How to test

1. Go to one of your space settings, then advanced tab
2. Click on "Delete space" button
3. It should show a modal with an input and checkbox
4. Fill the input with space name
5. Tick the checkbox
6. Click on delete space 

The "Confirm" button is enable only when both form element are valid


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
