### PR TITLE
Lowercase profile address

### DIFF
--- a/src/composables/useProfiles.ts
+++ b/src/composables/useProfiles.ts
@@ -56,7 +56,9 @@ export function useProfiles() {
       Object.keys(profilesRes[0] ?? {}).forEach(address => {
         profilesRes[0][address] = {
           ...{ ens: profilesRes[0][address] },
-          ...profilesRes[1]?.find(p => p.id.toLowerCase() === address)
+          ...profilesRes[1]?.find(
+            p => p.id.toLowerCase() === address.toLowerCase()
+          )
         };
       });
     }


### PR DESCRIPTION
### Summary

Continueing on from PR #4550 we're doing our first delegate vote and noticed the profile name doesn't show up on the proposal page.

![image](https://github.com/snapshot-labs/snapshot/assets/20125808/2cb12b8a-bcef-4f7f-85a3-fd400f00c179)

The solution looks to be to also lowercase the (profile) address.

![image](https://github.com/snapshot-labs/snapshot/assets/20125808/c049fc1f-a1c5-427c-a06c-df2172b9b263)

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
