### PR TITLE
fix: Networks page doesn't work in dev mode

### DIFF
--- a/src/views/ExploreView.vue
+++ b/src/views/ExploreView.vue
@@ -37,7 +37,7 @@ const resultsStr = computed(() => {
 
 const createLink = computed(() => {
   if (isStrategies.value) return 'https://docs.snapshot.org/strategies/create';
-  if (isNetworks.value) return 'htts://snapshot.box/#/network';
+  if (isNetworks.value) return 'https://snapshot.box/#/network';
   if (isPlugins.value) return 'https://docs.snapshot.org/plugins/create';
   return 'https://docs.snapshot.org/strategies/create';
 });

--- a/src/views/ExploreView.vue
+++ b/src/views/ExploreView.vue
@@ -37,7 +37,7 @@ const resultsStr = computed(() => {
 
 const createLink = computed(() => {
   if (isStrategies.value) return 'https://docs.snapshot.org/strategies/create';
-  if (isNetworks.value) return { name: 'network' };
+  if (isNetworks.value) return 'htts://snapshot.box/#/network';
   if (isPlugins.value) return 'https://docs.snapshot.org/plugins/create';
   return 'https://docs.snapshot.org/strategies/create';
 });


### PR DESCRIPTION
### Summary
- `network` route now redirects to v2 network page

### How to test:
- Go to https://snapshot.org/#/?filter=networks it throws in console and Add network button will be hidden
![image](https://github.com/user-attachments/assets/5ac6e337-6959-417b-8254-7e5f8150e852)
- In dev mode, it will not load the entire page
- After fix you should see the page and button
