### PR TITLE
fix: ChainId is wrong while switching the network

### DIFF
--- a/src/composables/useChangeNetwork.ts
+++ b/src/composables/useChangeNetwork.ts
@@ -1,6 +1,5 @@
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { sleep } from '@snapshot-labs/snapshot.js/src/utils';
-import { hexlify } from '@ethersproject/bytes';
 
 export function useChangeNetwork() {
   const changingNetwork = ref(false);
@@ -11,7 +10,7 @@ export function useChangeNetwork() {
       method: 'wallet_switchEthereumChain',
       params: [
         {
-          chainId: hexlify(Number(networks[network].chainId))
+          chainId: `0x${Number(networks[network].chainId).toString(16)}`
         }
       ]
     });


### PR DESCRIPTION
ChainId is wrong while switching the network

## How to test: 
- Make sure your metamask wallet network is sepolia
- Go to http://localhost:8080/#/thanku.eth/boost/0x9ef1c0ad8329186500866f5962c24f8d49a382857b3ebe49f9b4615193ab72ad
- Select Ethereum and some token to deposit
<img width="623" alt="Untitled 9" src="https://github.com/snapshot-labs/snapshot/assets/15967809/0d63e778-d95f-438d-acbc-efe9f8abd4ae">

- Click on "Create"
- Before fix you will see error, now you should see that wallet is open to change the network
