### PR TITLE
feat: Add quorum type to space settings

### DIFF
--- a/src/components/SettingsVotingBlock.vue
+++ b/src/components/SettingsVotingBlock.vue
@@ -32,8 +32,8 @@ const { form, validationErrors } = useFormSpaceSettings(props.context);
         <TuneListbox
           v-model="form.voting.quorumType"
           placeholder="Default"
-          :label="$t(`settings.quorumType.label`)"
-          :hint="$t(`settings.quorumType.information`)"
+          label="Quorum type"
+          hint="The type of quorum used for this space."
           :items="[
             {
               value: 'default',

--- a/src/components/SettingsVotingBlock.vue
+++ b/src/components/SettingsVotingBlock.vue
@@ -29,6 +29,25 @@ const { form, validationErrors } = useFormSpaceSettings(props.context);
           block
         />
 
+        <TuneListbox
+          v-model="form.voting.quorumType"
+          placeholder="Default"
+          :label="$t(`settings.quorumType.label`)"
+          :hint="$t(`settings.quorumType.information`)"
+          :items="[
+            {
+              value: 'default',
+              name: 'Default'
+            },
+            {
+              value: 'optimistic',
+              name: 'Optimistic'
+            }
+          ]"
+          :disabled="isViewOnly"
+          :error="validationErrors?.voting?.quorumType"
+        />
+
         <TuneInput
           :model-value="form.voting.quorum"
           :label="$t('settings.quorum.label')"

--- a/src/composables/useFormSpaceSettings.ts
+++ b/src/composables/useFormSpaceSettings.ts
@@ -93,6 +93,9 @@ export function useFormSpaceSettings(
     ) {
       delete formData.delegationPortal;
     }
+    if (formData.voting.quorumType === 'default') {
+      delete formData.voting.quorumType;
+    }
     return formData;
   });
 
@@ -153,6 +156,7 @@ export function useFormSpaceSettings(
       period: formData.voting.period || undefined,
       type: formData.voting.type || undefined,
       quorum: formData.voting?.quorum || undefined,
+      quorumType: formData.voting.quorumType || undefined,
       privacy: formData.voting.privacy || undefined
     };
     formData.children = formData.children

--- a/src/composables/useFormSpaceSettings.ts
+++ b/src/composables/useFormSpaceSettings.ts
@@ -156,7 +156,7 @@ export function useFormSpaceSettings(
       period: formData.voting.period || undefined,
       type: formData.voting.type || undefined,
       quorum: formData.voting?.quorum || undefined,
-      quorumType: formData.voting.quorumType || undefined,
+      quorumType: formData.voting.quorumType || 'default',
       privacy: formData.voting.privacy || undefined
     };
     formData.children = formData.children

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -179,6 +179,7 @@ export interface ExtendedSpace {
     hideAbstain: boolean;
     period: number | null;
     quorum: number | null;
+    quorumType: string;
     type: string | null;
     privacy: string | null;
   };

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -179,7 +179,7 @@ export interface ExtendedSpace {
     hideAbstain: boolean;
     period: number | null;
     quorum: number | null;
-    quorumType: string;
+    quorumType: 'default' | 'optimistic';
     type: string | null;
     privacy: string | null;
   };

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -484,6 +484,7 @@ export const SPACE_QUERY = gql`
         period
         type
         quorum
+        quorumType
         privacy
         hideAbstain
       }

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -487,10 +487,6 @@
       "label": "Quorum",
       "information": "The minimum amount of voting power required for the proposal to pass"
     },
-    "quorumType": {
-      "label": "Quorum type",
-      "information": "The type of quorum used for this space."
-    },
     "type": {
       "label": "Type",
       "information": "The type of voting system used for this space. (Enforced on all future proposals)"

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -487,6 +487,10 @@
       "label": "Quorum",
       "information": "The minimum amount of voting power required for the proposal to pass"
     },
+    "quorumType": {
+      "label": "Quorum type",
+      "information": "The type of quorum used for this space."
+    },
     "type": {
       "label": "Type",
       "information": "The type of voting system used for this space. (Enforced on all future proposals)"


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot/issues/4600

- [x] Waiting for hub changes to merge https://github.com/snapshot-labs/snapshot-hub/pull/827
 
### Summary

Add a new field `quorumType` to space settings
- Default to `default`, or can be `optimistic`
- if value is `default` we store empty string on backend

<img width="659" alt="Untitled" src="https://github.com/snapshot-labs/snapshot/assets/15967809/1ff5ddd7-c8b3-4225-a11a-d116dea2c42a">

## How to test: 
Make sure to change quorum type to default or optimistic

