### PR TITLE
feat: add core network support to osnap plugin

### DIFF
--- a/src/plugins/oSnap/constants.ts
+++ b/src/plugins/oSnap/constants.ts
@@ -1418,6 +1418,15 @@ export const contractData = [
     deployBlock: 27816737
   },
   {
+    // core
+    network: '1116',
+    name: 'OptimisticOracleV3',
+    address: '0xD84ACa67d683aF7702705141b3C7E57e4e5e7726',
+    subgraph:
+      'https://thegraph.coredao.org/subgraphs/name/umaprotocol/core-optimistic-oracle-v3',
+    deployBlock: 11341063
+  },
+  {
     // mainnet
     network: '1',
     name: 'OptimisticGovernor',
@@ -1480,6 +1489,15 @@ export const contractData = [
     deployBlock: 28050250,
     subgraph:
       'https://api.thegraph.com/subgraphs/name/umaprotocol/avalanche-optimistic-governor'
+  },
+  {
+    // core
+    network: '1116',
+    name: 'OptimisticGovernor',
+    address: '0x596Fd6A5A185c67aBD1c845b39f593fBA9C233aa',
+    deployBlock: 11341122,
+    subgraph:
+    'https://thegraph.coredao.org/subgraphs/name/umaprotocol/core-optimistic-governor'
   }
 ] as const;
 

