### PR TITLE
fix: iframely api key management change

### DIFF
--- a/iframely.config.js
+++ b/iframely.config.js
@@ -1,0 +1,5 @@
+const config = {
+    apiKey: "IFRAMELY_API_KEY_HERE"
+};
+
+export default config; 

--- a/src/components/BlockLink.vue
+++ b/src/components/BlockLink.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { debouncedWatch } from '@vueuse/core';
+import config from '../../iframely.config.js';
 
 const props = withDefaults(
   defineProps<{
@@ -45,7 +46,7 @@ async function update(val: string) {
     loaded.value = false;
     preview.value = null;
     new URL(val);
-    const IFRAMELY_API_KEY = 'd155718c86be7d5305ccb6';
+    const IFRAMELY_API_KEY = config.apiKey;
     const url = `https://cdn.iframe.ly/api/iframely?url=${encodeURI(
       val
     )}&api_key=${IFRAMELY_API_KEY}`;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->
Under /src/components/BlockLink.vue, the used iframely api key is hard-coded. A better way of api key management for vue is setting up an external configuration file (in this PR iframely.config.js) with developers providing their own api key. 

[IFramely Documentation](https://iframely.com/docs/allow-origins)
![image](https://github.com/snapshot-labs/snapshot/assets/113321341/f953f88d-b6cd-45ce-9f97-1aca2f8bf057)

### How to test

1. Insert iframely api key into iframely.config.js, then build as usual


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)

