### PR TITLE
fix: fix invalid selected choices computation

### DIFF
--- a/src/components/SpaceProposalVote.vue
+++ b/src/components/SpaceProposalVote.vue
@@ -27,10 +27,10 @@ const selectedChoices = computed(() => {
 const validatedUserChoice = computed(() => {
   if (selectedChoices.value) {
     return voting[props.proposal.type].isValidChoice(
-      selectedChoices.value,
+      props.modelValue,
       props.proposal.choices
     )
-      ? selectedChoices.value
+      ? props.modelValue
       : null;
   }
   if (!userVote.value?.choice) return null;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix the issue where an error message is shown instead of the user's votes, on active proposals

![Metis __ Snapshot - 2024-06-20 11_32_45](https://github.com/snapshot-labs/snapshot/assets/495709/32c9d441-ffd4-4c00-8bbe-fe3fa4d4f262)

### How to test

1. Go to any active proposal you already voted on
2. It should show your votes instead of the error message
3. On proposals you have not voted on, it should show the full vote form
4. By appending `?choice=1` to the end of the url (on basic and single choice proposal), it should open the vote modal on page load, with the choice `1` as selected
