### PR TITLE
fix: disabled space votes privacy on testnet

### DIFF
--- a/src/components/BaseModalSelectItem.vue
+++ b/src/components/BaseModalSelectItem.vue
@@ -14,7 +14,7 @@ defineProps<{
       'transition-colors hover:border-skin-text cursor-pointer',
       {
         '!border-skin-link': selected,
-        'hover:!border-skin-border cursor-not-allowed': disabled
+        'hover:!border-skin-border hover:!cursor-not-allowed': disabled
       }
     ]"
   >

--- a/src/components/BaseModalSelectItem.vue
+++ b/src/components/BaseModalSelectItem.vue
@@ -4,21 +4,28 @@ defineProps<{
   title: string;
   tag?: string;
   description?: string;
+  disabled?: boolean;
 }>();
 </script>
 
 <template>
   <BaseBlock
     :class="[
-      'cursor-pointer transition-colors hover:border-skin-text',
-      { '!border-skin-link': selected }
+      'transition-colors hover:border-skin-text cursor-pointer',
+      {
+        '!border-skin-link': selected,
+        'hover:!border-skin-border cursor-not-allowed': disabled
+      }
     ]"
   >
     <div class="relative inset-y-0 flex items-center">
       <div :class="['w-full text-left', { 'pr-[44px]': selected }]">
         <div class="mb-2 flex items-center gap-2">
           <h3
-            :class="['mb-0 truncate', { 'mt-0': description }]"
+            :class="[
+              'mb-0 truncate',
+              { 'mt-0': description, 'text-skin-text': disabled }
+            ]"
             v-text="title"
           />
           <BasePill>{{ tag }}</BasePill>

--- a/src/components/ModalVotingPrivacy.vue
+++ b/src/components/ModalVotingPrivacy.vue
@@ -8,6 +8,8 @@ defineProps<{
 
 const emit = defineEmits(['close', 'update:selected']);
 
+const { env } = useApp();
+
 const types = ['shutter'];
 
 function select(id) {
@@ -31,8 +33,13 @@ function select(id) {
           :title="$t('privacy.none')"
         />
       </a>
-      <a v-for="(type, key) in types" :key="key" @click="select(type)">
+      <a
+        v-for="(type, key) in types"
+        :key="key"
+        @click="env === 'demo' ? null : select(type)"
+      >
         <BaseModalSelectItem
+          :disabled="env === 'demo'"
           :selected="type === selected"
           :title="$t(`privacy.${type}.label`)"
           :description="$t(`privacy.${type}.description`)"


### PR DESCRIPTION
### Summary

Disable voting privacy (shutter) on testnet

Closes: #4517 

### How to test

1. Go to your space settings on testnet
2. Go to votes
3. Click on privacy input
4. All options beside "All" should be disabled

When doing the same steps on mainnet, you should be able to select "Shutter"


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
