### PR TITLE
fix: only show activation button if plugin installed

### DIFF
--- a/src/components/SettingsTreasuriesBlockItemButton.vue
+++ b/src/components/SettingsTreasuriesBlockItemButton.vue
@@ -53,9 +53,9 @@ onUnmounted(() => {
     <div class="flex items-center gap-2 truncate pr-[20px] text-left">
       <h4 class="truncate">{{ treasury.name }}</h4>
     </div>
-    <div class="ml-auto mr-3">
+    <div v-if="hasOsnapPlugin" class="ml-auto mr-3">
       <SettingsTreasuryActivateOsnapButton
-        v-if="hasOsnapPlugin && isChainSupported"
+        v-if="isChainSupported"
         :is-osnap-enabled="isOsnapEnabled"
         @click.stop="
           !isViewOnly && emit('configureOsnap', treasuryIndex, isOsnapEnabled)


### PR DESCRIPTION
### Summary

Small fix in logic to show/hide the "activate oSnap" button in `Settings => Advanced`.
Currently if a space doesn't have osnap plugin installed it will show "oSnap unavailable". We only want this to show only if the plugin IS installed but there is no subgraph defined for the network.

### How to test

1. Go to `Space => Settings => Advanced => Treasury Section`
2. If oSnap plugin installed and the network is supported (we have config) we show a button with either `activate osnap` or `oSnap activated` OR if no config for this chain we show text "oSnap unavailable"
3. If oSnap plugin not installed, show nothing.
