### PR TITLE
refactor: use tune components on proposal page

### DIFF
--- a/src/components/ModalPostVote.vue
+++ b/src/components/ModalPostVote.vue
@@ -63,11 +63,8 @@ onMounted(() => {
 
           <template v-else>
             <h3 v-text="$t('proposal.postVoteModal.defaultTitle')" />
-            <p class="italic" v-text="'Thank you for your participation!'" />
-            <p
-              class="italic"
-              v-text="'Votes can be changed while the proposal is active.'"
-            />
+            <p>Thank you for your participation!</p>
+            <p>Votes can be changed while the proposal is active.</p>
           </template>
         </div>
       </div>

--- a/src/components/ModalPostVote.vue
+++ b/src/components/ModalPostVote.vue
@@ -44,8 +44,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <!-- TODO: Add gratitude message -->
-  <BaseModal :open="open" max-height="550px" @close="emit('close')">
+  <TuneModal :open="open" max-height="550px" @close="emit('close')">
     <div class="flex flex-col justify-between p-4 md:h-auto">
       <div>
         <img
@@ -64,68 +63,69 @@ onMounted(() => {
 
           <template v-else>
             <h3 v-text="$t('proposal.postVoteModal.defaultTitle')" />
-            <p class="italic" v-text="$t('proposal.postVoteModal.tips.1')" />
+            <p class="italic" v-text="'Thank you for your participation!'" />
+            <p
+              class="italic"
+              v-text="'Votes can be changed while the proposal is active.'"
+            />
           </template>
         </div>
       </div>
     </div>
-    <template #footer>
-      <div class="space-y-2">
-        <TuneButton
-          class="flex !h-[42px] w-full items-center justify-center gap-2"
-          @click="
-            props.waitingForSigners
-              ? shareProposalX(space, proposal)
-              : share('x')
-          "
-        >
-          <i-s-x class="text-md" />
-          Share on X
-        </TuneButton>
-        <TuneButton
-          class="flex !h-[42px] w-full items-center justify-center gap-2"
-          @click="
-            props.waitingForSigners
-              ? shareProposalHey(space, proposal)
-              : share('hey')
-          "
-        >
-          <i-s-hey class="text-[#FB3A5D]" />
-          {{ $t('shareOnHey') }}
-        </TuneButton>
 
-        <TuneButton
-          v-if="userState !== 'VERIFIED' && initialized"
-          class="flex !h-[42px] w-full items-center justify-center gap-2"
-          @click="subscribeEmail"
-        >
-          <i-ho-mail class="text-skin-link" />
-          {{ $t('proposal.postVoteModal.subscribe') }}
-        </TuneButton>
+    <div class="space-y-2 p-3">
+      <TuneButton
+        class="flex !h-[42px] w-full items-center justify-center gap-2"
+        @click="
+          props.waitingForSigners ? shareProposalX(space, proposal) : share('x')
+        "
+      >
+        <i-s-x class="text-md" />
+        Share on X
+      </TuneButton>
+      <TuneButton
+        class="flex !h-[42px] w-full items-center justify-center gap-2"
+        @click="
+          props.waitingForSigners
+            ? shareProposalHey(space, proposal)
+            : share('hey')
+        "
+      >
+        <i-s-hey class="text-[#FB3A5D]" />
+        {{ $t('shareOnHey') }}
+      </TuneButton>
 
-        <div v-if="props.waitingForSigners">
-          <BaseLink
-            :link="`https://gnosis-safe.io/app/eth:${web3Account}/transactions/queue`"
-            hide-external-icon
-          >
-            <TuneButton tabindex="-1" class="w-full">
-              <div class="flex flex-grow items-center justify-center gap-1">
-                {{ $t('proposal.postVoteModal.seeQueue') }}
-                <i-ho-external-link class="text-sm" />
-              </div>
-            </TuneButton>
-          </BaseLink>
-        </div>
+      <TuneButton
+        v-if="userState !== 'VERIFIED' && initialized"
+        class="flex !h-[42px] w-full items-center justify-center gap-2"
+        @click="subscribeEmail"
+      >
+        <i-ho-mail class="text-skin-link" />
+        {{ $t('proposal.postVoteModal.subscribe') }}
+      </TuneButton>
 
-        <TuneButton
-          primary
-          class="!h-[42px] w-full"
-          data-testid="post-vote-modal-close"
-          @click="emit('close')"
+      <div v-if="props.waitingForSigners">
+        <BaseLink
+          :link="`https://gnosis-safe.io/app/eth:${web3Account}/transactions/queue`"
+          hide-external-icon
         >
-          {{ $t('close') }}
-        </TuneButton>
+          <TuneButton tabindex="-1" class="w-full">
+            <div class="flex flex-grow items-center justify-center gap-1">
+              {{ $t('proposal.postVoteModal.seeQueue') }}
+              <i-ho-external-link class="text-sm" />
+            </div>
+          </TuneButton>
+        </BaseLink>
       </div>
-    </template>
-  </BaseModal>
+
+      <TuneButton
+        primary
+        class="!h-[42px] w-full"
+        data-testid="post-vote-modal-close"
+        @click="emit('close')"
+      >
+        {{ $t('close') }}
+      </TuneButton>
+    </div>
+  </TuneModal>
 </template>

--- a/src/components/ModalStrategies.vue
+++ b/src/components/ModalStrategies.vue
@@ -11,11 +11,13 @@ defineEmits(['close']);
 </script>
 
 <template>
-  <BaseModal :open="open" @close="$emit('close')">
-    <template #header>
-      <h3>{{ $t('strategiesPage') }}</h3>
-    </template>
-    <div class="m-4">
+  <TuneModal :open="open" @close="$emit('close')">
+    <TuneModalTitle class="my-3 px-3">
+      {{ $t('strategiesPage') }}
+    </TuneModalTitle>
+    <div
+      class="max-h-[calc(100vh-175px)] md:max-h-[488px] overflow-y-auto space-y-3 px-3"
+    >
       <StrategiesListItem
         v-for="(strategy, i) in strategies"
         :key="i"
@@ -23,5 +25,9 @@ defineEmits(['close']);
         :proposal="proposal"
       />
     </div>
-  </BaseModal>
+
+    <div class="px-3 py-3">
+      <TuneButton class="w-full" @click="$emit('close')"> Close </TuneButton>
+    </div>
+  </TuneModal>
 </template>

--- a/src/components/ModalStrategies.vue
+++ b/src/components/ModalStrategies.vue
@@ -16,7 +16,7 @@ defineEmits(['close']);
       {{ $t('strategiesPage') }}
     </TuneModalTitle>
     <div
-      class="max-h-[calc(100vh-175px)] md:max-h-[488px] overflow-y-auto space-y-3 px-3"
+      class="max-h-[calc(100vh-100px)] md:max-h-[488px] overflow-y-auto space-y-3 px-3 pb-3"
     >
       <StrategiesListItem
         v-for="(strategy, i) in strategies"
@@ -24,10 +24,6 @@ defineEmits(['close']);
         :strategy="strategy"
         :proposal="proposal"
       />
-    </div>
-
-    <div class="px-3 py-3">
-      <TuneButton class="w-full" @click="$emit('close')"> Close </TuneButton>
     </div>
   </TuneModal>
 </template>

--- a/src/components/ModalVote.vue
+++ b/src/components/ModalVote.vue
@@ -157,189 +157,177 @@ watch(
       <TuneModalTitle class="mt-3 mx-1">
         {{ $tc('proposal.castVote') }}
       </TuneModalTitle>
-      <div class="flex flex-auto flex-col">
-        <div class="space-y-3 text-skin-link">
-          <div class="mx-1">
-            <div class="flex">
-              <span
-                class="mr-1 flex-auto text-skin-text"
-                v-text="$t('choice')"
-              />
-              <span
-                v-if="
-                  proposal.type === 'approval' &&
-                  Array.isArray(selectedChoices) &&
-                  selectedChoices?.length === 0
-                "
-                class="text-right"
-              >
-                Blank vote
-              </span>
-              <span
-                v-else
-                v-tippy="{
-                  content:
-                    format(proposal, selectedChoices).length > 30
-                      ? format(proposal, selectedChoices)
-                      : null
-                }"
-                class="ml-4 truncate text-right"
-              >
-                {{ format(proposal, selectedChoices) }}
-              </span>
-            </div>
 
-            <div class="flex">
-              <span
-                class="mr-1 flex-auto text-skin-text"
-                v-text="$t('snapshot')"
-              />
-              <BaseLink
-                :link="
-                  explorerUrl(proposal.network, proposal.snapshot, 'block')
-                "
-                class="float-right"
-              >
-                {{ formatNumber(Number(proposal.snapshot)) }}
-              </BaseLink>
-            </div>
-
-            <div
+      <div class="space-y-3 text-skin-link">
+        <div class="mx-1">
+          <div class="flex">
+            <span class="mr-1 flex-auto text-skin-text" v-text="$t('choice')" />
+            <span
               v-if="
-                proposal.validation?.name !== 'any' &&
-                isValidationAndPowerLoaded &&
-                !isValidationAndPowerLoading
+                proposal.type === 'approval' &&
+                Array.isArray(selectedChoices) &&
+                selectedChoices?.length === 0
               "
-              class="flex"
+              class="text-right"
             >
-              <span
-                class="mr-1 flex-auto text-skin-text"
-                v-text="$t('votingValidation.label')"
-              />
-              <div class="flex items-center gap-1">
-                <span
-                  v-if="hasVotingValidationFailed"
-                  class="flex items-center gap-1"
-                >
-                  <i-ho-exclamation-circle class="text-sm text-red" />
-                  {{ $t('failed') }}
-                </span>
-                <span v-else class="flex items-center">
-                  <i-ho-check v-if="isValidVoter" class="text-green" />
-                  <i-ho-x v-else class="text-red" />
-                  {{ $t(`votingValidation.${proposal.validation.name}.label`) }}
-                </span>
-              </div>
-            </div>
+              Blank vote
+            </span>
+            <span
+              v-else
+              v-tippy="{
+                content:
+                  format(proposal, selectedChoices).length > 30
+                    ? format(proposal, selectedChoices)
+                    : null
+              }"
+              class="ml-4 truncate text-right"
+            >
+              {{ format(proposal, selectedChoices) }}
+            </span>
+          </div>
 
-            <div class="flex">
+          <div class="flex">
+            <span
+              class="mr-1 flex-auto text-skin-text"
+              v-text="$t('snapshot')"
+            />
+            <BaseLink
+              :link="explorerUrl(proposal.network, proposal.snapshot, 'block')"
+              class="float-right"
+            >
+              {{ formatNumber(Number(proposal.snapshot)) }}
+            </BaseLink>
+          </div>
+
+          <div
+            v-if="
+              proposal.validation?.name !== 'any' &&
+              isValidationAndPowerLoaded &&
+              !isValidationAndPowerLoading
+            "
+            class="flex"
+          >
+            <span
+              class="mr-1 flex-auto text-skin-text"
+              v-text="$t('votingValidation.label')"
+            />
+            <div class="flex items-center gap-1">
               <span
-                class="mr-1 flex-auto text-skin-text"
-                v-text="$t('votingPower')"
-              />
-              <span v-if="hasVotingPowerFailed" class="flex items-center gap-1">
+                v-if="hasVotingValidationFailed"
+                class="flex items-center gap-1"
+              >
                 <i-ho-exclamation-circle class="text-sm text-red" />
                 {{ $t('failed') }}
               </span>
-              <span
-                v-else-if="
-                  isValidationAndPowerLoaded && !isValidationAndPowerLoading
-                "
-                v-tippy="{
-                  content: votingPowerByStrategy
-                    .map(
-                      (score, index) =>
-                        `${formatCompactNumber(
-                          votingPower === 0 ? 0 : score
-                        )} ${symbols[index]}`
-                    )
-                    .join(' + ')
-                }"
-              >
-                {{ formatCompactNumber(votingPower) }}
-                {{ shorten(proposal.symbol || space.symbol, 'symbol') }}
+              <span v-else class="flex items-center">
+                <i-ho-check v-if="isValidVoter" class="text-green" />
+                <i-ho-x v-else class="text-red" />
+                {{ $t(`votingValidation.${proposal.validation.name}.label`) }}
               </span>
-              <LoadingSpinner v-else />
             </div>
           </div>
 
-          <MessageWarningGnosisNetwork
-            v-if="isGnosisAndNotSpaceNetwork"
-            :space="space"
-            action="vote"
-          />
-          <template
-            v-else-if="
-              isValidationAndPowerLoaded && !isValidationAndPowerLoading
-            "
-          >
-            <!-- Voting power messages -->
-            <BaseMessageBlock v-if="hasVotingPowerFailed" level="warning">
-              <i18n-t
-                keypath="votingPowerFailedMessage"
-                tag="span"
-                scope="global"
-              >
-                <template #discord>
-                  <BaseLink link="https://discord.snapshot.org"
-                    >Discord</BaseLink
-                  >
-                </template>
-              </i18n-t>
-            </BaseMessageBlock>
-
-            <!-- Voting validation messages -->
-            <BaseMessageBlock
-              v-else-if="hasVotingValidationFailed"
-              level="warning"
-            >
-              <!-- {{ t('votingValidationFailedMessage') }} -->
-
-              <i18n-t
-                keypath="votingValidationFailedMessage"
-                tag="span"
-                scope="global"
-              >
-                <template #discord>
-                  <BaseLink link="https://discord.snapshot.org"
-                    >Discord</BaseLink
-                  >
-                </template>
-              </i18n-t>
-            </BaseMessageBlock>
-            <MessageWarningValidation
-              v-else-if="!isValidVoter && proposal.validation?.name"
-              context="voting"
-              :space-id="proposal.space.id"
-              :validation-name="proposal.validation.name"
-              :validation-params="proposal.validation?.params || {}"
-              :min-score="proposal.validation?.params?.minScore || 0"
-              :symbol="validationStrategySymbolsString"
+          <div class="flex">
+            <span
+              class="mr-1 flex-auto text-skin-text"
+              v-text="$t('votingPower')"
             />
-            <!-- No voting power -->
-            <BaseMessageBlock v-else-if="votingPower === 0" level="warning">
-              {{
-                $t('noVotingPower', {
-                  blockNumber: formatNumber(Number(proposal.snapshot))
-                })
-              }}
-              <BaseLink
-                link="https://github.com/snapshot-labs/snapshot/discussions/767"
-              >
-                {{ $t('learnMore') }}</BaseLink
-              >
-            </BaseMessageBlock>
-            <!-- Reason field -->
-            <div v-else-if="props.proposal.privacy !== 'shutter'" class="flex">
-              <TextareaAutosize
-                v-model="reason"
-                :max-length="140"
-                class="s-input !rounded-3xl"
-                :placeholder="$t('comment.placeholder')"
-              />
-            </div>
-          </template>
+            <span v-if="hasVotingPowerFailed" class="flex items-center gap-1">
+              <i-ho-exclamation-circle class="text-sm text-red" />
+              {{ $t('failed') }}
+            </span>
+            <span
+              v-else-if="
+                isValidationAndPowerLoaded && !isValidationAndPowerLoading
+              "
+              v-tippy="{
+                content: votingPowerByStrategy
+                  .map(
+                    (score, index) =>
+                      `${formatCompactNumber(votingPower === 0 ? 0 : score)} ${
+                        symbols[index]
+                      }`
+                  )
+                  .join(' + ')
+              }"
+            >
+              {{ formatCompactNumber(votingPower) }}
+              {{ shorten(proposal.symbol || space.symbol, 'symbol') }}
+            </span>
+            <LoadingSpinner v-else />
+          </div>
         </div>
+
+        <MessageWarningGnosisNetwork
+          v-if="isGnosisAndNotSpaceNetwork"
+          :space="space"
+          action="vote"
+        />
+        <template
+          v-else-if="isValidationAndPowerLoaded && !isValidationAndPowerLoading"
+        >
+          <!-- Voting power messages -->
+          <BaseMessageBlock v-if="hasVotingPowerFailed" level="warning">
+            <i18n-t
+              keypath="votingPowerFailedMessage"
+              tag="span"
+              scope="global"
+            >
+              <template #discord>
+                <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
+              </template>
+            </i18n-t>
+          </BaseMessageBlock>
+
+          <!-- Voting validation messages -->
+          <BaseMessageBlock
+            v-else-if="hasVotingValidationFailed"
+            level="warning"
+          >
+            <!-- {{ t('votingValidationFailedMessage') }} -->
+
+            <i18n-t
+              keypath="votingValidationFailedMessage"
+              tag="span"
+              scope="global"
+            >
+              <template #discord>
+                <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
+              </template>
+            </i18n-t>
+          </BaseMessageBlock>
+          <MessageWarningValidation
+            v-else-if="!isValidVoter && proposal.validation?.name"
+            context="voting"
+            :space-id="proposal.space.id"
+            :validation-name="proposal.validation.name"
+            :validation-params="proposal.validation?.params || {}"
+            :min-score="proposal.validation?.params?.minScore || 0"
+            :symbol="validationStrategySymbolsString"
+          />
+          <!-- No voting power -->
+          <BaseMessageBlock v-else-if="votingPower === 0" level="warning">
+            {{
+              $t('noVotingPower', {
+                blockNumber: formatNumber(Number(proposal.snapshot))
+              })
+            }}
+            <BaseLink
+              link="https://github.com/snapshot-labs/snapshot/discussions/767"
+            >
+              {{ $t('learnMore') }}</BaseLink
+            >
+          </BaseMessageBlock>
+          <!-- Reason field -->
+          <div v-else-if="props.proposal.privacy !== 'shutter'" class="flex">
+            <TextareaAutosize
+              v-model="reason"
+              :max-length="140"
+              class="s-input !rounded-3xl"
+              :placeholder="$t('comment.placeholder')"
+            />
+          </div>
+        </template>
       </div>
 
       <div class="mb-3 mt-5 flex gap-x-[12px]">

--- a/src/components/SettingsStrategiesBlock.vue
+++ b/src/components/SettingsStrategiesBlock.vue
@@ -112,7 +112,7 @@ function handleSubmitStrategy(strategy) {
           </TuneButton>
         </div>
       </div>
-      <div class="mt-3">
+      <div class="mt-3 space-y-3">
         <StrategiesListItem
           v-for="(strategy, i) in strategies"
           :key="i"

--- a/src/components/SettingsStrategiesBlock.vue
+++ b/src/components/SettingsStrategiesBlock.vue
@@ -117,7 +117,6 @@ function handleSubmitStrategy(strategy) {
           v-for="(strategy, i) in strategies"
           :key="i"
           :strategy="strategy"
-          class="rounded-md !border last:!mb-0"
           :show-delete="!isViewOnly"
           :show-edit="!isViewOnly"
           @edit="handleEditStrategy(i)"

--- a/src/components/SpaceProposalInformation.vue
+++ b/src/components/SpaceProposalInformation.vue
@@ -34,13 +34,7 @@ const symbols = computed((): string[] =>
             :key="symbol"
             class="flex"
           >
-            <span
-              v-tippy="{
-                content: symbol
-              }"
-            >
-              <AvatarSpace :space="space" :symbol-index="symbolIndex" />
-            </span>
+            <AvatarSpace :space="space" :symbol-index="symbolIndex" />
             <span v-show="symbolIndex !== symbols.length - 1" class="ml-1" />
           </span>
         </span>

--- a/src/components/StrategiesListItem.vue
+++ b/src/components/StrategiesListItem.vue
@@ -33,8 +33,8 @@ function openStrategy() {
 </script>
 
 <template>
-  <BaseBlock slim class="group mb-3 p-4 text-skin-link">
-    <div class="items-center justify-between sm:flex">
+  <TuneBlock class="group text-skin-link">
+    <div class="items-center justify-between sm:flex -mt-1">
       <h3 class="my-0 leading-5" v-text="strategy.name" />
       <div class="flex">
         <div
@@ -97,5 +97,5 @@ function openStrategy() {
         />
       </div>
     </div>
-  </BaseBlock>
+  </TuneBlock>
 </template>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -934,7 +934,7 @@
   },
   "hal": {
     "title": "Track proposals for {spaceName}",
-    "text": "Receive notifications every time a new proposal is created or ends"
+    "text": "Receive notifications every time a {space} proposal is created or ends"
   },
   "timeUnits": {
     "second": "1 second | {n} seconds",

--- a/src/plugins/hal/components/CustomBlock.vue
+++ b/src/plugins/hal/components/CustomBlock.vue
@@ -13,9 +13,6 @@ const halLogoUrl = computed(
 
 <template>
   <TuneBlock>
-    <template #header>
-      <TuneBlockHeader :title="$t('hal.title', { spaceName: space.name })" />
-    </template>
     <div class="flex flex-col items-center">
       <div>
         <a :href="halUrl" target="_blank">

--- a/src/plugins/hal/components/CustomBlock.vue
+++ b/src/plugins/hal/components/CustomBlock.vue
@@ -25,7 +25,9 @@ const halLogoUrl = computed(
           />
         </a>
       </div>
-      <div class="mb-2 text-center text-skin-link">{{ $t('hal.text') }}</div>
+      <div class="mb-2 text-center text-skin-link">
+        {{ $t('hal.text', { space: space.name }) }}
+      </div>
       <a :href="halUrl" target="_blank">
         <TuneButton tabindex="-1">Be notified</TuneButton>
       </a>

--- a/src/plugins/hal/components/CustomBlock.vue
+++ b/src/plugins/hal/components/CustomBlock.vue
@@ -12,7 +12,10 @@ const halLogoUrl = computed(
 </script>
 
 <template>
-  <BaseBlock :title="$t('hal.title', { spaceName: space.name })">
+  <TuneBlock>
+    <template #header>
+      <TuneBlockHeader :title="$t('hal.title', { spaceName: space.name })" />
+    </template>
     <div class="flex flex-col items-center">
       <div>
         <a :href="halUrl" target="_blank">
@@ -30,5 +33,5 @@ const halLogoUrl = computed(
         <TuneButton tabindex="-1">Be notified</TuneButton>
       </a>
     </div>
-  </BaseBlock>
+  </TuneBlock>
 </template>

--- a/src/plugins/oSnap/Proposal.vue
+++ b/src/plugins/oSnap/Proposal.vue
@@ -101,7 +101,7 @@ function enrichTransactionForDisplay(transaction: Transaction) {
 <template>
   <template v-if="safe.transactions.length > 0">
     <div
-      class="flex w-full flex-col gap-4 rounded-2xl border border-skin-border p-3 md:p-4 relative"
+      class="flex w-full flex-col gap-4 rounded-2xl border border-skin-border p-3 relative"
     >
       <OsnapMarketingWidget class="absolute top-[-16px] right-[16px]" />
       <h2 class="text-lg">oSnap Transactions</h2>

--- a/src/plugins/poap/components/CustomBlock.vue
+++ b/src/plugins/poap/components/CustomBlock.vue
@@ -141,7 +141,7 @@ export default {
 </script>
 
 <template>
-  <BaseBlock
+  <TuneBlock
     v-if="currentState === 'LOADING' || currentState !== 'NO_POAP'"
     title="I voted POAP"
     :loading="loading"
@@ -162,7 +162,7 @@ export default {
       />
       <TuneButton
         v-if="currentState !== 'NO_POAP'"
-        class="mb-2 mt-3 w-full"
+        class="mt-3 w-full"
         :disabled="!actionEnabled"
         :loading="actionLoading"
         @click="action"
@@ -170,5 +170,5 @@ export default {
         {{ $t(buttonText) }}
       </TuneButton>
     </div>
-  </BaseBlock>
+  </TuneBlock>
 </template>

--- a/src/plugins/poap/components/CustomBlock.vue
+++ b/src/plugins/poap/components/CustomBlock.vue
@@ -143,7 +143,6 @@ export default {
 <template>
   <TuneBlock
     v-if="currentState === 'LOADING' || currentState !== 'NO_POAP'"
-    title="I voted POAP"
     :loading="loading"
   >
     <div class="flex flex-col items-center">

--- a/src/plugins/progress/components/CustomBlock.vue
+++ b/src/plugins/progress/components/CustomBlock.vue
@@ -176,23 +176,27 @@ onMounted(async () => {
 </script>
 
 <template>
-  <BaseBlock title="Progress" :loading="!loaded">
+  <TuneBlock :loading="!loaded">
+    <template #header>
+      <TuneBlockHeader title="Progress">
+        <BaseButtonIcon class="!p-0">
+          <i-ho-cog
+            v-if="isOwner() && isComplete()"
+            class="text-base"
+            @click="toggleEditMode()"
+          />
+        </BaseButtonIcon>
+      </TuneBlockHeader>
+    </template>
     <div v-if="!isComplete()">{{ $t('progress.comeBack') }}</div>
-    <div v-if="isComplete()" class="flex h-0 flex-row-reverse">
-      <i
-        v-if="isOwner() && isComplete()"
-        class="edit-icon iconfont icongear relative cursor-pointer hover:text-skin-link"
-        style="font-size: 25px; line-height: 25px"
-        @click="toggleEditMode()"
-      ></i>
-    </div>
-    <div v-if="isComplete()" class="flex flex-col">
+
+    <div v-else class="flex flex-col">
       <div>
         <div
           :class="{
             'border-green': isComplete()
           }"
-          class="h-32 mt-2 min-w-[178px] rounded-xl border-2 bg-skin-block-bg p-3 text-base"
+          class="h-32 min-w-[178px] rounded-xl border-2 bg-skin-block-bg p-3 text-base"
         >
           <div class="h-16 flex">
             <div>
@@ -221,11 +225,8 @@ onMounted(async () => {
             </div>
           </div>
         </div>
-        <div class="h-[1rem]">
-          <div
-            v-if="steps.length > 0"
-            class="h-full w-[2.3rem] border-r-2 border-green"
-          ></div>
+        <div v-if="steps.length > 0" class="h-[1rem]">
+          <div class="h-full w-[2.3rem] border-r-2 border-green"></div>
         </div>
         <div v-for="(step, index) in steps" :key="step.id">
           <div
@@ -337,7 +338,7 @@ onMounted(async () => {
         </div>
       </div>
     </div>
-  </BaseBlock>
+  </TuneBlock>
   <BaseModal :open="closeModal" @close="closeEvent">
     <template #header>
       <h3>{{ $t('progress.deleteStep') }}</h3>

--- a/src/plugins/projectGalaxy/components/CustomBlock.vue
+++ b/src/plugins/projectGalaxy/components/CustomBlock.vue
@@ -193,14 +193,13 @@ export default {
 </script>
 
 <template>
-  <BaseBlock
+  <TuneBlock
     v-if="!disabled && currentState !== 'NO_OAT'"
     title="OAT for Vote"
     :loading="loading"
-    :slim="true"
     class="overflow-hidden"
   >
-    <div class="relative overflow-hidden">
+    <div class="relative overflow-hidden -m-3">
       <!-- background image -->
       <div class="absolute bottom-0 left-0 right-0 top-0 z-0 w-full blur-3xl">
         <img
@@ -284,5 +283,5 @@ export default {
         </a>
       </div>
     </div>
-  </BaseBlock>
+  </TuneBlock>
 </template>

--- a/src/plugins/safeSnap/components/Config.vue
+++ b/src/plugins/safeSnap/components/Config.vue
@@ -60,10 +60,10 @@ export default {
 <template>
   <div
     v-if="!preview || input.safes.length > 0"
-    class="mb-4 rounded-none border-b border-t bg-skin-block-bg md:rounded-xl md:border"
+    class="bg-skin-block-bg rounded-xl border"
   >
     <div
-      class="block border-b px-4 pt-3"
+      class="block px-3 pt-3"
       style="
         padding-bottom: 12px;
         display: flex;

--- a/src/plugins/safeSnap/components/SafeTransactions.vue
+++ b/src/plugins/safeSnap/components/SafeTransactions.vue
@@ -302,7 +302,7 @@ export default {
 <template>
   <div>
     <h4
-      class="flex rounded-t-none border-b px-4 pb-[12px] pt-3 md:rounded-t-md"
+      class="flex rounded-t-none border-b px-3 pb-[12px] pt-3 md:rounded-t-md"
     >
       <BaseAvatar class="float-left mr-2" :src="networkIcon" size="28" />
       {{ networkName }} Safe

--- a/src/views/SpaceAbout.vue
+++ b/src/views/SpaceAbout.vue
@@ -115,12 +115,11 @@ onMounted(() => {
           slim
           @show-more="isModalStrategiesOpen = true"
         >
-          <div class="grid grid-cols-1 gap-0 px-0 md:gap-4 md:p-4 md:px-4">
+          <div class="p-4 space-y-3">
             <StrategiesListItem
               v-for="(strategy, i) in space.strategies.slice(0, 2)"
               :key="i"
               :strategy="strategy"
-              class="!mb-0 !border-t-0 last:border-b-0 md:!border-b md:!border-t"
             />
           </div>
         </BaseBlock>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

For consistency I've refactored modal and block components on the proposal page to use tune components, to match the changes from the Boost PR.

- [x] @ChaituVR I couldn't find any spaces still using Poap, do you know any?

| Before                | After                 |
|-----------------------|-----------------------|
|  <img width="492" alt="Screenshot 2024-03-19 at 4 54 25 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/0a7e3992-dcfe-4065-a8f8-64bacd45f80b"> | <img width="472" alt="Screenshot 2024-03-19 at 4 54 18 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/eb0b72d5-2545-4fd4-99a4-b9a81a8f14b3"> |
| <img width="662" alt="Screenshot 2024-03-19 at 4 53 05 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/be654b30-5415-49f2-af9a-b9369f4d33e8"> | <img width="664" alt="Screenshot 2024-03-19 at 4 53 11 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/e0d35257-a245-4f4c-8288-b7861be38260"> |
| <img width="391" alt="Screenshot 2024-03-19 at 4 53 39 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/14a85a28-0fa6-41f9-ace8-80d2b40bb13b"> | <img width="357" alt="Screenshot 2024-03-19 at 5 07 24 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/ede262a2-4014-4af3-930b-466ad2b31798"> |
| <img width="477" alt="Screenshot 2024-03-19 at 4 55 05 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/c27bb3dd-ba77-46c4-b608-2d56eae7f2df"> | <img width="480" alt="Screenshot 2024-03-19 at 4 55 01 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/b57bb595-20ce-4cba-b5e9-898d73a95326"> |
| <img width="474" alt="Screenshot 2024-03-19 at 4 55 29 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/7fd48e6b-538f-4d37-88ed-d51ea4e033f0"> | <img width="472" alt="Screenshot 2024-03-19 at 4 55 25 in the afternoon" src="https://github.com/snapshot-labs/snapshot/assets/51686767/fdb95e77-ee81-48c2-856f-9a13d577d487"> |























<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
