### PR TITLE
fix: osnap snapshot tx builder bug

### DIFF
--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -112,9 +112,13 @@ function enhanceTokensWithBalances(
     )
     .map(balance => enhanceTokenWithBalance(balance, tokens, network))
     .sort((a, b) => {
-      if (a.verified && b.verified) return 0;
-      if (a.verified) return -1;
-      return 1;
+      if (a.address === 'main' && b.address !== 'main') return -1;
+      if (!(a.address === 'main') && b.address === 'main') return 1;
+      if (a.verified && !b.verified) return -1;
+      if (!a.verified && b.verified) return +1;
+      if (!a.balance || !b.balance) return 0;
+      if (parseFloat(a.balance) > parseFloat(b.balance)) return -1;
+      return 0;
     });
 }
 

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -22,6 +22,7 @@ import {
 } from './utils';
 import OsnapMarketingWidget from './components/OsnapMarketingWidget.vue';
 import BotSupportWarning from './components/BotSupportWarning.vue';
+import { getAddress } from '@ethersproject/address';
 
 const props = defineProps<{
   space: ExtendedSpace;
@@ -183,7 +184,7 @@ async function createOsnapEnabledSafes() {
       );
       return {
         safeName: treasury.name,
-        safeAddress: treasury.address,
+        safeAddress: getAddress(treasury.address),
         network: treasury.network as Network,
         transactions: [] as Transaction[],
         moduleAddress

--- a/src/plugins/oSnap/components/TransactionBuilder/TokensModalItem.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TokensModalItem.vue
@@ -54,7 +54,7 @@ const exploreUrl = computed(() => {
     </div>
 
     <div class="h-full text-right">
-      <span v-if="token.address !== 'main'" class="text-skin-link">
+      <span class="text-skin-link">
         {{
           formatNumber(
             Number(token.balance),

--- a/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
@@ -34,7 +34,7 @@ const selectedTokenAddress = ref<Token['address']>(
 const selectedToken = computed(
   () =>
     tokens.value.find(token => token.address === selectedTokenAddress.value) ??
-    tokens.value.find(token => !token.address) ??
+    tokens.value.find(token => token.address === 'main') ??
     tokens.value[0]
 );
 

--- a/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
@@ -23,10 +23,9 @@ const emit = defineEmits<{
   updateTransaction: [transaction: TransferFundsTransaction];
 }>();
 
-const nativeAsset = getNativeAsset(props.network);
 const amount = ref(props.transaction.amount ?? '');
 const recipient = ref(props.transaction.recipient ?? '');
-const tokens = ref<Token[]>([nativeAsset, ...props.tokens]);
+const tokens = ref<Token[]>(props.tokens);
 
 const selectedTokenAddress = ref<Token['address']>(
   props.transaction?.token?.address ?? 'main'
@@ -35,7 +34,8 @@ const selectedTokenAddress = ref<Token['address']>(
 const selectedToken = computed(
   () =>
     tokens.value.find(token => token.address === selectedTokenAddress.value) ??
-    nativeAsset
+    tokens.value.find(token => !token.address) ??
+    tokens.value[0]
 );
 
 const isTokenModalOpen = ref(false);

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -35,6 +35,7 @@ import {
   TransactionsProposedEvent
 } from '../types';
 import { getPagedEvents } from './events';
+import { getAddress } from '@ethersproject/address';
 
 /**
  * Calls the Gnosis Safe Transaction API
@@ -55,7 +56,8 @@ async function callGnosisSafeTransactionApi<TResult = any>(
  */
 export const getGnosisSafeBalances = memoize(
   (network: Network, safeAddress: string) => {
-    const endpointPath = `/v1/safes/${safeAddress}/balances?exclude_spam=true`;
+    const checksumAddress = getAddress(safeAddress);
+    const endpointPath = `/v1/safes/${checksumAddress}/balances?exclude_spam=true`;
     return callGnosisSafeTransactionApi<Partial<BalanceResponse>[]>(
       network,
       endpointPath

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -55,7 +55,7 @@ async function callGnosisSafeTransactionApi<TResult = any>(
  */
 export const getGnosisSafeBalances = memoize(
   (network: Network, safeAddress: string) => {
-    const endpointPath = `/v1/safes/${safeAddress}/balances/`;
+    const endpointPath = `/v1/safes/${safeAddress}/balances?exclude_spam=true`;
     return callGnosisSafeTransactionApi<Partial<BalanceResponse>[]>(
       network,
       endpointPath


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

There was a bug in the transaction builder where the app would load all tokens you have balances for (your safe on a certain network), then when you switch safes, that list of tokens would not update. We also were not including the balance of the native token in the token chooser modal. This was because the balance pulled from gnosis, if that balance was for a native token it would be stripped out by the app, then later we just hardcoded in the native asset for the chain as an option, but without the balance info.

This PR rectifies some of the state management so that we reload token balances and token lists when we switch safes.
It also ensures we keep the safe's balance for native tokens so we can display this data to the user.

![image](https://github.com/snapshot-labs/snapshot/assets/4429761/29e5bc65-10ba-4036-a988-d17654129a0b)

### How to test

1. go to an osnap plugin enabled space
2. create a proposal, in the transactiion builder select send tokens
3. see that safe assets show up in the assets list


<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
