### PR TITLE
fix: Replace X icon on flash notification with exclamation icon

### DIFF
--- a/src/components/TheFlashNotification.vue
+++ b/src/components/TheFlashNotification.vue
@@ -17,7 +17,10 @@ const { items } = useFlashNotification();
           :class="`!bg-${item.type}`"
         >
           <div class="flex items-center gap-2">
-            <i-ho-x v-if="item.type === 'red'" class="shrink-0 text-base" />
+            <i-ho-exclamation-circle
+              v-if="item.type === 'red'"
+              class="shrink-0 text-base"
+            />
             <i-ho-check
               v-if="item.type === 'green'"
               class="shrink-0 text-base"


### PR DESCRIPTION
Context: https://discord.com/channels/955773041898573854/1221106380300357804/1221141225751576646

### Summary

Right now we display two X icons on flash notification (which is confusing)
<img width="459" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/97f26a32-92c4-4282-b323-42dd1d3f3aeb">

Now changed into exclamation circle icon 
<img width="464" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/8fc8d07d-b79a-435d-b043-e7a48d3a886a">


### How to test

1. Try to do any signature and reject sign in wallet
2. For example, Go to any proposal, try to vote and click reject in metamask model

