### PR TITLE
fix: Add existing network section to network page

### DIFF
--- a/src/views/Network.vue
+++ b/src/views/Network.vue
@@ -178,6 +178,21 @@ useMeta({
     </BaseContainer>
 
     <BaseContainer class="!max-w-[880px]">
+      <div class="border p-4 rounded-lg">
+        <h3 class="mb-1 mt-0 leading-[33px] text-[22px]">
+          <i-ho-exclamation-circle
+            class="inline-block mr-1 w-[20px] h-[20px]"
+          />
+          Is your network already live on Snapshot?
+        </h3>
+        <div class="text-md">
+          Starting July 1, 2024, all networks must subscribe to the network plan
+          to maintain support on Snapshot. To ensure continuous service and
+          avoid interruptions, please contact our team today.
+        </div>
+      </div>
+    </BaseContainer>
+    <BaseContainer class="!max-w-[880px]">
       <div class="mb-2 eyebrow text-center">Frequently asked questions</div>
       <h1 class="mb-3 text-center text-[34px] leading-[44.2px]">Questions?</h1>
       <div v-for="(question, i) in FAQ" :key="i" class="border-b">


### PR DESCRIPTION
### Summary
Adds new existing network section to network page

### How to test

1. Go to http://localhost:8080/#/network
2. You should see the new section same as https://snapshotx.xyz/#/network
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/da967946-bc60-4fbc-b4f6-6f7be5a2774d)

