### PR TITLE
fix: Replace support links with help center link

### DIFF
--- a/src/components/ModalVote.vue
+++ b/src/components/ModalVote.vue
@@ -3,6 +3,7 @@ import { shorten, getChoiceString, explorerUrl } from '@/helpers/utils';
 import { getPower, voteValidation } from '@/helpers/snapshot';
 import { ExtendedSpace, Proposal } from '@/helpers/interfaces';
 import shutterEncryptChoice from '@/helpers/shutter';
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
 
 const { web3Account } = useWeb3();
 
@@ -273,8 +274,8 @@ watch(
               tag="span"
               scope="global"
             >
-              <template #discord>
-                <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
+              <template #help>
+                <BaseLink :link="SNAPSHOT_HELP_LINK">Help Center</BaseLink>
               </template>
             </i18n-t>
           </BaseMessageBlock>
@@ -291,8 +292,8 @@ watch(
               tag="span"
               scope="global"
             >
-              <template #discord>
-                <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
+              <template #help>
+                <BaseLink :link="SNAPSHOT_HELP_LINK">Help Center</BaseLink>
               </template>
             </i18n-t>
           </BaseMessageBlock>

--- a/src/components/SetupMessageHelp.vue
+++ b/src/components/SetupMessageHelp.vue
@@ -1,4 +1,6 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
+</script>
 
 <template>
   <BaseBlock class="mt-4 text-skin-text">
@@ -13,8 +15,8 @@
           documentation</BaseLink
         >
       </template>
-      <template #discord>
-        <BaseLink link="https://discord.snapshot.org/"> Discord</BaseLink>
+      <template #help>
+        <BaseLink :link="SNAPSHOT_HELP_LINK">Help Center</BaseLink>
       </template>
     </i18n-t>
   </BaseBlock>

--- a/src/components/SpaceCreateWarnings.vue
+++ b/src/components/SpaceCreateWarnings.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
 import { ExtendedSpace } from '@/helpers/interfaces';
 
 const props = defineProps<{
@@ -63,7 +64,7 @@ const strategySymbolsString = computed(() => {
       is-responsive
     >
       {{ $t('create.errorGettingSnapshot') }}
-      <BaseLink link="https://discord.snapshot.org/">
+      <BaseLink :link="SNAPSHOT_HELP_LINK">
         {{ $t('learnMore') }}
       </BaseLink>
     </BaseMessageBlock>

--- a/src/components/SpaceProposalResults.vue
+++ b/src/components/SpaceProposalResults.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
 import {
   ExtendedSpace,
   Proposal,
@@ -72,7 +73,7 @@ onMounted(() => {
       </BaseMessage>
       <BaseLink
         v-if="isAdmin"
-        link="https://discord.snapshot.org/"
+        :link="SNAPSHOT_HELP_LINK"
         class="mt-3 block"
         hide-external-icon
       >

--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
 import { Proposal, Choice } from '@/helpers/interfaces';
 import voting from '@snapshot-labs/snapshot.js/src/voting';
 
@@ -120,8 +121,8 @@ watch(
       class="border px-3 py-[12px] rounded-xl bg-[--border-color-subtle]"
     >
       Oops, we were unable to validate your vote. Please try voting again or
-      consider opening a ticket with our support team on
-      <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
+      consider contacting our support team on
+      <BaseLink :link="SNAPSHOT_HELP_LINK">Help Center</BaseLink>
     </BaseMessage>
     <div v-else>
       <SpaceProposalVoteSingleChoice

--- a/src/components/SpaceProposalsNotice.vue
+++ b/src/components/SpaceProposalsNotice.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
 import { useStorage } from '@vueuse/core';
 
 defineProps<{
@@ -49,8 +50,8 @@ const createdSpaces = useStorage(
                 documentation</BaseLink
               >
             </template>
-            <template #discord>
-              <BaseLink link="https://discord.snapshot.org/"> Discord</BaseLink>
+            <template #help>
+              <BaseLink :link="SNAPSHOT_HELP_LINK">Help Center</BaseLink>
             </template>
           </i18n-t>
         </div>

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
+
 const yearNow = new Date().getFullYear();
 
 const snapshotTextLinks = [
@@ -31,7 +33,7 @@ const resourcesTextLinks = [
   },
   {
     text: 'support',
-    link: 'https://discord.snapshot.org/'
+    link: SNAPSHOT_HELP_LINK
   }
 ];
 </script>

--- a/src/components/TheModalNotification.vue
+++ b/src/components/TheModalNotification.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
 import defaults from '@/locales/default.json';
 
 const { items } = useModalNotification();
@@ -20,8 +21,8 @@ const { items } = useModalNotification();
             tag="span"
             scope="global"
           >
-            <template #discord>
-              <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
+            <template #help>
+              <BaseLink :link="SNAPSHOT_HELP_LINK">Discord</BaseLink>
             </template>
           </i18n-t>
         </template>

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -93,3 +93,5 @@ export const CHAIN_CURRENCIES: Record<string, ChainCurrency> = {
 
 export const TWO_WEEKS = 1209600;
 export const ONE_DAY = 86400;
+
+export const SNAPSHOT_HELP_LINK = 'https://help.snapshot.org/en';

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -17,8 +17,8 @@
   "ticketWithAnyOrBasicErrorSetup": "Use of the ticket strategy requires setting a voting validation strategy. To continue go one step back and select the \"One person, one vote\" option. {article}",
   "missingProposalValidationError": "Proposal validation is required to prevent unauthorized proposals and spam. If you don't want proposal validation you can toggle only the \"Allow only authors to submit a proposal\" option.",
   "resultsCalculating": "Final results are being calculated. If you still see this message after a few minutes contact the space admin.",
-  "votingPowerFailedMessage": "Your voting power could not be calculated. This is often due to a misconfigured strategy or an unresponsive RPC node involved in the strategy. If the problem persists, consider contacting the space admin or our support team on {discord}",
-  "votingValidationFailedMessage": "We were not able to validate your eligibility to vote. This is often due to a misconfigured vote validation setting or an unresponsive RPC node. If the problem persists, consider contacting the space admin or our support team on {discord}",
+  "votingPowerFailedMessage": "Your voting power could not be calculated. This is often due to a misconfigured strategy or an unresponsive RPC node involved in the strategy. If the problem persists, consider contacting our support team on {help}",
+  "votingValidationFailedMessage": "We were not able to validate your eligibility to vote. This is often due to a misconfigured vote validation setting or an unresponsive RPC node. If the problem persists, consider contacting our support team on {help}",
   "getHelp": "Get help",
   "retry": "Retry",
   "currentResults": "Current results",
@@ -179,7 +179,7 @@
   "newSpaceNotice": {
     "header": "Your space is live!",
     "mainText": "You can change how voting power is calculated via strategies in your {settings}. Changes to your settings will only affect new proposals, existing proposals can not be changed.",
-    "learnMore": "Learn more in the {documentation} or join Snapshot {discord} for help.",
+    "learnMore": "Learn more in the {documentation} or contact support on {help}.",
     "gotIt": "Got it!"
   },
   "errors": {
@@ -352,15 +352,15 @@
   "modalNotifications": {
     "wrong timestamp": {
       "title": "Wrong timestamp",
-      "message": "The message timestamp is not valid. Please check the clock on your device, make sure it is set to the correct date and time and try again.\n\n If you need further assistance, feel free to reach out to our support team on {discord}."
+      "message": "The message timestamp is not valid. Please check the clock on your device, make sure it is set to the correct date and time and try again.\n\n If you need further assistance, feel free to reach out to our support team on {help}."
     },
     "space with ticket requires voting validation": {
       "title": "Missing voting validation",
-      "message": "Your proposal cannot be submitted due to a missing voting validation rule required with the 'ticket' strategy. Please adjust your settings by either using another strategy or adding the required validation.\n\n If further assistance is needed, contact our support team on {discord}."
+      "message": "Your proposal cannot be submitted due to a missing voting validation rule required with the 'ticket' strategy. Please adjust your settings by either using another strategy or adding the required validation.\n\n If further assistance is needed, contact our support team on {help}."
     },
     "space missing proposal validation": {
       "title": "Missing proposal validation",
-      "message": "Your proposal cannot be submitted due to a missing proposal validation rule. To prevent unauthorized proposals and spam, add a validation rule in your space settings.\n\n For assistance, reach out to our support team on {discord}."
+      "message": "Your proposal cannot be submitted due to a missing proposal validation rule. To prevent unauthorized proposals and spam, add a validation rule in your space settings.\n\n For assistance, reach out to our support team on {help}."
     }
   },
   "modalTerms": {
@@ -554,7 +554,7 @@
     "createASpace": "Create a space",
     "registerEnsButton": "Register",
     "supportedEnsTLDs": "Supported domain endings",
-    "helpDocsAndDiscordLinks": "Not sure how to setup your space? Learn more in the {docs} or join Snapshot {discord}.",
+    "helpDocsAndDiscordLinks": "Not sure how to setup your space? Learn more in the {docs} or contact support on {help}.",
     "setSpaceController": "Space controller",
     "setSpaceControllerExists": "The snapshot text-record for this domain has already been set. Choose edit to change it, otherwise you can skip to the next step.",
     "setSpaceControllerInfo": " The space controller is the account that will be able to manage the space settings. Additional space controllers (admins) can be added later.",

--- a/src/views/SpaceDelegates.vue
+++ b/src/views/SpaceDelegates.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SNAPSHOT_HELP_LINK } from '@/helpers/constants';
 import { ExtendedSpace } from '@/helpers/interfaces';
 import { useInfiniteScroll, refDebounced } from '@vueuse/core';
 
@@ -210,9 +211,8 @@ onMounted(() => {
         </div>
         <BaseMessageBlock v-if="hasDelegatesLoadFailed" level="warning-red">
           An error occurred while loading delegates. Please try again later. If
-          the problem persists, consider contacting the space admin or our
-          support team on
-          <BaseLink link="https://discord.snapshot.org">Discord</BaseLink>
+          the problem persists, consider contacting our support team on
+          <BaseLink :link="SNAPSHOT_HELP_LINK">Help Center</BaseLink>
         </BaseMessageBlock>
         <template v-else-if="searchInputDebounced">
           <div


### PR DESCRIPTION
### Summary
Replacing support links with new help center link

### How to test:
- Go to places where we have support links
- for example
- on space creation:
![Untitled 4](https://github.com/snapshot-labs/snapshot/assets/15967809/da03bc53-2d55-4555-92c0-125fa1ed97e3)
- Footer:
![Untitled 3](https://github.com/snapshot-labs/snapshot/assets/15967809/299cc0b3-c440-4e5d-b017-9e14e58fd561)
- While voting:
![Untitled 2](https://github.com/snapshot-labs/snapshot/assets/15967809/9943a7aa-553f-473a-90be-ea7022658e70)
