### PR TITLE
fix: fix optimism chain in osnap

### DIFF
--- a/src/composables/useBoost.ts
+++ b/src/composables/useBoost.ts
@@ -15,7 +15,7 @@ export function useBoost() {
   const loadingClaim = ref(false);
 
   function isWhitelisted(spaceId: string) {
-    return BOOST_WHITELIST_SETTINGS[env].includes(spaceId);
+    return (BOOST_WHITELIST_SETTINGS[env] ?? []).includes(spaceId);
   }
 
   function sanitizeBoosts(

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -95,7 +95,7 @@ async function fetchBalances(network: Network, safeAddress: string) {
 
     return enhanceTokensWithBalances(balancesWithNative, tokens, network);
   } catch (e) {
-    console.warn('Error fetching balances');
+    console.warn('Error fetching balances',e);
     return [];
   }
 }
@@ -105,7 +105,6 @@ function enhanceTokensWithBalances(
   tokens: Token[],
   network: Network
 ) {
-  console.log({ balances, tokens });
   return balances
     .filter(
       (balance): balance is BalanceResponse =>
@@ -153,7 +152,6 @@ async function fetchCollectibles(network: Network, gnosisSafeAddress: string) {
       network,
       gnosisSafeAddress
     );
-    console.log({ response });
     return response.results;
   } catch (error) {
     console.warn('Error fetching collectibles');

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -95,7 +95,7 @@ async function fetchBalances(network: Network, safeAddress: string) {
 
     return enhanceTokensWithBalances(balancesWithNative, tokens, network);
   } catch (e) {
-    console.warn('Error fetching balances',e);
+    console.warn('Error fetching balances', e);
     return [];
   }
 }

--- a/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
@@ -85,18 +85,19 @@ watch(selectedTokenAddress, updateTransaction);
       <span class="text-skin-text">{{ $t('safeSnap.asset') }}</span>
       <AvatarToken
         :address="
-          selectedToken?.address === 'main'
+          selectedToken.address === 'main'
             ? ETH_CONTRACT
-            : selectedToken?.address
+            : selectedToken.address
         "
         class="ml-2"
+        v-if="selectedToken"
       />
-      <span v-if="selectedToken">{{ selectedToken?.symbol }}</span>
-      <span>
+      <span v-if="selectedToken">{{ selectedToken.symbol }}</span>
+      <span v-if="selectedToken">
         {{
-          selectedToken?.address === 'main'
+          selectedToken.address === 'main'
             ? ''
-            : `(${shorten(selectedToken?.address)})`
+            : `(${shorten(selectedToken.address)})`
         }}
       </span>
     </div>

--- a/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
@@ -85,18 +85,18 @@ watch(selectedTokenAddress, updateTransaction);
       <span class="text-skin-text">{{ $t('safeSnap.asset') }}</span>
       <AvatarToken
         :address="
-          selectedToken.address === 'main'
+          selectedToken?.address === 'main'
             ? ETH_CONTRACT
-            : selectedToken.address
+            : selectedToken?.address
         "
         class="ml-2"
       />
-      <span v-if="selectedToken">{{ selectedToken.symbol }}</span>
+      <span v-if="selectedToken">{{ selectedToken?.symbol }}</span>
       <span>
         {{
-          selectedToken.address === 'main'
+          selectedToken?.address === 'main'
             ? ''
-            : `(${shorten(selectedToken.address)})`
+            : `(${shorten(selectedToken?.address)})`
         }}
       </span>
     </div>

--- a/src/plugins/oSnap/constants.ts
+++ b/src/plugins/oSnap/constants.ts
@@ -1100,6 +1100,7 @@ export const safePrefixes = {
 export const EXPLORER_API_URLS = {
   '1': 'https://api.etherscan.io/api',
   '5': 'https://api-goerli.etherscan.io/api',
+  '10': 'https://api-optimistic.etherscan.io/api',
   '100': 'https://gnosis.blockscout.com/api',
   '73799': 'https://volta-explorer.energyweb.org/api',
   '246': 'https://explorer.energyweb.org/api',
@@ -1113,6 +1114,7 @@ export const EXPLORER_API_URLS = {
 export const GNOSIS_SAFE_TRANSACTION_API_URLS = {
   '1': 'https://safe-transaction-mainnet.safe.global/api',
   '5': 'https://safe-transaction-goerli.safe.global/api',
+  '10': 'https://safe-transaction-optimism.safe.global/api',
   '100': 'https://safe-transaction-gnosis-chain.safe.global/api',
   '73799': 'https://safe-transaction-volta.safe.global/api',
   '246': 'https://safe-transaction-ewc.safe.global/api',

--- a/src/plugins/oSnap/utils/coins.ts
+++ b/src/plugins/oSnap/utils/coins.ts
@@ -52,11 +52,22 @@ const CORE_COIN = {
     'https://cloudflare-ipfs.com/ipfs/bafkreigjv5yb7uhlrryzib7j2f73nnwqan2tmfnwjdu26vkk365fyesoiu'
 } as const;
 
+const OPTIMISM_COIN = {
+  name: 'OPTIMISM',
+  symbol: 'OP',
+  address: 'main',
+  decimals: 18,
+  logoUri:
+    'https://optimistic.etherscan.io/images/svg/brands/optimism.svg?v=24.3.2.1'
+} as const;
+
 export function getNativeAsset(network: Network) {
   switch (parseInt(network)) {
     case 137:
     case 80001:
       return MATIC_COIN;
+    case 10:
+      return OPTIMISM_COIN;
     case 100:
       return XDAI_COIN;
     case 246:

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -47,6 +47,8 @@ async function callGnosisSafeTransactionApi<TResult = any>(
   network: Network,
   url: string
 ) {
+  if(!GNOSIS_SAFE_TRANSACTION_API_URLS[network])
+    throw new Error(`No gnosis safe api defined for network ${network}`)
   const apiUrl = GNOSIS_SAFE_TRANSACTION_API_URLS[network];
   const response = await fetch(apiUrl + url);
   return response.json() as TResult;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->
Optimism chain is not working with oSnap. This adds in OP data, such as token info and api endpoints, as well as fixes issues in rendering when certain data is not available. 

Closes: #

### How to test

1. find an osnap enabled space with an optimism treasury ( #/umadev.eth/create )
2. create a new osnap proposal
3. select the optimism safe, add new transaction
4. see that it loads correctly
5. select contract interaction, use this address: 0xcDF27F107725988f2261Ce2256bDfCdE8B382B10
6. load abi
7. see that abi loads


<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
