### PR TITLE
fix: Change Safe URL

### DIFF
--- a/src/components/ModalPostVote.vue
+++ b/src/components/ModalPostVote.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { getChoiceString } from '@/helpers/utils';
 import { ExtendedSpace, Proposal } from '@/helpers/interfaces';
+import { getSafeAppLink } from '@/plugins/oSnap/utils';
 
 const { shareVote, shareProposalX, shareProposalHey } = useSharing();
-const { web3Account } = useWeb3();
+const { web3, web3Account } = useWeb3();
 const { userState, loadEmailSubscriptions, initialized } =
   useEmailSubscription();
 
@@ -100,10 +101,13 @@ onMounted(() => {
         <i-ho-mail class="text-skin-link" />
         {{ $t('proposal.postVoteModal.subscribe') }}
       </TuneButton>
-
       <div v-if="props.waitingForSigners">
         <BaseLink
-          :link="`https://gnosis-safe.io/app/eth:${web3Account}/transactions/queue`"
+          :link="
+            getSafeAppLink(web3.network.chainId, web3Account, {
+              path: 'transactions/queue'
+            })
+          "
           hide-external-icon
         >
           <TuneButton tabindex="-1" class="w-full">

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -37,6 +37,7 @@ import {
 } from '../types';
 import { getPagedEvents } from './events';
 import { toChecksumAddress } from '@/helpers/utils';
+import app from '../../../main';
 
 /**
  * Calls the Gnosis Safe Transaction API
@@ -745,10 +746,10 @@ export function getSafeNetworkPrefix(network: Network): SafeNetworkPrefix {
 export function getSafeAppLink(
   network: Network,
   safeAddress: string,
-  appUrl = 'https://gnosis-safe.io/app/'
+  {appUrl = 'https://app.safe.global', path = '/home' } = {appUrl: 'https://app.safe.global', path: '/home'}
 ) {
   const prefix = getSafeNetworkPrefix(network);
-  return `${appUrl}${prefix}:${safeAddress}`;
+  return new URL(`${path}?safe=${prefix}:${safeAddress}`, appUrl).toString();
 }
 
 /**

--- a/src/plugins/safeSnap/components/SafeTransactions.vue
+++ b/src/plugins/safeSnap/components/SafeTransactions.vue
@@ -15,6 +15,7 @@ import Plugin, {
   getGnosisSafeBalances,
   getGnosisSafeCollectibles
 } from '../index';
+import { getSafeAppLink } from '@/plugins/oSnap/utils';
 
 const plugin = new Plugin();
 
@@ -210,8 +211,7 @@ export default {
   },
   computed: {
     safeLink() {
-      const prefix = EIP3770_PREFIXES[this.network];
-      return `https://gnosis-safe.io/app/${prefix}:${this.gnosisSafeAddress}`;
+      return getSafeAppLink(this.network, this.gnosisSafeAddress);
     },
     networkName() {
       if (this.network === '1') return 'Mainnet';


### PR DESCRIPTION
### Summary
Changes safe URL to new domain 
While reviewing https://github.com/snapshot-labs/snapshot/pull/4649 I noticed we are still using old domain and it is broken 

### How to test
- Trust me bro 🤣 

Or 

- Vote with a safe and after voting a model will be open, you should see the link to the transactions queue
- Go to http://localhost:8080/#/shapeshiftdao.eth/create
- Login with an admin account using guest tool
- You should see new safe app link in oSnap transactions 
- ![image](https://github.com/snapshot-labs/snapshot/assets/15967809/a1c67518-dbaf-425a-bd60-21eaac673372)
