### PR TITLE
fix: disable sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ const app = createApp({
   render: () => h(App)
 });
 
-initSentry(app, router);
+// initSentry(app, router);
 
 app
   .use(head)

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import options from '@/helpers/auth';
 import VueTippy from 'vue-tippy';
 import VueViewer from 'v-viewer';
 import { apolloClient } from '@/helpers/apollo';
-import { initSentry } from '@/sentry';
+// import { initSentry } from '@/sentry';
 import { KNOWN_HOSTS } from '@/helpers/constants';
 import i18n from '@/helpers/i18n';
 import router from '@/router';


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #

Disable the sentry plugin, as it's not currently used, and is triggering warning on AVG

### How to test

1.

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
