### PR TITLE
feat: Show v2 banner

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,17 +43,18 @@ const showBanner = computed(() => {
       </div>
       <div
         v-if="showBanner"
-        class="relative flex items-center justify-center gap-1 mb-2 bg-purple-300/20 text-purple-400 px-3 py-2"
+        class="relative flex items-center justify-center gap-2 mb-2 bg-skin-border px-4 py-[10px]"
       >
-        <i-ho-speakerphone class="shrink-0" />
-        <div class="leading-6">
-          Snapshot v2 is now available at
-          <a
-            class="text-purple-400 underline font-semibold"
-            href="https://snapshot.box/#/home"
-            >snapshot.box</a
-          >
-        </div>
+        <a
+          class="flex gap-2"
+          target="_blank"
+          href="https://snapshot.box/#/home"
+        >
+          <i-ho-speakerphone class="shrink-0" />
+          <div class="leading-6">
+            Snapshot v2 is here! Experience our new and improved interface now.
+          </div>
+        </a>
         <button class="xs:absolute xs:right-3" @click="bannerClosed = true">
           <i-ho-x />
         </button>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useStorage } from '@vueuse/core';
+
 const { domain, init, isReady, showSidebar } = useApp();
 const route = useRoute();
 const { restorePendingTransactions } = useTxStatus();
@@ -6,6 +8,11 @@ const { restorePendingTransactions } = useTxStatus();
 onMounted(async () => {
   await init();
   restorePendingTransactions();
+});
+const bannerClosed = useStorage('snapshot.v2-banner-closed', false);
+const showBanner = computed(() => {
+  const showInPages = ['home', 'timeline'];
+  return showInPages.includes(route.name as string) && !bannerClosed.value;
 });
 </script>
 
@@ -33,6 +40,23 @@ onMounted(async () => {
         class="sticky top-0 z-40 border-b border-skin-border bg-skin-bg"
       >
         <TheNavbar />
+      </div>
+      <div
+        v-if="showBanner"
+        class="relative flex items-center justify-center gap-1 mb-2 bg-purple-300/20 text-purple-400 px-3 py-2"
+      >
+        <i-ho-speakerphone class="shrink-0" />
+        <div class="leading-6">
+          Snapshot v2 is now available at
+          <a
+            class="text-purple-400 underline font-semibold"
+            href="https://snapshot.box/#/home"
+            >snapshot.box</a
+          >
+        </div>
+        <button class="xs:absolute xs:right-3" @click="bannerClosed = true">
+          <i-ho-x />
+        </button>
       </div>
       <div id="content" class="pb-6 pt-4">
         <router-view v-slot="{ Component }">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/210

Displays a banner on top of explore page and timeline page
Desktop:
![image](https://github.com/user-attachments/assets/9b0affff-c64f-451b-ad14-4958007193da)
![image](https://github.com/user-attachments/assets/4bbf0eae-3b23-47d4-be9c-e10cbf34535d)

Mobile:
![image](https://github.com/user-attachments/assets/4d6cd2f2-1ed0-4320-a5d2-d5d2ec11d39d)
![image](https://github.com/user-attachments/assets/6cef2868-2ec9-43e0-9f0e-a3a92cab7bd3)


### How to test

1. go to explore page / timeline page
2. you should see new banner 
3. which should not show up once it is closed


