### PR TITLE
fix: Privacy label name for any option

### DIFF
--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -717,7 +717,7 @@
     "label": "Privacy",
     "title": "Select voting privacy",
     "information": "The type of privacy used on proposals. (Enforced on all future proposals)",
-    "any": "No Privacy",
+    "any": "No privacy",
     "none": "None",
     "shutter": {
       "label": "Shutter",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -717,7 +717,7 @@
     "label": "Privacy",
     "title": "Select voting privacy",
     "information": "The type of privacy used on proposals. (Enforced on all future proposals)",
-    "any": "Any",
+    "any": "No Privacy",
     "none": "None",
     "shutter": {
       "label": "Shutter",


### PR DESCRIPTION
Closes #4701 

### How to test:
- Go to your space settings => voting

| Before | After |
| ------  | ----- |
| <img width="676" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/d247dfa6-f55c-43e7-b131-8a2ef8e8efad"> | <img width="668" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/4b69d95b-ad74-42db-a2d5-af3341962c0f"> |
| <img width="458" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/4e00be44-a778-4054-83b5-ee66a284ddf3"> | <img width="444" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/e38aea01-350f-43db-a3c5-820d1db1998e">|
