### PR TITLE
fix: button primary color to black and white

### DIFF
--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -10,7 +10,7 @@
 
 [data-color-scheme='dark'] {
   color-scheme: dark;
-  --primary-color: #384aff;
+  --primary-color: #ffffff;
   --bg-color: #1c1b20;
   --text-color: #8b949e;
   --link-color: #ffffff;
@@ -23,7 +23,7 @@
 
 [data-color-scheme='light'] {
   color-scheme: light;
-  --primary-color: #384aff;
+  --primary-color: #000000;
   --bg-color: white;
   --text-color: #57606a;
   --link-color: #444444;

--- a/src/components/Tune/TuneButton.vue
+++ b/src/components/Tune/TuneButton.vue
@@ -15,6 +15,8 @@ withDefaults(
     disabled: false
   }
 );
+
+const { domain } = useApp();
 </script>
 
 <template>
@@ -25,7 +27,8 @@ withDefaults(
       {
         primary: primary,
         danger: variant === 'danger',
-        disabled: disabled
+        disabled: disabled,
+        '!text-skin-bg': !domain && primary
       }
     ]"
     :disabled="disabled || loading"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

As discussed on the design call we want to have the primary button color black and white for the default skin. Custom domains are unchanged and will work as before.
<img width="390" alt="Screenshot 2024-02-13 at 12 40 07 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/9b6dce29-1024-4902-8165-ff50b0e607d7">
<img width="394" alt="Screenshot 2024-02-13 at 12 40 12 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/3af33364-04c8-4c8a-91f2-0c9bf973d91d">


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
