### PR TITLE
feat: add mantle safe to known hosts

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -14,7 +14,8 @@ export const SNAPSHOT_BREAKPOINTS = {
 export const KNOWN_HOSTS = [
   'app.safe.global',
   'pilot.gnosisguild.org',
-  'metissafe.tech'
+  'metissafe.tech',
+  'multisig.mantle.xyz'
 ];
 
 export const SPACE_CATEGORIES = [


### PR DESCRIPTION
### Summary
Adds Mantle Safe host to known hosts to enable multi-signature wallets interact with snapshot as a safe app.
Mantle Safe URL: https://multisig.mantle.xyz

Closes: #4573 

### How to test
1. Open Mantle Safe and either create or open safe wallet: https://multisig.mantle.xyz/welcome
2. Go to custom apps
3. Add snapshot URL (for mainnet: https://snapshot.org/, for testnet: https://testnet.snapshot.org/, local - http://localhost:8080)
4. Find a Mantle space and proposal and try voting. (For prepared test proposal see below).

#### Testnet voting proposal
- Open testnet (local) snapshot safe app in Mantle Safe;
- Search for "[Testing Snapshot Voting](https://testnet.snapshot.org/#/testingsafe.eth)" space (created for Mantle network).
- Navigate to the latest [proposal](https://testnet.snapshot.org/#/testingsafe.eth/proposal/0xb867235402eff21f77d9d7dc534443531a4af8264276a656ee834609b5f944b3)
- Try voting. Safe should be able to sign messages using EIP-1271.

<!--
### Self-review checklist
- [X] I have performed a full self-review of my changes
- [X] I have tested my changes on a preview deployment
- [X] I have tested my changes on different screen sizes (sm, md)
-->
