### PR TITLE
fix: fix wrong address case when resolved from ENS name

### DIFF
--- a/src/composables/useDelegates.ts
+++ b/src/composables/useDelegates.ts
@@ -1,4 +1,5 @@
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
+import { getAddress } from '@ethersproject/address';
 import {
   DelegateWithPercent,
   DelegatesVote,
@@ -92,7 +93,7 @@ export function useDelegates(space: ExtendedSpace) {
     try {
       const resolvedAddress = await resolveName(addressOrEns);
       if (!resolvedAddress) return;
-      const response = await reader.getDelegate(resolvedAddress);
+      const response = await reader.getDelegate(getAddress(resolvedAddress));
       delegate.value = response;
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue when delegating using the delegation dashboard, when the address is not checksummed.

Issue happens when the address is resolved from ENS, since our ENSNameResolver is always returning a lowercase address, while the delegation form is accepting only checksummed address

### How to test

1. Go to http://localhost:8080/#/cowtesting.eth/delegates?search=middleway.eth
2. It should show the delegation card for the address `0xA11DA8B2D9A7883eb636d7de426025e5fD9fda1A`
3. Clicking on the delegate button should open the delegate modal, with the address pre-populated in the form, and is a valid checksummed address
