### PR TITLE
fix: Add created_gt filter to aliases query

### DIFF
--- a/src/composables/useAliasAction.ts
+++ b/src/composables/useAliasAction.ts
@@ -54,9 +54,10 @@ export function useAliasAction() {
 
   async function setAlias() {
     const rndWallet = Wallet.createRandom();
-    aliases.value = Object.assign(aliases.value, {
+    aliases.value = {
+      ...aliases.value,
       [web3.value.account]: rndWallet.privateKey
-    });
+    };
     lsSet('aliases', aliases.value);
 
     if (aliasWallet.value?.address) {

--- a/src/composables/useAliasAction.ts
+++ b/src/composables/useAliasAction.ts
@@ -39,7 +39,8 @@ export function useAliasAction() {
           query: ALIASES_QUERY,
           variables: {
             address: web3.value.account,
-            alias: aliasWallet.value.address
+            alias: aliasWallet.value.address,
+            created_gt: Math.floor(Date.now() / 1000) - 30 * 60 * 60 * 24
           }
         },
         'aliases'
@@ -53,12 +54,9 @@ export function useAliasAction() {
 
   async function setAlias() {
     const rndWallet = Wallet.createRandom();
-    aliases.value = Object.assign(
-      {
-        [web3.value.account]: rndWallet.privateKey
-      },
-      aliases.value
-    );
+    aliases.value = Object.assign(aliases.value, {
+      [web3.value.account]: rndWallet.privateKey
+    });
     lsSet('aliases', aliases.value);
 
     if (aliasWallet.value?.address) {

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -192,8 +192,10 @@ export const SUBSCRIPTIONS_QUERY = gql`
 `;
 
 export const ALIASES_QUERY = gql`
-  query Aliases($address: String!, $alias: String!) {
-    aliases(where: { address: $address, alias: $alias }) {
+  query Aliases($address: String!, $alias: String!, $created_gt: Int) {
+    aliases(
+      where: { address: $address, alias: $alias, created_gt: $created_gt }
+    ) {
       address
       alias
     }


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot-sequencer/pull/353/files

### Summary
- Only use aliases that were created within the last 30 days

### How to test

1. Try following/unfollowing a space with an alias created 30 days ago
2. It should ask to create new alias in this case
