### PR TITLE
fix: Proposal author doesn't load

### DIFF
--- a/src/components/SpaceProposalHeader.vue
+++ b/src/components/SpaceProposalHeader.vue
@@ -100,7 +100,8 @@ watch(
   () => {
     if (!props.proposal) return;
     loadProfiles([props.proposal.author]);
-  }
+  },
+  { immediate: true }
 );
 </script>
 


### PR DESCRIPTION
### Summary
Proposal author doesn't load on the page load, but works fine if we go from proposals page

### How to test

1. Go to https://snapshot.org/#/unidexapp.eth/proposal/0xc588b51bc4c4f59741b110c32be503a012ba9de5bb1148e361ffe0e5bed418bf 
2. Notice that proposal author doesn't load, but works fine if we go to proposal from proposals page 
<img width="673" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot/assets/15967809/36b3d295-2c0b-488b-b923-e4268893f7bf">
