### PR TITLE
fix: Hide very long ENS names

### DIFF
--- a/src/components/SettingsTreasuriesBlock.vue
+++ b/src/components/SettingsTreasuriesBlock.vue
@@ -22,7 +22,7 @@ const modalOsnapOpen = ref(false);
 const currentTreasuryIndex = ref<number | null>(null);
 const currentTreasury = ref<TreasuryWallet>(clone(treasuryObj));
 const hasOsnapPlugin = computed(() => {
-  return Object.keys(props.space.plugins).includes('oSnap');
+  return Object.keys(form.value.plugins).includes('oSnap');
 });
 const isOsnapEnabledOnCurrentTreasury = ref(false);
 

--- a/src/components/SetupDomain.vue
+++ b/src/components/SetupDomain.vue
@@ -57,7 +57,8 @@ const availableDomains = computed(() => {
     d =>
       !spaceIds.includes(d.name) &&
       !d.isInvalid &&
-      !deletedSpaces.value.includes(d.name)
+      !deletedSpaces.value.includes(d.name) &&
+      d.name.length <= 64
   );
 });
 

--- a/src/components/SetupDomain.vue
+++ b/src/components/SetupDomain.vue
@@ -38,10 +38,18 @@ watch(
 );
 
 const triggerEnsUnavailableTooltip = (key: string, error_code: string) => {
-  const text =
-    error_code === 'deleted-space'
-      ? 'This ENS name is used by a previously deleted space, and can not be used anymore to create a new space. <a target="_blank" href="https://docs.snapshot.org/faq#why-cant-i-create-a-new-space-with-my-previous-deleted-space-ens-name">Learn more.</a>'
-      : t('setup.domain.invalidEns');
+  let text;
+  switch (error_code) {
+    case 'deleted-space':
+      text =
+        'This ENS name is used by a previously deleted space, and can not be used anymore to create a new space. <a target="_blank" href="https://docs.snapshot.org/faq#why-cant-i-create-a-new-space-with-my-previous-deleted-space-ens-name">Learn more.</a>';
+      break;
+    case 'invalid-ens-length':
+      text = 'The ENS name is too long. It must be less than 64 characters.';
+      break;
+    default:
+      text = t('setup.domain.invalidEns');
+  }
 
   useTippy(refEnsUnavailableTooltip.value[key], {
     content: text,
@@ -67,7 +75,9 @@ const unavailableDomains = computed(() => {
   return ownedEnsDomains.value.filter(
     d =>
       !spaceIds.includes(d.name) &&
-      (d.isInvalid || deletedSpaces.value.includes(d.name))
+      (d.isInvalid ||
+        deletedSpaces.value.includes(d.name) ||
+        d.name.length > 64)
   );
 });
 
@@ -190,7 +200,37 @@ onUnmounted(() => clearInterval(waitingForRegistrationInterval));
                     </div>
                   </TuneButton>
                 </template>
-
+                <template v-else-if="ens.name.length > 64">
+                  <TuneButton class="flex w-full items-center justify-between">
+                    {{ shortenInvalidEns(ens.name) }}
+                    <div
+                      @mouseenter="
+                        triggerEnsUnavailableTooltip(
+                          ens.name,
+                          'invalid-ens-length'
+                        )
+                      "
+                      @focus="
+                        triggerEnsUnavailableTooltip(
+                          ens.name,
+                          'invalid-ens-length'
+                        )
+                      "
+                    >
+                      <div
+                        :ref="
+                          v => {
+                            refEnsUnavailableTooltip[ens.name] = v;
+                          }
+                        "
+                      >
+                        <i-ho-exclamation-circle
+                          class="-mr-2 text-red cursor-help"
+                        />
+                      </div>
+                    </div>
+                  </TuneButton>
+                </template>
                 <template v-else-if="ens.isInvalid">
                   <TuneButton class="flex w-full items-center justify-between">
                     {{ shortenInvalidEns(ens.name) }}


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot-sequencer/pull/321

Before
<img width="732" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot/assets/15967809/f99b651f-8fd1-4556-a29e-239010fa7599">


After
<img width="790" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot/assets/15967809/38ba07a3-f179-4ca3-bc08-a107d432dbb6">



