### PR TITLE
fix: Escape underscores in links

### DIFF
--- a/src/components/BaseMarkdown.vue
+++ b/src/components/BaseMarkdown.vue
@@ -29,6 +29,8 @@ const markdown = computed(() => {
   }
   body = body.replace(/!\[.*?\]\((ipfs:\/\/[a-zA-Z0-9]+?)\)/g, replaceIpfsUrl);
 
+  // if body contains a link that contain `_` , replace it with `\_` to escape it
+  body = body.replace(/(http.*?)(?=_)/g, '$1\\');
   return remarkable.render(body);
 });
 


### PR DESCRIPTION
### Summary
Some links are not working if it contains `_` 
this fix will escape `_` with `/_` 

### How to test

1. Go to http://localhost:8080/#/gov.bloomstudio.eth/proposal/0x6f6e3458c0ee772569eca7cf03fa323e2f31870c2293898a083ca3ffbb73247f
2. Before the fix:
<img width="667" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot/assets/15967809/4197ed5c-66cd-4e4c-a9ef-1e94a4d85952">

3. After the fix:  
<img width="641" alt="Untitled 5" src="https://github.com/snapshot-labs/snapshot/assets/15967809/fa07bfcc-44bf-43b8-89cf-82955d96c837">


