### PR TITLE
[oSnap] fix: oSnap settings are not working even if oSnap is enabled …

### DIFF
--- a/src/components/SettingsTreasuriesBlock.vue
+++ b/src/components/SettingsTreasuriesBlock.vue
@@ -22,7 +22,7 @@ const modalOsnapOpen = ref(false);
 const currentTreasuryIndex = ref<number | null>(null);
 const currentTreasury = ref<TreasuryWallet>(clone(treasuryObj));
 const hasOsnapPlugin = computed(() => {
-  return Object.keys(props.space.plugins).includes('oSnap');
+  return Object.keys(form.value.plugins).includes('oSnap');
 });
 const isOsnapEnabledOnCurrentTreasury = ref(false);
 


### PR DESCRIPTION
### Summary
- Before:
Even if you add oSnap in your plugins, you will not see notices or settings related to oSnap (until you save and reload)
- Now:
Once you add oSnap in your plugins, you will see notice and settings related to oSnap

| Before    | Now |
| -------- | ------- |
| <img width="748" alt="Untitled 3" src="https://github.com/snapshot-labs/snapshot/assets/15967809/c6222704-8eb4-4c52-921f-c04861c8c682">  |  <img width="726" alt="Untitled 5" src="https://github.com/snapshot-labs/snapshot/assets/15967809/269c7b0b-7baf-4907-ab37-1afc26517982">  |
| <img width="705" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot/assets/15967809/7da253f9-3259-4ec5-b411-768e3442292e"> | <img width="739" alt="Untitled 4" src="https://github.com/snapshot-labs/snapshot/assets/15967809/2a6fdaa2-8e80-4d02-b62e-b1297c3ba666">  |





