### PR TITLE
feature: add moonbeam safe to known hosts

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -16,7 +16,8 @@ export const KNOWN_HOSTS = [
   'pilot.gnosisguild.org',
   'metissafe.tech',
   'multisig.mantle.xyz',
-  'wallet.ambire.com'
+  'wallet.ambire.com',
+  'multisig.moonbeam.network'
 ];
 
 export const SPACE_CATEGORIES = [


### PR DESCRIPTION
Summary

Adds Moonbeam Safe host to known hosts to enable multi-signature wallets interact with snapshot as a safe app.
Moonbeam Safe URL: https://multisig.moonbeam.network

Closes: https://github.com/snapshot-labs/snapshot/issues/4698
How to test
   
1. Open Moonbeam Safe and either create or open safe wallet: https://multisig.moonbeam.network
2. Go to custom apps
3. Add snapshot URL (for mainnet: https://snapshot.org/, for testnet: https://testnet.snapshot.org/, local - http://localhost:8080/)
 4. Find a Moonbeam space and proposal and try voting.