### PR TITLE
fix: Ask for symbol and decimals if covalent fail

### DIFF
--- a/src/components/SetupStrategyBasic.vue
+++ b/src/components/SetupStrategyBasic.vue
@@ -11,7 +11,7 @@ const DEFAULT_TOKEN = {
   logo: '',
   standard: 'ERC-20',
   symbol: '',
-  decimals: 18
+  decimals: '18'
 };
 
 const emit = defineEmits(['next']);

--- a/src/components/SetupStrategyBasic.vue
+++ b/src/components/SetupStrategyBasic.vue
@@ -11,7 +11,7 @@ const DEFAULT_TOKEN = {
   logo: '',
   standard: 'ERC-20',
   symbol: '',
-  decimals: null
+  decimals: 18
 };
 
 const emit = defineEmits(['next']);
@@ -93,9 +93,15 @@ async function getTokenInfo() {
       token.value.name = tokenInfo[0];
       token.value.symbol = tokenInfo[1];
       token.value.decimals = tokenInfo[2];
-    } catch {
+    } catch (e) {
+      console.log(e);
       tokenError.value = t('setup.strategy.tokenVoting.tokenNotFound');
-      token.value = clone(DEFAULT_TOKEN);
+      if (
+        token.value.standard === 'ERC-721' ||
+        token.value.standard === 'ERC-1155'
+      ) {
+        token.value.decimals = '0';
+      }
     } finally {
       isTokenLoading.value = false;
     }
@@ -130,9 +136,46 @@ watch(
               v-model.trim="contract"
               title="Token contract"
               placeholder="Enter address"
-              :error="{ message: !token.name ? tokenError : '', push: true }"
+              :error="{
+                message:
+                  tokenError !== $t('setup.strategy.tokenVoting.tokenNotFound')
+                    ? tokenError
+                    : '',
+                push: true
+              }"
               :loading="isTokenLoading"
               focus-on-mount
+            />
+          </div>
+          <div>
+            <BaseInput
+              v-if="
+                !isTokenLoading &&
+                tokenError === $t('setup.strategy.tokenVoting.tokenNotFound')
+              "
+              v-model.trim="token.symbol"
+              title="Symbol"
+              placeholder="Enter Symbol"
+              :error="{
+                message: !token.symbol ? 'Symbol is required' : '',
+                push: true
+              }"
+              focus-on-mount
+            />
+          </div>
+          <div>
+            <BaseInput
+              v-if="
+                !isTokenLoading &&
+                tokenError === $t('setup.strategy.tokenVoting.tokenNotFound')
+              "
+              v-model.trim="token.decimals"
+              title="Decimals"
+              placeholder="Enter Decimals"
+              :error="{
+                message: !token.decimals ? 'Decimals is required' : '',
+                push: true
+              }"
             />
           </div>
         </div>


### PR DESCRIPTION
Context https://discord.com/channels/955773041898573854/1030773050217615440/1289392373037662208

### Summary

Form will  now ask for symbol and decimals if covalent fail

### How to test

1. Go to space creation, strategies page, select "Token weighted voting"
2. Select any network, Select any standard
3. Enter an invalid token (for example your EOA address)
4. It should ask for  symbol and decimals if covalent fail, instead of showing the error
5. You should be able to continue with space setup now


Before:
![image](https://github.com/user-attachments/assets/78f406ee-ec91-46b4-bfc6-79b28b281530)

Now:
![image](https://github.com/user-attachments/assets/57dceead-79b8-4859-82ca-cbe8636143d4)

