### PR TITLE
Fix: webAccount.value can possibly be a null

### DIFF
--- a/src/composables/useUsername.ts
+++ b/src/composables/useUsername.ts
@@ -6,7 +6,7 @@ export function useUsername() {
 
   function getUsername(address: string, profile?: Profile) {
     if (
-      web3Account &&
+      web3Account?.value &&
       address.toLowerCase() === web3Account.value.toLowerCase()
     ) {
       return 'You';


### PR DESCRIPTION
### Summary
There is a case where `web3Account.value` could be `null` , considering this https://github.com/snapshot-labs/snapshot/blob/master/src/composables/useWeb3.ts#L81 so In such cases, it will return an error `Cannot read properties of null (reading 'toLowerCase')` which can result in following view

![image](https://github.com/snapshot-labs/snapshot/assets/15967809/a377173c-1693-4577-9288-a5b63a0e6401)

