### PR TITLE
fix: Prefer selected choice over user vote

### DIFF
--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -59,6 +59,7 @@ const votedAndShutter = computed(
 );
 
 function emitChoice(c) {
+  if (c === null) return;
   emit('update:modelValue', c);
 }
 

--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -25,6 +25,14 @@ const selectedChoices = computed(() => {
 });
 
 const validatedUserChoice = computed(() => {
+  if (selectedChoices.value) {
+    return voting[props.proposal.type].isValidChoice(
+      selectedChoices.value,
+      props.proposal.choices
+    )
+      ? selectedChoices.value
+      : null;
+  }
   if (!userVote.value?.choice) return null;
   if (
     voting[props.proposal.type].isValidChoice(
@@ -59,7 +67,6 @@ const votedAndShutter = computed(
 );
 
 function emitChoice(c) {
-  if (c === null) return;
   emit('update:modelValue', c);
 }
 


### PR DESCRIPTION
### Summary

There is an issue when the URL contains selected choice `?choice=1` (used by discord bot),
- Try going to https://snapshot.org/#/thanku.eth/proposal/0x72d902d7c3cfc0c52dd2d890321cb5778e73429d544fe2d14a24d96280a02680?choice=1 and it should print an error in console
- With my change, we give preference to the selected choice instead of the user vote (which is null if the user doesn't vote yet)

### How to test

1.  Go any proposal with `?choice=1`  for example https://snapshot-git-fix-selected-choice-snapshot.vercel.app/#/thanku.eth/proposal/0x72d902d7c3cfc0c52dd2d890321cb5778e73429d544fe2d14a24d96280a02680?choice=1
2. Connect your wallet
3. You should be able to vote with pre-selected choice 
