### PR TITLE
fix: Profile page - check for valid address and send requests only with checksummed addresses

### DIFF
--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
+import { getAddress } from '@ethersproject/address';
 const route = useRoute();
 
 const modalProfileFormOpen = ref(false);
 
-const userAddress = computed(
-  () => route.params.address.toLowerCase() as string
-);
+let userAddress = computed(() => {
+  const address = route.params.address as string;
+  try {
+    return getAddress(address);
+  } catch (error) {
+    console.error(error);
+    return '';
+  }
+});
 
 const { profiles, loadProfiles } = useProfiles();
 
@@ -13,7 +20,10 @@ onMounted(() => loadProfiles([userAddress.value]));
 </script>
 
 <template>
-  <TheLayout>
+  <BaseBlock v-if="!userAddress" class="text-center m-4">
+    Invalid address
+  </BaseBlock>
+  <TheLayout v-else>
     <template #sidebar-left>
       <ProfileSidebar
         :profiles="profiles"


### PR DESCRIPTION
### Issue 
Profile page doesn't show any activity https://discord.com/channels/955773041898573854/1182427601046884352/1249731067963904050

### Summary
- Problem: Profile page doesn't show any activity
- Profile page: Check if the address param an address or not
- if not, show an error
- if yes, send requests to hub only with checksummed address instead of lowercase

### How to test
1. Go to http://localhost:8080/#/profile/0x24F15402C6Bb870554489b2fd2049A85d75B982f it should work normal and show activity
2. Go to http://localhost:8080/#/profile/0x24f15402c6bb870554489b2fd2049a85d75b982f should still work but send requests to hub with checksummed addresses
3. Go to http://localhost:8080/#/profile/ABCD should show a message
4. <img width="1644" alt="image" src="https://github.com/snapshot-labs/snapshot/assets/15967809/188811a5-f7b0-4a55-9541-b92f4493a756">

