### PR TITLE
fix: show data for raw tx

### DIFF
--- a/src/plugins/oSnap/Proposal.vue
+++ b/src/plugins/oSnap/Proposal.vue
@@ -48,8 +48,8 @@ function enrichTransactionsForDisplay(transactions: Transaction[]) {
 }
 
 function enrichTransactionForDisplay(transaction: Transaction) {
-  const { to, value } = transaction;
-  const commonProperties = { to, value: formatEther(value) };
+  const { to, value, data } = transaction;
+  const commonProperties = { to, value: formatEther(value), data };
   if (transaction.type === 'raw') {
     return { ...commonProperties, type: 'Raw' };
   }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->
When creating a raw tx, the data field would not show in the proposal page

Closes: #

### How to test

1. Using an osnap space, create a new proposal
2. select raw tx
3. enter value in the data field
4. propose, and ensure the transaction shows a data field in vote page
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/d9e5cc5d-0638-4196-a83a-6970bb2ef214)

<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
