### PR TITLE
Add ENS support for sepolia

### DIFF
--- a/src/components/SetupDomain.vue
+++ b/src/components/SetupDomain.vue
@@ -126,7 +126,7 @@ onUnmounted(() => clearInterval(waitingForRegistrationInterval));
       />
 
       <BaseMessageBlock
-        v-if="defaultNetwork === '5'"
+        v-if="defaultNetwork && env === 'demo'"
         level="info"
         class="mb-4"
         is-responsive

--- a/src/helpers/connectors.ts
+++ b/src/helpers/connectors.ts
@@ -10,7 +10,9 @@ const connectors = {
     options: {
       projectId: 'e6454bd61aba40b786e866a69bd4c5c6',
       chains: [1],
-      optionalChains: [4, 5, 10, 42, 56, 100, 137, 246, 1088, 42161, 73799],
+      optionalChains: [
+        4, 5, 10, 42, 56, 100, 137, 246, 1088, 42161, 73799, 1115511
+      ],
       methods: ['eth_sendTransaction', 'personal_sign', 'eth_signTypedData_v4'],
       optionalMethods: ['eth_accounts'],
       rpcMap: {
@@ -24,7 +26,8 @@ const connectors = {
         '137': `${import.meta.env.VITE_BROVIDER_URL}/137`,
         '246': `${import.meta.env.VITE_BROVIDER_URL}/246`,
         '42161': `${import.meta.env.VITE_BROVIDER_URL}/42161`,
-        '73799': `${import.meta.env.VITE_BROVIDER_URL}/73799`
+        '73799': `${import.meta.env.VITE_BROVIDER_URL}/73799`,
+        '11155111': `${import.meta.env.VITE_BROVIDER_URL}/11155111`
       },
       showQrModal: true
     },

--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -1,13 +1,12 @@
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import {
   ApolloClient,
   createHttpLink,
   InMemoryCache
 } from '@apollo/client/core';
 
-const uri =
-  import.meta.env.VITE_DEFAULT_NETWORK === '5'
-    ? 'https://api.thegraph.com/subgraphs/name/ensdomains/ensgoerli'
-    : 'https://api.thegraph.com/subgraphs/name/ensdomains/ens';
+const env = import.meta.env.VITE_DEFAULT_NETWORK;
+const uri = networks[env].ensSubgraph;
 
 const httpLink = createHttpLink({ uri });
 


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot/issues/4614

## How to test:
- Change .env to 
```
VITE_ENV=demo
VITE_DEFAULT_NETWORK=11155111
```
- When you go to http://localhost:8080/#/setup?step=1 you should see ENS names from sepolia
- When you go to your space, you should be able to get controller from sepolia 
- You should be able to create new spaces using sepolia ENS