### PR TITLE
fix: Coinbase wallet issue while switching accounts in different tab

### DIFF
--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -33,6 +33,7 @@ export function useWeb3() {
 
   function logout() {
     auth = getInstance();
+    if (auth.provider?.value?.isCoinbaseWallet) auth.provider.value.close();
     auth.logout();
     state.account = '';
   }


### PR DESCRIPTION
### Summary
While using coinbase wallet extension, if we switch the account in a new tab, the injected object is not updated, so whenever user clicks logout and connects again, we always get previous address instead of current one

With this fix, If user clicks on logout, we close the connection so user have to connect again - which will fix all the account switch issuse

### How to test
1. Make sure you have two accounts in coinbase wallet
2. Try connecting coinbase wallet to snapshot
3. In a new tab try changing the account to different account
4. click on logout and connect again

Before the fix, you should see that we still show previous address as connected address
After the fix, you should see the new address as connected address
