### PR TITLE
fix(osnap): fix proposal execution step

### DIFF
--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -616,12 +616,14 @@ export async function getOGProposalStateGql(params: {
     return { status: 'can-propose-to-og', isDisputed: true };
   }
 
+  // no assertion made yet
   if (!hasAssertionId) {
     return { status: 'can-propose-to-og', isDisputed: false };
   }
 
   const assertion = await getAssertionGql({ network, assertionId });
 
+  // cannot find assertion for some reason
   if (!assertion) {
     return { status: 'can-propose-to-og', isDisputed: false };
   }
@@ -666,9 +668,8 @@ export async function getOGProposalStateGql(params: {
     };
   }
 
-  // if all the above fails, fall back to the no assertion state
-  // this should not be possible though
-  return { status: 'can-propose-to-og', isDisputed: false };
+  // request execution if there is no settlement yet and liveness has expired
+  return { status: 'can-request-tx-execution', assertionHash, assertionLogIndex };
 }
 
 /**


### PR DESCRIPTION
### Summary

We have a proposal that cant be executed in osnap. This fixes the state machine logic to handle the case where we should be able to execute a proposal. 
currently it looks like this:
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/1b4aa1f3-a787-4594-9995-ec8135c9bc07)

after fix:
![image](https://github.com/snapshot-labs/snapshot/assets/4429761/60c54f25-4e84-4190-a41f-fa7dc90deef8)


### How to test

1.  visit : /#/umadev.eth/proposal/0xb588a73b28666fb143e8c87473a9ca17abbd180875f5551d71de52354d0f7c0f
2. see that you can execute this proposal

<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
