### PR TITLE
fix: store safe addresses as checksum

### DIFF
--- a/src/components/ModalTreasury.vue
+++ b/src/components/ModalTreasury.vue
@@ -2,6 +2,7 @@
 import { clone, validateSchema } from '@snapshot-labs/snapshot.js/src/utils';
 import schemas from '@snapshot-labs/snapshot.js/src/schemas';
 import { TreasuryWallet } from '@/helpers/interfaces';
+import { toChecksumAddress } from '@/helpers/utils';
 
 const props = defineProps<{
   open: boolean;
@@ -35,7 +36,9 @@ const isValid = computed(() =>
 );
 
 function handleSubmit() {
+  const checksumAddress = toChecksumAddress(input.value.address);
   const treasuryObj = clone(input.value);
+  treasuryObj.address = checksumAddress;
   emit('add', treasuryObj);
   emit('close');
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -4,6 +4,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import voting from '@snapshot-labs/snapshot.js/src/voting';
 import { getUrl } from '@snapshot-labs/snapshot.js/src/utils';
+import { getAddress } from '@ethersproject/address';
 
 export function shortenAddress(str = '') {
   return `${str.slice(0, 6)}...${str.slice(str.length - 4)}`;
@@ -181,4 +182,8 @@ export function isSnapshotUrl(url: string) {
   }
 
   return false;
+}
+
+export function toChecksumAddress(address: string) {
+  return getAddress(address.toLowerCase());
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -184,6 +184,11 @@ export function isSnapshotUrl(url: string) {
   return false;
 }
 
+
 export function toChecksumAddress(address: string) {
-  return getAddress(address.toLowerCase());
+  try {
+    return getAddress(address.toLowerCase());
+  } catch (e) {
+    return address;
+  }
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -184,7 +184,6 @@ export function isSnapshotUrl(url: string) {
   return false;
 }
 
-
 export function toChecksumAddress(address: string) {
   try {
     return getAddress(address.toLowerCase());

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -22,7 +22,7 @@ import {
 } from './utils';
 import OsnapMarketingWidget from './components/OsnapMarketingWidget.vue';
 import BotSupportWarning from './components/BotSupportWarning.vue';
-import { getAddress } from '@ethersproject/address';
+import { toChecksumAddress } from '@/helpers/utils';
 
 const props = defineProps<{
   space: ExtendedSpace;
@@ -184,7 +184,7 @@ async function createOsnapEnabledSafes() {
       );
       return {
         safeName: treasury.name,
-        safeAddress: getAddress(treasury.address),
+        safeAddress: toChecksumAddress(treasury.address),
         network: treasury.network as Network,
         transactions: [] as Transaction[],
         moduleAddress

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -36,7 +36,7 @@ import {
   TransactionsProposedEvent
 } from '../types';
 import { getPagedEvents } from './events';
-import { getAddress } from '@ethersproject/address';
+import { toChecksumAddress } from '@/helpers/utils';
 
 /**
  * Calls the Gnosis Safe Transaction API
@@ -57,7 +57,7 @@ async function callGnosisSafeTransactionApi<TResult = any>(
  */
 export const getGnosisSafeBalances = memoize(
   (network: Network, safeAddress: string) => {
-    const checksumAddress = getAddress(safeAddress);
+    const checksumAddress = toChecksumAddress(safeAddress);
     const endpointPath = `/v1/safes/${checksumAddress}/balances?exclude_spam=true`;
     return callGnosisSafeTransactionApi<Partial<BalanceResponse>[]>(
       network,
@@ -254,7 +254,10 @@ export function makeConfigureOsnapUrl(params: {
     spaceUrl,
     appUrl = 'https://osnap.uma.xyz/'
   } = params;
-  const baseUrl = params.baseUrl ?? SAFE_APP_URLS[network] ?? 'https://app.safe.global/apps/open';
+  const baseUrl =
+    params.baseUrl ??
+    SAFE_APP_URLS[network] ??
+    'https://app.safe.global/apps/open';
   const safeAddressPrefix = getSafeNetworkPrefix(network);
   const appUrlSearchParams = new URLSearchParams();
   appUrlSearchParams.set('spaceName', spaceName);


### PR DESCRIPTION
### Summary

When calling safe's API to fetch token balances for a particular safe, the checksum check would sometimes fail.
This PR ensures that:
- If a user attempts to add a treasury with a mixed-case or non-checksum address, we convert it first.
- All calls to gnosis api converts addresses to checksum, in case.

Closes: #

### How to test

1. Go to settings > advanced > add treasury > enter mixed case or lowercase address 
2. See that the submitted safe address is correctly converted to checksum

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
