### PR TITLE
fix: do not force error message casing

### DIFF
--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -22,7 +22,7 @@ function getErrorMessage(errorObject): string {
 
   return `${errorObject.message
     .charAt(0)
-    .toLocaleUpperCase()}${errorObject.message.slice(1).toLocaleLowerCase()}.`;
+    .toLocaleUpperCase()}${errorObject.message.slice(1)}.`;
 }
 export function validateForm(
   schema: Record<string, any>,


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Do not force form error message to be lowercase (beside first char). 

Some error message are case sensitive, like regex 

Closes: #4512

### How to test

1.

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
