### PR TITLE
fix: Ignore delegation dashboard

### DIFF
--- a/src/components/SpaceSidebarNavigation.vue
+++ b/src/components/SpaceSidebarNavigation.vue
@@ -16,7 +16,7 @@ const hasDelegationStrategy = computed(() => {
 
 const hasDelegatesSettings = computed(() => {
   // delegation dashboard enabled on v2 for these spaces
-  const ignoreSpaces = ['ens.eth', 'gitcoindao.eth', 'uniswapgovernance.eth']; 
+  const ignoreSpaces = ['ens.eth', 'gitcoindao.eth', 'uniswapgovernance.eth'];
   if (ignoreSpaces.includes(props.space.id)) return false;
   return props.space.delegationPortal?.delegationType;
 });

--- a/src/components/SpaceSidebarNavigation.vue
+++ b/src/components/SpaceSidebarNavigation.vue
@@ -15,6 +15,9 @@ const hasDelegationStrategy = computed(() => {
 });
 
 const hasDelegatesSettings = computed(() => {
+  // delegation dashboard enabled on v2 for these spaces
+  const ignoreSpaces = ['ens.eth', 'gitcoindao.eth', 'uniswapgovernance.eth']; 
+  if (ignoreSpaces.includes(props.space.id)) return false;
   return props.space.delegationPortal?.delegationType;
 });
 


### PR DESCRIPTION
Full context: https://discord.com/channels/955773041898573854/1280744653183782963/1285552934804783144

## Summary
- Ignores deleegation dashboard for these spaces
`'ens.eth', 'gitcoindao.eth', 'uniswapgovernance.eth'`

## How to test
- Go to http://localhost:8080/#/gitcoindao.eth or http://localhost:8080/#/ens.eth
- Click on delegates
- Should open snapshot delegation instead of delegation dashboard