### PR TITLE
fix(ui): fix overflowing image due to border radius

### DIFF
--- a/src/views/PaymentNetwork.vue
+++ b/src/views/PaymentNetwork.vue
@@ -96,7 +96,7 @@ watch(paymentTx, () => {
           :key="planId"
           :class="[
             {
-              'bg-[#384aff]/20 rounded-xl px-[1px] pb-[1px] mb-[-1px]':
+              'bg-[#384aff]/20 rounded-xl px-[1px] pb-[1px] mb-[-1px] overflow-hidden':
                 plan.discount
             }
           ]"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

The star background is not cut when the parent element have a border radius, making it spilling over the element

![Screenshot 2024-03-05 at 03 56 04](https://github.com/snapshot-labs/snapshot/assets/495709/03675891-e710-4771-9016-f20659746a75)


Closes: #

### How to test

1. Go to  http://localhost:8080/#/payment/network
2. The star background on the first option should not overflow over the border radius

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
