### PR TITLE
fix: Hide walletlink if coinbase is injected

### DIFF
--- a/src/components/ModalAccount.vue
+++ b/src/components/ModalAccount.vue
@@ -17,6 +17,8 @@ const injected = computed(() => getInjected());
 
 const filteredConnectors = computed(() => {
   const baseConnectors = ['injected', 'walletconnect', 'walletlink'];
+  // If injected is Coinbase, hide WalletLink
+  if (injected.value?.name === 'Coinbase') connectors.walletlink.hidden = true;
   if (isShowingAllConnectors.value) return Object.keys(connectors);
   return Object.keys(connectors).filter(cId => baseConnectors.includes(cId));
 });

--- a/src/helpers/connectors.ts
+++ b/src/helpers/connectors.ts
@@ -43,7 +43,8 @@ const connectors = {
       chainId: 1,
       ethJsonrpcUrl: `${import.meta.env.VITE_BROVIDER_URL}/1`
     },
-    icon: 'ipfs://QmbJKEaeMz6qR3DmJSTxtYtrZeQPptVfnnYK72QBsvAw5q'
+    icon: 'ipfs://QmbJKEaeMz6qR3DmJSTxtYtrZeQPptVfnnYK72QBsvAw5q',
+    hidden: false
   },
   portis: {
     id: 'portis',


### PR DESCRIPTION
### Summary

Right now, if Coinbase is injected, we display two Coinbase connectors, which is confusing.

![image](https://github.com/snapshot-labs/snapshot/assets/15967809/c2fda0a0-8100-400d-b49d-a3a473987b0c)


### How to test

1. Disable other wallet extensions except coinbase wallet 
2. Try to connect wallet on snapshot 
3. Now we should see only one coinbase

Or 
1. open snapshot in coinbase mobile wallet
2. now we should see only one coinbase instead of two

