### PR TITLE
Rename to 'Quorum of rejection'

### DIFF
--- a/src/components/ProposalsItemFooter.vue
+++ b/src/components/ProposalsItemFooter.vue
@@ -12,9 +12,9 @@ const quorumText = computed(() => {
     return '';
   }
 
-  const optimisticQuorum = props.proposal.quorumType === 'optimistic';
+  const quorumOfRejection = props.proposal.quorumType === 'rejection';
   const percentage = formatPercentNumber(
-    optimisticQuorum
+    quorumOfRejection
       ? Number(
           props.proposal.scores
             .filter((c, i) => i === 1)
@@ -22,7 +22,7 @@ const quorumText = computed(() => {
         )
       : Number(props.proposal.scores_total / props.proposal.quorum)
   );
-  return optimisticQuorum
+  return quorumOfRejection
     ? `${percentage} quorum rejection`
     : `${percentage} quorum reached`;
 });

--- a/src/components/SettingsVotingBlock.vue
+++ b/src/components/SettingsVotingBlock.vue
@@ -40,8 +40,8 @@ const { form, validationErrors } = useFormSpaceSettings(props.context);
               name: 'Default'
             },
             {
-              value: 'optimistic',
-              name: 'Optimistic'
+              value: 'rejection',
+              name: 'Quorum of rejection'
             }
           ]"
           :disabled="isViewOnly"

--- a/src/components/SpaceProposalResultsQuorum.vue
+++ b/src/components/SpaceProposalResultsQuorum.vue
@@ -17,7 +17,7 @@ const { formatCompactNumber, formatPercentNumber } = useIntl();
   <div class="pt-2 text-skin-link">
     <div class="flex justify-between">
       <div class="flex items-center gap-1">
-        {{ quorumType === 'optimistic' ? 'Optimistic Quorum' : 'Quorum' }}
+        {{ quorumType === 'rejection' ? 'Quorum of rejection' : 'Quorum' }}
       </div>
       <LoadingSpinner v-if="loadingQuorum" class="mr-1" />
       <div v-else class="flex gap-2">
@@ -29,7 +29,7 @@ const { formatCompactNumber, formatPercentNumber } = useIntl();
         />
         <i-ho-x
           v-if="
-            quorum && quorumType === 'optimistic' && totalQuorumScore >= quorum
+            quorum && quorumType === 'rejection' && totalQuorumScore >= quorum
           "
           class="text-red"
         />

--- a/src/composables/useQuorum.ts
+++ b/src/composables/useQuorum.ts
@@ -18,7 +18,7 @@ export function useQuorum(props: QuorumProps) {
   const quorumType = ref('default');
 
   const totalQuorumScore = computed(() => {
-    if (props.proposal.quorumType === 'optimistic') {
+    if (props.proposal.quorumType === 'rejection') {
       return props.results.scores
         .filter((c, i) => i === 1)
         .reduce((a, b) => a + b, 0);

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -179,7 +179,7 @@ export interface ExtendedSpace {
     hideAbstain: boolean;
     period: number | null;
     quorum: number | null;
-    quorumType: 'default' | 'optimistic';
+    quorumType: 'default' | 'rejection';
     type: string | null;
     privacy: string | null;
   };
@@ -230,7 +230,7 @@ export interface Proposal {
   validation: VoteValidation;
   discussion: string;
   quorum: number;
-  quorumType: 'default' | 'optimistic';
+  quorumType: 'default' | 'rejection';
   scores: number[];
   scores_state: string;
   scores_total: number;


### PR DESCRIPTION
### Summary

Related to https://github.com/snapshot-labs/snapshot/issues/4600

Now we call it "Quorum of rejection"

### How to test

1. Go to https://snapshot-git-rename-to-quorum-of-rejection-snapshot.vercel.app/#/thanku.eth/settings
 settings -> voting -> Change quorum type to "Quorum of rejection"
<img width="680" alt="Untitled 3" src="https://github.com/snapshot-labs/snapshot/assets/15967809/cd6f1fcf-3da3-4d54-ac2b-5228c55df8a8">

2. Create new proposal

3. Try to vote on second option and you will see quorum is updated
<img width="345" alt="Untitled 6" src="https://github.com/snapshot-labs/snapshot/assets/15967809/a70561fd-a055-4503-b04a-8d3d3e009c83">

5. Check proposals page
<img width="713" alt="Untitled 7" src="https://github.com/snapshot-labs/snapshot/assets/15967809/f27f9a01-71cd-4b8e-a8e2-84a414e74d5d">
