### PR TITLE
fix: Use published subgraphs instead of test URLs

### DIFF
--- a/src/helpers/boost/subgraph.ts
+++ b/src/helpers/boost/subgraph.ts
@@ -3,13 +3,13 @@ import { SUPPORTED_NETWORKS } from '@/helpers/boost';
 import { BoostSubgraph } from '@/helpers/boost/types';
 
 const SUBGRAPH_URLS = {
-  '1': 'https://api.studio.thegraph.com/query/23545/boost/version/latest',
+  '1': 'https://subgrapher.snapshot.org/subgraph/arbitrum/A6EEuSAB7mFrWvLBnL1HZXwfiGfqFYnFJjc14REtMNkd',
   '11155111':
-    'https://api.studio.thegraph.com/query/23545/boost-sepolia/version/latest',
+    'https://subgrapher.snapshot.org/subgraph/arbitrum/6T64qrPe7S46zhArSoBF8CAmc5cG3PyKa92Nt4Jhymcy',
   '137':
-    'https://api.studio.thegraph.com/query/23545/boost-polygon/version/latest',
+    'https://subgrapher.snapshot.org/subgraph/arbitrum/CkNpf5gY7XPCinJWP1nh8K7u6faXwDjchGGV4P9rgJ7',
   '8453':
-    'https://api.studio.thegraph.com/query/23545/boost-base/version/latest'
+    'https://subgrapher.snapshot.org/subgraph/arbitrum/52uVpyUHkkMFieRk1khbdshUw26CNHWAEuqLojZzcyjd'
 };
 
 export async function getClaims(recipient: string) {


### PR DESCRIPTION
### Summary
Related to https://github.com/snapshot-labs/pitches/issues/84

- Use published subgraphs
- https://thegraph.com/explorer/subgraphs/A6EEuSAB7mFrWvLBnL1HZXwfiGfqFYnFJjc14REtMNkd?view=Query&chain=arbitrum-one
- https://thegraph.com/explorer/subgraphs/6T64qrPe7S46zhArSoBF8CAmc5cG3PyKa92Nt4Jhymcy?view=Query&chain=arbitrum-one
- https://thegraph.com/explorer/subgraphs/CkNpf5gY7XPCinJWP1nh8K7u6faXwDjchGGV4P9rgJ7?view=Query&chain=arbitrum-one
- https://thegraph.com/explorer/subgraphs/52uVpyUHkkMFieRk1khbdshUw26CNHWAEuqLojZzcyjd?view=Query&chain=arbitrum-one

### How to test

1. Go to proposals with boosts (for ex: https://snapshot-git-fix-boost-subgraph-urls-snapshot.vercel.app/#/thanku.eth/proposal/0x72d902d7c3cfc0c52dd2d890321cb5778e73429d544fe2d14a24d96280a02680)
2. You should see boosts and rewards if you are eligible 
