### PR TITLE
fix: fix invalid status when saving delegate statement

### DIFF
--- a/src/components/SpaceDelegateEdit.vue
+++ b/src/components/SpaceDelegateEdit.vue
@@ -9,6 +9,9 @@ const props = defineProps<{
   statement: {
     about: string;
     statement: string;
+    discourse: string;
+    network: string;
+    status: string;
   };
   edited: boolean;
   saving: boolean;

--- a/src/composables/useStatement.ts
+++ b/src/composables/useStatement.ts
@@ -91,8 +91,8 @@ export function useStatement() {
     const defaultStatement = {
       about: '',
       statement: '',
-      network: '',
-      status: 's',
+      network: 's',
+      status: 'INACTIVE',
       discourse: ''
     };
     return clone(statements.value?.[id?.toLowerCase()] || defaultStatement);


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Saving a new delegate statement is not doing anything, clicking on the "Save changes" button in the edit delegate statement form is not doing anything (no error shown)

This PR fix this issuem by setting the hidden field correctly

### How to test

1. Go to a http://localhost:8080/#/cowtesting.eth/delegate/YOUR-ADDRESS or any other space with delegation dashboard where you don't have a statement yet
2. Edit and save the statement
3. It should save the statement

