### PR TITLE
Add Shutter DAO to Boost testers

### DIFF
--- a/src/helpers/boost/index.ts
+++ b/src/helpers/boost/index.ts
@@ -28,6 +28,7 @@ export const BOOST_WHITELIST_SETTINGS = {
     'kumaprotocol.eth',
     'mimo.eth',
     'vote.vitadao.eth',
+    'shutterdao0x36.eth',
     // Internal testers
     'testsnap.eth',
     'fabien.eth',


### PR DESCRIPTION
Add Shutter DAO space (shutterdao0x36.eth) to Boost beta testing whitelist as per their request.