--- a/src/plugins/oSnap/constants.ts
+++ b/src/plugins/oSnap/constants.ts
@@ -1105,7 +1105,8 @@ export const EXPLORER_API_URLS = {
   '246': 'https://explorer.energyweb.org/api',
   '137': 'https://api.polygonscan.com/api',
   '56': 'https://api.bscscan.com/api',
-  '42161': 'https://api.arbiscan.io/api'
+  '42161': 'https://api.arbiscan.io/api',
+  // '1116': Add 'https://openapi.coredao.org/api' if API key requirement is removed
 } as const;
 
 export const GNOSIS_SAFE_TRANSACTION_API_URLS = {
@@ -1116,7 +1117,20 @@ export const GNOSIS_SAFE_TRANSACTION_API_URLS = {
   '246': 'https://safe-transaction-ewc.safe.global/api',
   '137': 'https://safe-transaction-polygon.safe.global/api',
   '56': 'https://safe-transaction-bsc.safe.global/api',
-  '42161': 'https://safe-transaction-arbitrum.safe.global/api'
+  '42161': 'https://safe-transaction-arbitrum.safe.global/api',
+  // '1116': Add when public tx service is available for Core
+} as const;
+
+export const SAFE_APP_URLS = {
+  '1': 'https://app.safe.global/apps/open',
+  '5': 'https://app.safe.global/apps/open',
+  '100': 'https://app.safe.global/apps/open',
+  '73799': 'https://app.safe.global/apps/open',
+  '246': 'https://app.safe.global/apps/open',
+  '137': 'https://app.safe.global/apps/open',
+  '56': 'https://app.safe.global/apps/open',
+  '42161': 'https://app.safe.global/apps/open',
+  '1116': 'https://safe.coredao.org/apps/open'
 } as const;
 
 // ABIs

--- a/src/plugins/oSnap/utils/coins.ts
+++ b/src/plugins/oSnap/utils/coins.ts
@@ -48,7 +48,7 @@ const CORE_COIN = {
   symbol: 'CORE',
   address: 'main',
   decimals: 18,
-  logiUri:
+  logoUri:
     'https://cloudflare-ipfs.com/ipfs/bafkreigjv5yb7uhlrryzib7j2f73nnwqan2tmfnwjdu26vkk365fyesoiu'
 } as const;
 

--- a/src/plugins/oSnap/utils/coins.ts
+++ b/src/plugins/oSnap/utils/coins.ts
@@ -43,6 +43,14 @@ const BNB_COIN = {
   logoUri:
     'https://safe-transaction-assets.safe.global/chains/56/currency_logo.png'
 } as const;
+const CORE_COIN = {
+  name: 'Core',
+  symbol: 'CORE',
+  address: 'main',
+  decimals: 18,
+  logiUri:
+    'https://cloudflare-ipfs.com/ipfs/bafkreigjv5yb7uhlrryzib7j2f73nnwqan2tmfnwjdu26vkk365fyesoiu'
+} as const;
 
 export function getNativeAsset(network: Network) {
   switch (parseInt(network)) {
@@ -55,6 +63,8 @@ export function getNativeAsset(network: Network) {
       return EWC_COIN;
     case 56:
       return BNB_COIN;
+    case 1116:
+      return CORE_COIN;
   }
 
   return ETHEREUM_COIN;

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -15,6 +15,7 @@ import {
   GNOSIS_SAFE_TRANSACTION_API_URLS,
   OPTIMISTIC_GOVERNOR_ABI,
   OPTIMISTIC_ORACLE_V3_ABI,
+  SAFE_APP_URLS,
   contractData,
   safePrefixes,
   solidityZeroHexString
@@ -248,9 +249,9 @@ export function makeConfigureOsnapUrl(params: {
     network,
     spaceName,
     spaceUrl,
-    baseUrl = 'https://app.safe.global/apps/open',
     appUrl = 'https://osnap.uma.xyz/'
   } = params;
+  const baseUrl = params.baseUrl ?? SAFE_APP_URLS[network] ?? 'https://app.safe.global/apps/open';
   const safeAddressPrefix = getSafeNetworkPrefix(network);
   const appUrlSearchParams = new URLSearchParams();
   appUrlSearchParams.set('spaceName', spaceName);

--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -18,7 +18,8 @@ export const EIP3770_PREFIXES = {
   246: 'ewt',
   73799: 'vt',
   42161: 'arb1',
-  137: 'matic'
+  137: 'matic',
+  1116: 'core'
 };
 
 export const EXPLORER_API_URLS = {
@@ -348,6 +349,7 @@ export const MULTI_SEND_V1_3_0 = {
   '288': '0x998739BFdAAdde7C933B942a68053933098f9EDa',
   '588': '0x998739BFdAAdde7C933B942a68053933098f9EDa',
   '1088': '0x998739BFdAAdde7C933B942a68053933098f9EDa',
+  '1116': '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761',
   '1285': '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761',
   '1287': '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761',
   '4002': '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761',
@@ -461,6 +463,15 @@ export const contractData: ContractData[] = [
     deployBlock: 27816737
   },
   {
+    // core
+    network: '43114',
+    name: 'OptimisticOracleV3',
+    address: '0xD84ACa67d683aF7702705141b3C7E57e4e5e7726',
+    subgraph:
+      'https://thegraph.coredao.org/subgraphs/name/umaprotocol/core-optimistic-oracle-v3',
+    deployBlock: 11341063
+  },
+  {
     // mainnet
     network: '1',
     name: 'OptimisticGovernor',
@@ -523,5 +534,14 @@ export const contractData: ContractData[] = [
     deployBlock: 28050250,
     subgraph:
       'https://api.thegraph.com/subgraphs/name/umaprotocol/avalanche-optimistic-governor'
+  },
+  {
+    // core
+    network: '1116',
+    name: 'OptimisticGovernor',
+    address: '0x596Fd6A5A185c67aBD1c845b39f593fBA9C233aa',
+    deployBlock: 11341122,
+    subgraph:
+      'https://thegraph.coredao.org/subgraphs/name/umaprotocol/core-optimistic-governor'
   }
 ];

--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -30,7 +30,8 @@ export const EXPLORER_API_URLS = {
   '246': 'https://explorer.energyweb.org/api',
   '137': 'https://api.polygonscan.com/api',
   '56': 'https://api.bscscan.com/api',
-  '42161': 'https://api.arbiscan.io/api'
+  '42161': 'https://api.arbiscan.io/api',
+  // '1116': Add 'https://openapi.coredao.org/api' if API key requirement is removed
 };
 
 export const GNOSIS_SAFE_TRANSACTION_API_URLS = {
@@ -41,7 +42,8 @@ export const GNOSIS_SAFE_TRANSACTION_API_URLS = {
   '246': 'https://safe-transaction-ewc.safe.global/api',
   '137': 'https://safe-transaction-polygon.safe.global/api',
   '56': 'https://safe-transaction-bsc.safe.global/api',
-  '42161': 'https://safe-transaction-arbitrum.safe.global/api'
+  '42161': 'https://safe-transaction-arbitrum.safe.global/api',
+  // '1116': // Add when public tx service is available for Core
 };
 
 // ABIs

--- a/src/plugins/safeSnap/utils/coins.ts
+++ b/src/plugins/safeSnap/utils/coins.ts
@@ -41,6 +41,14 @@ const BNB_COIN: TokenAsset = {
   logoUri:
     'https://safe-transaction-assets.safe.global/chains/56/currency_logo.png'
 };
+const CORE_COIN: TokenAsset = {
+  name: 'Core',
+  symbol: 'CORE',
+  address: 'main',
+  decimals: 18,
+  logoUri:
+    'https://cloudflare-ipfs.com/ipfs/bafkreigjv5yb7uhlrryzib7j2f73nnwqan2tmfnwjdu26vkk365fyesoiu'
+};
 
 export function getNativeAsset(network: Network) {
   switch (parseInt(network)) {
@@ -53,7 +61,9 @@ export function getNativeAsset(network: Network) {
       return EWC_COIN;
     case 56:
       return BNB_COIN;
-  }
+    case 1116:
+      return CORE_COIN;
+    }
 
   return ETHEREUM_COIN;
 }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

We want to add core dao support in oSnap.  This adds core support in oSnap plugin and safesnap plugin.  Due to external dependencies we are only able to get partial support for core but basic transactions will work. We are shipping this with partial support for Core, as the Coredao team is aware of this. 

There are still couple of outstanding issues for adding Core support:

- Safe app links in both oSnap/safeSnap tx builder does not work as Core Safe app instance does not support safe externally
- Transaction builder is not able to automatically fetch contract ABI since Core chain explorer requires API key to fetch that.
- Transaction builder fails to load token/NFT balances for Core as Covalent service does not support Core network:


### How to test

1. Add core treasury to safe snap enabled space
2. See that you can create proposals with osnap and core chain transactions


TODO: Once third party dependencies are worked out, update to enable missing features

<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
