### PR TITLE
fix: Add support for delegation related strategies on delegation page

### DIFF
--- a/src/views/DelegateView.vue
+++ b/src/views/DelegateView.vue
@@ -121,9 +121,16 @@ async function getDelegationsAndDelegates() {
   }
 }
 
+const delegationStrategies = [
+  'delegation',
+  'erc20-balance-of-delegation',
+  'delegation-with-cap'
+];
+
 async function getDelegatesWithScore() {
-  const delegationStrategy = space.value.strategies.filter(
-    strategy => strategy.name === 'delegation'
+  console.log('getDelegatesWithScore');
+  const delegationStrategy = space.value.strategies.filter(strategy =>
+    delegationStrategies.includes(strategy.name)
   );
   if (delegationStrategy.length === 0) return;
 

--- a/src/views/DelegateView.vue
+++ b/src/views/DelegateView.vue
@@ -128,7 +128,6 @@ const delegationStrategies = [
 ];
 
 async function getDelegatesWithScore() {
-  console.log('getDelegatesWithScore');
   const delegationStrategy = space.value.strategies.filter(strategy =>
     delegationStrategies.includes(strategy.name)
   );

--- a/src/views/DelegateView.vue
+++ b/src/views/DelegateView.vue
@@ -124,7 +124,8 @@ async function getDelegationsAndDelegates() {
 const delegationStrategies = [
   'delegation',
   'erc20-balance-of-delegation',
-  'delegation-with-cap'
+  'delegation-with-cap',
+  'delegation-with-overrides'
 ];
 
 async function getDelegatesWithScore() {


### PR DESCRIPTION
Closes #4659 

Previously only delegation strategy works on delegation page, this PR will add `erc20-balance-of-delegation` and `delegation-with-cap` as these strategies are very similar to delegation strategy and should not create any problems

## How to test:
- Go to https://snapshot-2xwxdbhwj-snapshot.vercel.app/#/delegate/balancer.eth and you should see top delegates