### PR TITLE
fix: fix stamp avatar case sensitiveness

### DIFF
--- a/src/components/AvatarUser.vue
+++ b/src/components/AvatarUser.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { getAddress } from '@ethersproject/address';
+
 const props = withDefaults(
   defineProps<{
     address: string;
@@ -13,15 +15,23 @@ const props = withDefaults(
 
 const { profilesCreated } = useProfiles();
 
+const normalizedAddress = computed(() => getAddress(props.address));
+
 const timestamp = computed(() => {
-  if (!props?.address || !profilesCreated.value?.[props.address]) return '';
-  return `&ts=${profilesCreated.value[props.address]}`;
+  if (
+    !normalizedAddress.value ||
+    !profilesCreated.value?.[normalizedAddress.value]
+  ) {
+    return '';
+  }
+
+  return `&ts=${profilesCreated.value[normalizedAddress.value]}`;
 });
 </script>
 
 <template>
   <BaseAvatar
-    :src="`https://cdn.stamp.fyi/avatar/eth:${address}?s=${
+    :src="`https://cdn.stamp.fyi/avatar/eth:${normalizedAddress}?s=${
       Number(size) * 2
     }${timestamp}`"
     :preview-file="previewFile"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where the `UserAvatar` component was case sensitive, this considering 2 exact same addres, but with different case as different.

This PR will always checksummed the address

### How to test

1. Go to http://localhost:8080/#/cowtesting.eth/delegates
2. Console inspect a random delegate with avatar
3. This avatar should have a timestamp params, and address is checksummed
4. Click on the card to go to delegate statement
5. The avatar in the sidebar should load immediately (since loaded from cache)
6. This avatar should have same same exact url as before (checksummed, and same timestamp params)
