### PR TITLE
feat: Boost reward to winning choice

### DIFF
--- a/src/components/SpaceProposalBoost.vue
+++ b/src/components/SpaceProposalBoost.vue
@@ -46,14 +46,24 @@ const newBoostLink = computed(() => ({
 const isActive = computed(() => props.proposal.state === 'active');
 const isFinal = computed(() => props.proposal.scores_state === 'final');
 
+const winningChoice = computed(() => {
+  const maxScore = Math.max(...props.proposal.scores);
+  const maxScoreCount = props.proposal.scores.filter(
+    score => score === maxScore
+  ).length;
+  return maxScoreCount > 1 ? 0 : props.proposal.scores.indexOf(maxScore) + 1;
+});
+
 function isEligible(boost: BoostSubgraph) {
+  const type = boost.strategy.eligibility.type;
   const choice = boost.strategy.eligibility.choice;
 
   if (!web3Account.value) return false;
   if (!isFinal.value) return false;
   if (!userVote.value) return false;
-  if (choice === null) return true;
-
+  if (type === 'prediction')
+    return userVote.value.choice.toString() === winningChoice.value.toString();
+  if (type === 'incentive' && choice === null) return true;
   return userVote.value.choice.toString() === choice;
 }
 

--- a/src/components/SpaceProposalBoostItem.vue
+++ b/src/components/SpaceProposalBoostItem.vue
@@ -242,7 +242,10 @@ const { pause } = useIntervalFn(() => {
         <div class="w-full">
           <div class="text-skin-heading flex flex-wrap -mt-1 pr-5">
             <div class="whitespace-nowrap mt-1 mr-1 flex items-center">
-              <template v-if="boost.strategy.eligibility.choice !== null">
+              <template v-if="boost.strategy.eligibility.type === 'prediction'">
+                Anyone who votes on winning choice
+              </template>
+              <template v-else-if="boost.strategy.eligibility.choice !== null">
                 Who votes
                 <div>
                   <TuneTag

--- a/src/helpers/boost/types.ts
+++ b/src/helpers/boost/types.ts
@@ -71,7 +71,7 @@ export type BoostSubgraph = {
     name: string;
     proposal: string;
     eligibility: {
-      type: 'incentive' | 'bribe';
+      type: 'incentive' | 'prediction' | 'bribe';
       choice: string | null;
     };
     distribution: {

--- a/src/views/SpaceBoost.vue
+++ b/src/views/SpaceBoost.vue
@@ -125,7 +125,7 @@ const eligibilityOptions = computed(() => {
     },
     {
       value: 'prediction',
-      label: 'Who vote for the winning choice'
+      label: 'Anyone who votes for the winning choice'
     },
     ...proposalChoices
   ];

--- a/src/views/SpaceBoost.vue
+++ b/src/views/SpaceBoost.vue
@@ -38,7 +38,7 @@ const props = defineProps<{
 
 type Form = {
   eligibility: {
-    choice: 'any' | number;
+    choice: 'any' | 'prediction' | number;
   };
   distribution: {
     type: 'lottery' | 'weighted';
@@ -123,6 +123,10 @@ const eligibilityOptions = computed(() => {
       value: 'any',
       label: 'Anyone who votes'
     },
+    {
+      value: 'prediction',
+      label: 'Who vote for the winning choice'
+    },
     ...proposalChoices
   ];
 });
@@ -206,13 +210,20 @@ const strategyDistributionLimit = computed(() => {
 });
 
 const strategy = computed<BoostStrategy>(() => {
-  const choice =
-    form.value.eligibility.choice === 'any'
-      ? undefined
-      : form.value.eligibility.choice.toString();
+  let choice;
+  let eligibilityType;
 
-  const eligibilityType =
-    form.value.eligibility.choice === 'any' ? 'incentive' : 'bribe';
+  switch (form.value.eligibility.choice) {
+    case 'any':
+      eligibilityType = 'incentive';
+      break;
+    case 'prediction':
+      eligibilityType = 'prediction';
+      break;
+    default:
+      choice = form.value.eligibility.choice.toString();
+      eligibilityType = 'bribe';
+  }
 
   return {
     name: 'Boost',


### PR DESCRIPTION
### Summary
Boost reward to winning choice 
- Add a new eligibility type for boost winning choice
  <img width="615" alt="Untitled 3" src="https://github.com/snapshot-labs/snapshot/assets/15967809/d0b8e0f5-94e2-4e44-8bf3-67ef664a1215">

- Change text to "Anyone who votes to winning choice" if eligibility type is `prediction` 
  <img width="591" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot/assets/15967809/93c1a250-1c49-4743-a872-68e7c1635188">

### How to test

1. Create a new proposal and try to create a new boost with new eligibility type
2. vote and proposal and make sure your choice is winning 
3. Claim