### PR TITLE
fix: Use correct chainId for sepolia in walletconnect config

### DIFF
--- a/src/helpers/connectors.ts
+++ b/src/helpers/connectors.ts
@@ -11,7 +11,7 @@ const connectors = {
       projectId: 'e6454bd61aba40b786e866a69bd4c5c6',
       chains: [1],
       optionalChains: [
-        4, 5, 10, 42, 56, 100, 137, 246, 1088, 42161, 73799, 1115511
+        4, 5, 10, 42, 56, 100, 137, 246, 1088, 42161, 73799, 11155111
       ],
       methods: ['eth_sendTransaction', 'personal_sign', 'eth_signTypedData_v4'],
       optionalMethods: ['eth_accounts'],


### PR DESCRIPTION
### Summary

The chainId for Sepolia is `11155111` but it was `1115511` in the walletconnect connector config. Trying to connect to Snapshot with a Safe on Sepolia doesn't work.

Follow up on #4622 

### How to test

1. Run the snapshot app
2. Press the connect wallet button and choose walletconnect
3. Copy the wc uri and open app.safe.global with a Safe on Sepolia
4. Paste the wc uri in the header
5. It should be possible to Approve the connection

<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
