### PR TITLE
fix: Social accounts section is missing

### DIFF
--- a/src/components/SettingsLinkBlock.vue
+++ b/src/components/SettingsLinkBlock.vue
@@ -20,7 +20,7 @@ const socialInputs: Array<{
     label: 'X (Twitter)',
     icon: 'x',
     placeholder: 'e.g. elonmusk',
-    key: 'x'
+    key: 'twitter'
   },
   {
     label: 'Github',


### PR DESCRIPTION
Right now if you go to space settings, you will see 
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/c3b18330-544f-42f9-b393-064b9b6a5625)

and error 
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/d0e44746-818f-4757-921a-e5777dbed1ef)

With this fix, you should see the social accounts section
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/33d76a69-cf11-4419-a8f0-9cf87f1878ac)
