### PR TITLE
fix(ui): fix overflowing text

### DIFF
--- a/src/components/BaseBlock.vue
+++ b/src/components/BaseBlock.vue
@@ -69,7 +69,7 @@ const isCollapsed = ref(true);
       <div
         v-if="!loading && (!isCollapsed || !isCollapsable)"
         :class="!slim && 'p-4'"
-        class="leading-5 sm:leading-6"
+        class="leading-5 sm:leading-6 break-words"
       >
         <slot />
         <div

--- a/src/components/NavbarAccount.vue
+++ b/src/components/NavbarAccount.vue
@@ -47,7 +47,7 @@ watch(
         />
         <span
           v-if="profile?.name || profile?.ens"
-          class="hidden sm:block"
+          class="hidden sm:block max-w-[120px] truncate"
           v-text="profile.name || profile.ens"
         />
         <span v-else class="hidden sm:block" v-text="shorten(web3Account)" />

--- a/src/components/ProfileAddressCopy.vue
+++ b/src/components/ProfileAddressCopy.vue
@@ -24,7 +24,7 @@ const { copyToClipboard } = useCopy();
       </div>
     </button>
     <button
-      class="flex cursor-pointer items-center rounded border px-1 text-xs"
+      class="flex cursor-pointer items-center rounded border px-1 text-xs shrink-0"
       @click="copyToClipboard(userAddress)"
     >
       {{ shorten(userAddress) }}

--- a/src/views/SpaceDelegate.vue
+++ b/src/views/SpaceDelegate.vue
@@ -239,7 +239,7 @@ onBeforeRouteLeave(async () => {
               <div>
                 <AvatarUser :address="address" size="40" />
               </div>
-              <div class="ml-2">
+              <div class="ml-2 truncate">
                 <ProfileName
                   :profile="getProfile(address)"
                   :address="address"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fixes a few UI issues where long text would overflow their container

- Limit username max length on topnav account to prevent this

![Screenshot 2024-09-18 at 13 34 05](https://github.com/user-attachments/assets/b5eab0f9-ca91-4ae5-9228-8aecc9748b40)

- Do not shrink copyAddress button to prevent multi line button

![Screenshot 2024-09-18 at 13 37 07](https://github.com/user-attachments/assets/b7aa6660-6dfb-48fb-bff2-b0095f1b6014)

- Force words break on BaseBlock to prevent overflow content

![Screenshot 2024-09-18 at 13 34 56](https://github.com/user-attachments/assets/ecddaaa8-8a58-472b-89d7-014e01e9953a)

- Truncate username in SpaceDelegate top prevent overflow

![Screenshot 2024-09-18 at 13 34 31](https://github.com/user-attachments/assets/d15a1ae8-5f60-416c-82fe-3eacda3cab3b)
