### PR TITLE
fix: Not able to claim boost reward

### DIFF
--- a/src/components/SpaceProposalBoostClaimModalItem.vue
+++ b/src/components/SpaceProposalBoostClaimModalItem.vue
@@ -32,10 +32,7 @@ const reward = computed(() => {
     props.boost.token.decimals
   );
 
-  return formatNumber(
-    Number(amountDecimal),
-    getNumberFormatter({ maximumFractionDigits: 8 }).value
-  );
+  return amountDecimal;
 });
 
 const claim = computed(() => {
@@ -84,7 +81,13 @@ async function handleClaimAndReload() {
           {{ hasClaimed ? 'Claimed' : 'Reward' }}
         </span>
         <TuneTag class="text-skin-heading text-base">
-          {{ reward }} {{ props.boost.token.symbol }}
+          {{
+            formatNumber(
+              Number(reward),
+              getNumberFormatter({ maximumFractionDigits: 8 }).value
+            )
+          }}
+          {{ props.boost.token.symbol }}
         </TuneTag>
         <div class="mt-1 flex items-center flex-wrap">
           <span


### PR DESCRIPTION
### Summary
Right now we are trying to convert formated number to `Number` using `Number(reward)` which return `NaN` if there is a `,` in value, for example `1,000`

- So now we format it only to display it, and others will still use the original number


### How to test

1. Go to http://localhost:8080/#/shutterdao0x36.eth/proposal/0x633518d79a16135f984d3a6e90fe858d354ff0afa41b1f394741bd6819f41853
2. Login with account `0xdffdb9beea2ab3151bcbcf37a01ee8726f22ed94`
3. Try claiming the reward
4. Before fix, you won't be able to see claim button, now you should see it
