### PR TITLE
fix: use select instead of listbox for boost eligibility dropdown 

### DIFF
--- a/src/assets/css/tune.scss
+++ b/src/assets/css/tune.scss
@@ -97,7 +97,7 @@
 }
 
 .tune-select {
-  @apply text-left;
+  @apply form-select text-left px-3 border border-skin-border w-full rounded-full outline-none focus:ring-0 focus:border-skin-text text-skin-link bg-skin-bg text-base;
 
   &.disabled {
     @apply cursor-not-allowed;

--- a/src/components/Tune/TuneSelect.vue
+++ b/src/components/Tune/TuneSelect.vue
@@ -2,6 +2,9 @@
 type Item = {
   label: string;
   value: string | number;
+  extras: {
+    disabled: boolean;
+  };
 };
 
 defineProps<{
@@ -21,10 +24,15 @@ function handleChange(event: any) {
   <select
     :disabled="disabled"
     :value="modelValue"
-    :class="['tune-select form-select', { disabled: disabled }]"
+    :class="['tune-select', { disabled: disabled }]"
     @change="handleChange($event)"
   >
-    <option v-for="(item, index) in items" :key="index" :value="item.value">
+    <option
+      v-for="(item, index) in items"
+      :key="index"
+      :value="item.value"
+      :disabled="item.extras?.disabled"
+    >
       {{ item.label }}
     </option>
   </select>

--- a/src/views/SpaceBoost.vue
+++ b/src/views/SpaceBoost.vue
@@ -102,7 +102,7 @@ const eligibilityOptions = computed(() => {
     (choice: string, index: number) => {
       return {
         value: index + 1,
-        name: `Who votes '${choice}'`,
+        label: `Who votes '${choice}'`,
         extras: { disabled: bribeDisabled.value }
       };
     }
@@ -111,7 +111,7 @@ const eligibilityOptions = computed(() => {
   return [
     {
       value: 'any',
-      name: 'Anyone who votes'
+      label: 'Anyone who votes'
     },
     ...proposalChoices
   ];
@@ -650,7 +650,7 @@ watch(
               />
             </template>
 
-            <TuneListbox
+            <TuneSelect
               v-model="form.eligibility.choice"
               :items="eligibilityOptions"
               label="Eligible to"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Until I find a good solution for Listbox lets use Select component.

Works the same as before, when bribe is disabled 

<img width="635" alt="Screenshot 2024-03-12 at 6 07 56 in the evening" src="https://github.com/snapshot-labs/snapshot/assets/51686767/90050325-9f2f-408a-a135-9db1719f49c1">
<img width="640" alt="Screenshot 2024-03-12 at 6 08 05 in the evening" src="https://github.com/snapshot-labs/snapshot/assets/51686767/c557ad6a-c6dd-47c2-8767-589b0143189c">


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
