### PR TITLE
Fix oSnap plugin

### DIFF
--- a/src/components/SpaceProposalPage.vue
+++ b/src/components/SpaceProposalPage.vue
@@ -177,7 +177,7 @@ onMounted(() => setMessageVisibility(props.proposal.flagged));
           <SpaceProposalVotes :space="space" :proposal="proposal" />
 
           <SpaceProposalPlugins
-            v-if="proposal?.plugins && loadedResults && results"
+            v-if="Object.keys(space.plugins).length && loadedResults && results"
             :id="proposalId"
             :space="space"
             :proposal="proposal"
@@ -208,7 +208,7 @@ onMounted(() => setMessageVisibility(props.proposal.flagged));
           @reload="reloadProposal"
         />
         <SpaceProposalPluginsSidebar
-          v-if="proposal.plugins && loadedResults && results"
+          v-if="Object.keys(space.plugins).length && loadedResults && results"
           :id="proposalId"
           :space="space"
           :proposal="proposal"

--- a/src/components/SpaceProposalPlugins.vue
+++ b/src/components/SpaceProposalPlugins.vue
@@ -15,13 +15,21 @@ const components = getPluginComponents(
   'Proposal',
   Object.keys(props.space.plugins)
 );
+
+const showPlugin = computed(() => {
+  if (Object.keys(props.space.plugins).includes('oSnap'))
+    return Object.keys(props.proposal.plugins).includes('oSnap');
+  else return true;
+});
 </script>
 
 <template>
-  <component
-    :is="component"
-    v-for="(component, key) in components"
-    :key="key"
-    v-bind="props"
-  />
+  <div v-if="showPlugin">
+    <component
+      :is="component"
+      v-for="(component, key) in components"
+      :key="key"
+      v-bind="props"
+    />
+  </div>
 </template>

--- a/src/components/SpaceProposalPlugins.vue
+++ b/src/components/SpaceProposalPlugins.vue
@@ -17,8 +17,8 @@ const components = getPluginComponents(
 );
 
 const showPlugin = computed(() => {
-  if (Object.keys(props.space.plugins).includes('oSnap'))
-    return Object.keys(props.proposal.plugins).includes('oSnap');
+  if (props.space.plugins.hasOwnProperty('oSnap'))
+    return props.proposal.plugins.hasOwnProperty('oSnap');
   else return true;
 });
 </script>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

1. These is a case when oSnap is enabled in the space settings which will cause an error on proposals that were previously created. This adds a check to make sure oSnap is also defined in the `proposal.plugins`
2. Fix conditions in `SpaceProposalPage`. We were checking for `proposal.plugins` on `SpaceProposalPlugins` and `SpaceProposalPluginsSidebar` which is always defined as `{}` so this check wasn't doing anything.

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
