### PR TITLE
fix: Edit profile button is not visible

### DIFF
--- a/src/components/ProfileSidebar.vue
+++ b/src/components/ProfileSidebar.vue
@@ -30,7 +30,7 @@ const { web3Account } = useWeb3();
         <ProfileSidebarHeaderSkeleton v-else />
 
         <div
-          v-if="userAddress === web3Account.toLowerCase()"
+          v-if="userAddress === web3Account"
           class="flex flex-grow justify-end lg:mt-3 lg:flex-auto lg:justify-center"
         >
           <TuneButton


### PR DESCRIPTION
### Summary

Right now profile page doesn't have an edit profile button, because a recent change hides it

### How to test

1. Go to your profile page 
2. you will notice the button
3. <img width="325" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot/assets/15967809/5ac1b4c5-3afe-4f4b-bed9-b9a87a323e0f">
