### PR TITLE
fix(ui): fix missing spacing on small screen

### DIFF
--- a/src/views/DelegateView.vue
+++ b/src/views/DelegateView.vue
@@ -366,7 +366,7 @@ onMounted(async () => {
       </div>
     </template>
     <template v-if="networkSupportsDelegate" #sidebar-right>
-      <BaseBlock>
+      <BaseBlock class="mt-4 lg:mt-0">
         <TuneButton
           :disabled="!isValidForm && !!web3Account"
           :loading="delegationLoading"


### PR DESCRIPTION
### Summary

Closes: #4540 

Fix missing space on small screen, for the last block element

### How to test

1. Go https://snapshot.org/#/delegate/ens.eth
2. On small screen, the last block (with the confirm button) should have a margin top
