### PR TITLE
fix: Boost fixes

### DIFF
--- a/src/components/SpaceProposalBoost.vue
+++ b/src/components/SpaceProposalBoost.vue
@@ -117,8 +117,8 @@ function handleStart() {
 async function loadBoosts() {
   try {
     const response = await getBoosts([props.proposal.id]);
-    const cleanBoosts = sanitizeBoosts(response, [props.proposal]);
-    boosts.value = cleanBoosts;
+    const sanitizedBoosts = sanitizeBoosts(response, [props.proposal]);
+    boosts.value = sanitizedBoosts;
   } catch (e) {
     console.error('Load boosts error:', e);
   }

--- a/src/components/SpaceProposalBoost.vue
+++ b/src/components/SpaceProposalBoost.vue
@@ -31,7 +31,9 @@ const router = useRouter();
 const { formatRelativeTime, longRelativeTimeFormatter } = useIntl();
 const { userVote, loadUserVote } = useProposalVotes(props.proposal);
 const { web3Account } = useWeb3();
-const { bribeDisabled } = useBoost({ spaceId: props.proposal.space.id });
+const { sanitizeBoosts } = useBoost({
+  spaceId: props.proposal.space.id
+});
 const dontShowModalAgain = useStorage(
   'snapshot.boosts-modal-dont-show-again',
   false
@@ -113,15 +115,9 @@ function handleStart() {
 }
 
 async function loadBoosts() {
-  // TODO: Filter boosts that where start doesn't match proposal end
   try {
     const response = await getBoosts([props.proposal.id]);
-    const cleanBoosts = response.filter(boost => {
-      if (bribeDisabled.value) {
-        return boost.strategy.eligibility.type !== 'bribe';
-      }
-      return true;
-    });
+    const cleanBoosts = sanitizeBoosts(response, [props.proposal]);
     boosts.value = cleanBoosts;
   } catch (e) {
     console.error('Load boosts error:', e);

--- a/src/components/SpaceProposalBoostItem.vue
+++ b/src/components/SpaceProposalBoostItem.vue
@@ -132,10 +132,10 @@ const amountPerWinner = computed(() => {
     BigNumber.from(props.boost.strategy.distribution.numWinners)
   );
 
-  return `${formatNumber(
+  return formatNumber(
     Number(formatUnits(amount, props.boost.token.decimals)),
     getNumberFormatter({ maximumFractionDigits: 8 }).value
-  )} ${props.boost.token.symbol}`;
+  );
 });
 
 const lotteryNoRewardFinal = computed(() => {
@@ -271,13 +271,12 @@ const { pause } = useIntervalFn(() => {
             </div>
             <div v-else-if="isLottery" class="mt-1 mr-1 flex items-center">
               can win
-              <!-- TODO: Show final reward when final -->
               <div>
                 <TuneTag
                   v-tippy="{
                     content: `The pool of ${boostBalanceFormatted} ${boost.token.symbol} will be equally distributed among ${boost.strategy.distribution.numWinners} winners. Chances of winning are proportional to the amount of voting-power. If the maximum amount of winners is not reached, the reward will be increased equally.`
                   }"
-                  :label="amountPerWinner"
+                  :label="`${amountPerWinner} ${props.boost.token.symbol}`"
                   class="text-skin-heading ml-1 cursor-help"
                 />
               </div>
@@ -394,14 +393,13 @@ const { pause } = useIntervalFn(() => {
                 View winners
               </button>
             </div>
-
             <div
               v-else-if="isEligible"
               class="flex flex-wrap items-center justify-center gap-x-1"
             >
               <i-ho-fire class="text-xs" />
               <template v-if="reward && isFinal">
-                You can claim
+                Claim
                 {{ `${rewardFormatted} ${boost.token.symbol}` }}
                 <button
                   v-if="isLottery"
@@ -415,6 +413,19 @@ const { pause } = useIntervalFn(() => {
               <template v-else> You are eligible </template>
             </div>
           </div>
+          <BaseMessage
+            v-if="
+              isLottery &&
+              Number(rewardFormatted) > 0 &&
+              Number(amountPerWinner) < Number(rewardFormatted)
+            "
+            level="info"
+            class="border bg-[--border-color-subtle] p-3 rounded-xl text-skin-text mt-2"
+          >
+            The reward increased due to not enough eligible voters to hit the
+            {{ boost.strategy.distribution.numWinners }} winner cap for this
+            boost.
+          </BaseMessage>
         </div>
         <SpaceProposalBoostItemMenu
           :boost="boost"

--- a/src/composables/useBoost.ts
+++ b/src/composables/useBoost.ts
@@ -1,4 +1,6 @@
 import { BOOST_WHITELIST_SETTINGS } from '@/helpers/boost';
+import { BoostSubgraph } from '@/helpers/boost/types';
+import { Proposal } from '@/helpers/interfaces';
 
 export function useBoost({ spaceId }: { spaceId: string }) {
   const { env } = useApp();
@@ -11,8 +13,24 @@ export function useBoost({ spaceId }: { spaceId: string }) {
     return BOOST_WHITELIST_SETTINGS[env]?.[spaceId]?.bribeDisabled;
   });
 
+  function sanitizeBoosts(boosts: BoostSubgraph[], proposals: Proposal[]) {
+    return boosts.filter(boost => {
+      if (bribeDisabled.value && boost.strategy.eligibility.type === 'bribe') {
+        return false;
+      }
+      if (
+        Number(boost.start) !==
+        proposals.find(p => p.id === boost.strategy.proposal)?.end
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }
+
   return {
     isWhitelisted,
-    bribeDisabled
+    bribeDisabled,
+    sanitizeBoosts
   };
 }

--- a/src/composables/useBoost.ts
+++ b/src/composables/useBoost.ts
@@ -1,6 +1,7 @@
 import { BOOST_WHITELIST_SETTINGS } from '@/helpers/boost';
 import { BoostSubgraph } from '@/helpers/boost/types';
 import { Proposal } from '@/helpers/interfaces';
+import { TWO_WEEKS } from '@/helpers/constants';
 
 export function useBoost({ spaceId }: { spaceId: string }) {
   const { env } = useApp();
@@ -22,6 +23,9 @@ export function useBoost({ spaceId }: { spaceId: string }) {
         Number(boost.start) !==
         proposals.find(p => p.id === boost.strategy.proposal)?.end
       ) {
+        return false;
+      }
+      if (Number(boost.end) - Number(boost.start) !== TWO_WEEKS) {
         return false;
       }
       return true;

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -36,7 +36,7 @@ const { profiles, loadProfiles } = useProfiles();
 const { apolloQuery } = useApolloQuery();
 const { web3Account } = useWeb3();
 const { isFollowing } = useFollowSpace(props.space.id);
-const { isWhitelisted, bribeDisabled } = useBoost({ spaceId: props.space.id });
+const { isWhitelisted, sanitizeBoosts } = useBoost({ spaceId: props.space.id });
 const {
   store,
   userVotedProposalIds,
@@ -99,12 +99,7 @@ async function loadBoosts(proposals: Proposal[]) {
     const response = await getBoosts(
       proposalsToLoad.map(proposal => proposal.id)
     );
-    const cleanBoosts = response.filter(boost => {
-      if (bribeDisabled.value) {
-        return boost.strategy.eligibility.type !== 'bribe';
-      }
-      return true;
-    });
+    const cleanBoosts = sanitizeBoosts(response, proposals);
     boosts.value = boosts.value.concat(cleanBoosts);
   } catch (e) {
     console.error('Load boosts error:', e);

--- a/src/views/SpaceProposals.vue
+++ b/src/views/SpaceProposals.vue
@@ -99,8 +99,8 @@ async function loadBoosts(proposals: Proposal[]) {
     const response = await getBoosts(
       proposalsToLoad.map(proposal => proposal.id)
     );
-    const cleanBoosts = sanitizeBoosts(response, proposals);
-    boosts.value = boosts.value.concat(cleanBoosts);
+    const sanitizedBoosts = sanitizeBoosts(response, proposals);
+    boosts.value = boosts.value.concat(sanitizedBoosts);
   } catch (e) {
     console.error('Load boosts error:', e);
   }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

1. With lottery sometimes rewards turn out to be higher because were not enough voters. So instead of just changing the reward amount in the boost description when rewards are final (like we discussed), I decided to show a message because I think it will be confusing for the user to see a different reward amount in the boost description than he saw previously. 
<img width="589" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/51686767/55dc1f4e-8489-44b1-ae6f-048f389a60aa">

2. Sanitize boosts where proposal end doesn't match boost start time.
3. Sanitize boosts that don't have 2 week period 



<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
