### PR TITLE
fix: debounce history pushing on search

### DIFF
--- a/src/components/TheSearchBar.vue
+++ b/src/components/TheSearchBar.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { watchDebounced } from '@vueuse/core';
+
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
@@ -46,10 +48,17 @@ function selectFilter(e) {
 function handleUpdateSearch(e: string) {
   input.value = e;
   emit('update:inputSearch', e);
-  router.push({
-    query: { ...route.query, q: e || undefined }
-  });
 }
+
+watchDebounced(
+  input,
+  () => {
+    router.push({
+      query: { ...route.query, q: input.value || undefined }
+    });
+  },
+  { debounce: 300 }
+);
 </script>
 
 <template>


### PR DESCRIPTION
### Summary

Debounce history update, when typing in the spaces search input

Closes: #4002

### How to test

1. Go to homepage
2. Start typing something long in the spaces search bar
3. Use the browser's BACK button to go back in history

Before: It go back one character at a time
After: it go back in batch of character

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
