### PR TITLE
fix: unblock safesnap users from making transactions with osnap

### DIFF
--- a/src/components/SpaceCreateLegacyOsnap.vue
+++ b/src/components/SpaceCreateLegacyOsnap.vue
@@ -3,7 +3,7 @@ import { ExtendedSpace } from '@/helpers/interfaces';
 
 defineProps<{
   space: ExtendedSpace | undefined;
-  legacyOsnap: { selection: boolean };
+  legacyOsnap: { selection: boolean; valid: boolean };
 }>();
 
 defineEmits<{
@@ -27,7 +27,7 @@ defineEmits<{
         will allow you to create oSnap proposals.
       </p>
     </div>
-    <div v-else>
+    <div v-else-if="legacyOsnap.valid">
       <h6>oSnap Proposal</h6>
       <p>
         Are you planning for this proposal to initiate a transaction that your
@@ -45,6 +45,22 @@ defineEmits<{
         Yes, use oSnap for transactions (this will restrict voting type to
         Basic).
       </label>
+    </div>
+    <div v-else>
+      <div
+        class="mb-4 border-y border-skin-border bg-skin-block-bg text-base md:rounded-xl md:border p-4"
+      >
+        <h6>oSnap Error</h6>
+        <p>
+          Something is wrong with your SafeSnap settings and oSnap will not work
+          correctly. Have an admin check SafeSnap configuration or
+          <a
+            href="https://docs.uma.xyz/developers/osnap/osnap-configuration-parameters-1"
+            target="_blank"
+            >migrate to the dedicated oSnap plugin.</a
+          >
+        </p>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/SpaceCreateOsnap.vue
+++ b/src/components/SpaceCreateOsnap.vue
@@ -14,7 +14,7 @@ defineEmits<{
     class="mb-4 border-y border-skin-border bg-skin-block-bg text-base md:rounded-xl md:border p-4"
   >
     <div v-if="legacyOsnap.enabled">
-      <h6>Warning</h6>
+      <h6>oSnap Warning</h6>
       <p class="mb-3">
         You currently have both the oSnap plugin and the SafeSnap plugin
         installed in your space. You can continue using oSnap with SafeSnap

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -231,13 +231,9 @@ onMounted(async () => {
 <template>
   <template v-if="hasLegacyPluginInstalled">
     <div class="rounded-2xl border p-4 text-md">
-      <h2 class="mb-2">Warning: Legacy plugin detected</h2>
+      <h2 class="mb-2">Warning: Multiple oSnap enabled plugins detected</h2>
       <p class="mb-2">
-        Using the oSnap plugin while the SafeSnap plugin is still installed on
-        your place will cause unexpected behavior.
-      </p>
-      <p class="font-bold">
-        Please remove the SafeSnap plugin before using the oSnap plugin.
+      For best experience using oSnap, please remove the SafeSnap plugin from your space.
       </p>
     </div>
   </template>

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -93,7 +93,6 @@ type DateRange = {
 };
 function sanitizeDateRange({ dateStart, dateEnd }: DateRange): DateRange {
   const { delay = 0, period = 0 } = props.space?.voting ?? {};
-  console.log('sanitizeDateRange', { dateStart, dateEnd, delay, period });
   const threeDays = 259200;
   const currentTimestamp = Math.floor(Date.now() / 1000);
 
@@ -382,19 +381,26 @@ const legacyOsnap = ref<{
   selection: boolean;
 }>({
   selection: false,
-  enabled: false
+  enabled: false,
+  valid: false
 });
 
 // Skip transaction page if osnap is enabled, its not selected to be used, and we are on the voting page
 function shouldSkipTransactions() {
   if (currentStep.value !== Step.VOTING) return false;
-  if (legacyOsnap.value.enabled && !legacyOsnap.value.selection) return true;
+  if (
+    legacyOsnap.value.enabled &&
+    legacyOsnap.value.valid &&
+    !legacyOsnap.value.selection
+  )
+    return true;
   if (hasOsnapPlugin.value && !shouldUseOsnap.value) return true;
   return false;
 }
 
 function handleLegacyOsnapToggle() {
   legacyOsnap.value.selection = !legacyOsnap.value.selection;
+  shouldUseOsnap.value = !shouldUseOsnap.value;
 }
 
 onMounted(async () => {
@@ -402,7 +408,8 @@ onMounted(async () => {
   const umaAddress = props?.space?.plugins?.safeSnap?.safes?.[0]?.umaAddress;
   if (network && umaAddress) {
     // this is how we check if osnap is enabled and valid.
-    legacyOsnap.value.enabled =
+    legacyOsnap.value.enabled = true;
+    legacyOsnap.value.valid =
       (await safeSnapPlugin.validateUmaModule(network, umaAddress)) === 'uma';
   }
   if (sourceProposal.value && !sourceProposalLoaded.value)


### PR DESCRIPTION
### Summary
We had a bug where you could not progress on creating a safesnap tx using osnap, and then we would show a big warning that shouldnt have been there on the tx page. Fixing this uncovered other issues with warnings and incorrect wording, as well as cases where safesnap is configured incorrectly. 

we now have several screens depending on your configuration:
safe snap configured incorrectly for osnap, and osnap plugin installed
![1](https://github.com/snapshot-labs/snapshot/assets/4429761/2882e495-279b-4929-a643-359f0fd27d29)

safe snap plugin configured correctly with osnap plugin as well
![2](https://github.com/snapshot-labs/snapshot/assets/4429761/b863d891-5e98-4bee-8624-a037471f29ff)

osnap plugin installed only
![3](https://github.com/snapshot-labs/snapshot/assets/4429761/b29002c8-b6bc-41fe-9dd0-89eabf09087d)

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #

### How to test

1. go to a space you can add plugins to
2. add the safesnap plugin but dont configure it correctly
3. see that we warn you of an issue cant proceed
4. configure safesnap correctly, see that you can proceed
5. add osnap plugin, see that you get a warning, but can still proceed with safesnap
6. remove safesnap plugin, see that you can proceed with osnap plugin

<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
