### PR TITLE
fix: Default value for number winners

### DIFF
--- a/src/views/SpaceBoost.vue
+++ b/src/views/SpaceBoost.vue
@@ -504,7 +504,7 @@ watch(
     if (form.value.distribution.type === 'weighted') {
       form.value.distribution.hasLotteryLimit = false;
       form.value.distribution.lotteryLimit = '';
-      form.value.distribution.numWinners = ''
+      form.value.distribution.numWinners = '';
     }
   },
   { deep: true }

--- a/src/views/SpaceBoost.vue
+++ b/src/views/SpaceBoost.vue
@@ -489,7 +489,7 @@ watchEffect(async () => {
 });
 
 watch(
-  () => form.value.distribution,
+  [() => form.value.distribution.type],
   () => {
     if (!form.value.distribution.hasWeightedLimit) {
       form.value.distribution.weightedLimit = '';
@@ -500,11 +500,12 @@ watch(
     if (form.value.distribution.type === 'lottery') {
       form.value.distribution.hasWeightedLimit = false;
       form.value.distribution.weightedLimit = '';
+      form.value.distribution.numWinners ??= '1';
     }
     if (form.value.distribution.type === 'weighted') {
       form.value.distribution.hasLotteryLimit = false;
       form.value.distribution.lotteryLimit = '';
-      form.value.distribution.numWinners = '';
+      form.value.distribution.numWinners = undefined;
     }
   },
   { deep: true }

--- a/src/views/SpaceBoost.vue
+++ b/src/views/SpaceBoost.vue
@@ -84,7 +84,7 @@ const form = ref<Form>({
     weightedLimit: '',
     hasLotteryLimit: false,
     lotteryLimit: '',
-    numWinners: 1
+    numWinners: '1'
   },
   network: '1',
   token: undefined,
@@ -227,7 +227,7 @@ const strategy = computed<BoostStrategy>(() => {
 
   const numWinners =
     form.value.distribution.type === 'lottery'
-      ? form.value.distribution.numWinners
+      ? Number(form.value.distribution.numWinners)
       : undefined;
 
   return {
@@ -500,12 +500,11 @@ watch(
     if (form.value.distribution.type === 'lottery') {
       form.value.distribution.hasWeightedLimit = false;
       form.value.distribution.weightedLimit = '';
-      form.value.distribution.numWinners = 1;
     }
     if (form.value.distribution.type === 'weighted') {
       form.value.distribution.hasLotteryLimit = false;
       form.value.distribution.lotteryLimit = '';
-      form.value.distribution.numWinners = undefined;
+      form.value.distribution.numWinners = ''
     }
   },
   { deep: true }
@@ -625,7 +624,7 @@ watch(
               <template v-if="form.distribution.type === 'lottery'">
                 <TuneInput
                   v-model="form.distribution.numWinners"
-                  default="1"
+                  label="Number of winners"
                   type="number"
                   placeholder="5"
                   always-show-error

--- a/src/views/SpaceBoost.vue
+++ b/src/views/SpaceBoost.vue
@@ -84,7 +84,7 @@ const form = ref<Form>({
     weightedLimit: '',
     hasLotteryLimit: false,
     lotteryLimit: '',
-    numWinners: ''
+    numWinners: 1
   },
   network: '1',
   token: undefined,
@@ -225,6 +225,11 @@ const strategy = computed<BoostStrategy>(() => {
       eligibilityType = 'bribe';
   }
 
+  const numWinners =
+    form.value.distribution.type === 'lottery'
+      ? form.value.distribution.numWinners
+      : undefined;
+
   return {
     name: 'Boost',
     description: 'Snapshot.org proposal boost',
@@ -242,7 +247,7 @@ const strategy = computed<BoostStrategy>(() => {
       distribution: {
         type: form.value.distribution.type,
         limit: strategyDistributionLimit.value,
-        numWinners: form.value.distribution.numWinners || undefined
+        numWinners
       }
     }
   };
@@ -495,11 +500,12 @@ watch(
     if (form.value.distribution.type === 'lottery') {
       form.value.distribution.hasWeightedLimit = false;
       form.value.distribution.weightedLimit = '';
+      form.value.distribution.numWinners = 1;
     }
     if (form.value.distribution.type === 'weighted') {
       form.value.distribution.hasLotteryLimit = false;
       form.value.distribution.lotteryLimit = '';
-      form.value.distribution.numWinners = '';
+      form.value.distribution.numWinners = undefined;
     }
   },
   { deep: true }
@@ -619,7 +625,7 @@ watch(
               <template v-if="form.distribution.type === 'lottery'">
                 <TuneInput
                   v-model="form.distribution.numWinners"
-                  label="Number of winners"
+                  default="1"
                   type="number"
                   placeholder="5"
                   always-show-error


### PR DESCRIPTION
### Summary

On Boost, the number of winners should default to `1` 

### How to test

1. Go to boost creation page
2. You should see the number of winners as `1`
3. Try switching between lottery and proportion
![Untitled 2](https://github.com/snapshot-labs/snapshot/assets/15967809/952761ac-80eb-4689-8060-5fd48027e5dc)

