### PR TITLE
fix: Change network page link and remove horizontal scroll for customers section

### DIFF
--- a/src/views/ExploreView.vue
+++ b/src/views/ExploreView.vue
@@ -37,7 +37,7 @@ const resultsStr = computed(() => {
 
 const createLink = computed(() => {
   if (isStrategies.value) return 'https://docs.snapshot.org/strategies/create';
-  if (isNetworks.value) return 'https://docs.snapshot.org/networks';
+  if (isNetworks.value) return { name: 'network' };
   if (isPlugins.value) return 'https://docs.snapshot.org/plugins/create';
   return 'https://docs.snapshot.org/strategies/create';
 });

--- a/src/views/Network.vue
+++ b/src/views/Network.vue
@@ -149,7 +149,7 @@ useMeta({
     <BaseContainer class="!max-w-[880px] text-center">
       <div class="eyebrow mb-4">Trusted by</div>
       <div class="overflow-y-scroll no-scrollbar">
-        <div class="grid grid-flow-col auto-cols-max justify-center gap-4">
+        <div class="flex flex-wrap gap-4 justify-center">
           <a
             v-for="(customer, i) in CUSTOMERS"
             :key="i"


### PR DESCRIPTION
### Summary
- Change the network page link on the networks page
- Remove horizontal scroll for the customers section (approved by `less`)
Details: https://discord.com/channels/955773041898573854/1031838169282392144/1248618727898091612

### How to test

1. ![image](https://github.com/snapshot-labs/snapshot/assets/15967809/c8306863-a51a-4364-92fc-a39ac33a3c2f)
2. On click of this button, we should go to the network page instead
3. Under "Trusted by" we should not see the scroll anymore. instead we see all customers
4. <img width="370" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot/assets/15967809/e10ae5fb-bc9c-4960-b85d-1778ce1763c7">


