### PR TITLE
fix: numWinners should be string instead of number

### DIFF
--- a/src/views/SpaceBoost.vue
+++ b/src/views/SpaceBoost.vue
@@ -46,7 +46,7 @@ type Form = {
     weightedLimit: string;
     hasLotteryLimit: boolean;
     lotteryLimit: string;
-    numWinners: string;
+    numWinners: string | undefined;
   };
   network: string;
   token?: Token;
@@ -227,7 +227,7 @@ const strategy = computed<BoostStrategy>(() => {
 
   const numWinners =
     form.value.distribution.type === 'lottery'
-      ? Number(form.value.distribution.numWinners)
+      ? form.value.distribution.numWinners
       : undefined;
 
   return {


### PR DESCRIPTION
Fix from #4804 

- `numWinners` should be a string instead of a number

## How to test:
- Create a boost with `lottery` type
- In the pinned file, `"numWinners"` should be a string