### PR TITLE
fix: Load voting power immediately once vote modal is open

### DIFF
--- a/src/components/ModalVote.vue
+++ b/src/components/ModalVote.vue
@@ -148,6 +148,9 @@ watch(
   async () => {
     if (props.open === false) return;
     loadValidationAndPower();
+  },
+  {
+    immediate: true
   }
 );
 </script>


### PR DESCRIPTION
### Summary
- Issue: When the model is open automatically due to `?choice=1`, voting power is not loading on the modal
- If you go to https://snapshot.org/#/cowgrants.eth/proposal/0x9214658a7ee9e1dc42f0d9f9c64b8470603d85df9518b2c6b70e94d915aafd6c?choice=1
- voting power will keep loading
![image](https://github.com/snapshot-labs/snapshot/assets/15967809/948d27f1-15db-48ac-aec8-a3c4c9b2dcd3)

### How to test

1. Go to a proposal with `?choice=1`
2. https://snapshot.org/#/cowgrants.eth/proposal/0x9214658a7ee9e1dc42f0d9f9c64b8470603d85df9518b2c6b70e94d915aafd6c?choice=1
3. Voting power should load
4. ![image](https://github.com/snapshot-labs/snapshot/assets/15967809/b874aff4-250f-4b64-9bb9-3dd8b8fe0f03)

