### PR TITLE
fix: Add error messages on input duration

### DIFF
--- a/src/components/SettingsVotingBlock.vue
+++ b/src/components/SettingsVotingBlock.vue
@@ -4,7 +4,7 @@ const props = defineProps<{
   isViewOnly?: boolean;
 }>();
 
-const { form } = useFormSpaceSettings(props.context);
+const { form, validationErrors } = useFormSpaceSettings(props.context);
 </script>
 
 <template>
@@ -15,6 +15,7 @@ const { form } = useFormSpaceSettings(props.context);
           v-model="form.voting.delay"
           :label="$t('settings.votingDelay')"
           :disabled="isViewOnly"
+          :error="validationErrors?.voting?.delay"
           hide-minutes
           block
         />
@@ -23,6 +24,7 @@ const { form } = useFormSpaceSettings(props.context);
           v-model="form.voting.period"
           :label="$t('settings.votingPeriod')"
           :disabled="isViewOnly"
+          :error="validationErrors?.voting?.period"
           hide-minutes
           block
         />

--- a/src/components/Tune/TuneInputDuration.vue
+++ b/src/components/Tune/TuneInputDuration.vue
@@ -3,6 +3,7 @@ interface DurationInputProps {
   modelValue: number;
   label?: string;
   hint?: string;
+  error?: string;
   definition?: any;
   hideDay?: boolean;
   hideMinutes?: boolean;
@@ -75,6 +76,16 @@ const inputRef = ref<any[]>([]);
 function addRef(ref: any) {
   inputRef.value.push(ref);
 }
+
+const showErrorMessage = ref(false);
+
+function forceShowError() {
+  showErrorMessage.value = true;
+}
+
+defineExpose({
+  forceShowError
+});
 </script>
 
 <template>
@@ -86,6 +97,7 @@ function addRef(ref: any) {
       :class="[
         'tune-input-duration inline-flex overflow-hidden',
         { 'w-full': block },
+        { 'tune-error-border': error && showErrorMessage },
         { disabled: disabled }
       ]"
       @click="inputRef?.[0].focus()"
@@ -111,6 +123,8 @@ function addRef(ref: any) {
                 ($event.target as HTMLInputElement)?.valueAsNumber
               )
             "
+            @blur="error ? (showErrorMessage = true) : null"
+            @focus="error ? null : (showErrorMessage = false)"
           />
           <span class="tune-input-duration-label">
             {{ item.label }}
@@ -118,6 +132,7 @@ function addRef(ref: any) {
         </div>
       </template>
     </div>
+    <TuneErrorInput v-if="error && showErrorMessage" :error="error" />
   </div>
 </template>
 


### PR DESCRIPTION
### Summary
No error messages for voting delay and period, which can confuse users if we merge this PR https://github.com/snapshot-labs/snapshot.js/pull/961

### How to test
1. Go to your space settings -> voting tab -> enter invalid values into `delay` and `period`
2. No error before
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/84ee07c5-7cd7-417c-b4cc-9fb3c84ffa57)
3. After fix, you should see errors similar to other inputs
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/2fab3441-0e0d-4ac6-9386-0afe7a0bb4aa)
