### PR TITLE
fix: footer link for network support should open in same tab

### DIFF
--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -70,7 +70,6 @@ const resourcesTextLinks = [
             v-for="item in snapshotTextLinks"
             :key="item.text"
             :link="item.link"
-            :is-external="item.isExternal || true"
           >
             {{ $t(`footerView.${item.text}`) }}
             <BasePill

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -14,7 +14,9 @@ const snapshotTextLinks = [
   },
   {
     text: 'network-support',
-    link: '#/network'
+    link: {
+      name: 'network'
+    }
   }
 ];
 
@@ -68,6 +70,7 @@ const resourcesTextLinks = [
             v-for="item in snapshotTextLinks"
             :key="item.text"
             :link="item.link"
+            :is-external="item.isExternal || true"
           >
             {{ $t(`footerView.${item.text}`) }}
             <BasePill


### PR DESCRIPTION
### Summary
Footer link for network support should open in same tab



### How to test
1. Go to footer in home page
2. click on network support
3. now it should open in same tab instead of new tab

