### PR TITLE
fix: fix search request not being resolved in order

### DIFF
--- a/src/views/SpaceDelegates.vue
+++ b/src/views/SpaceDelegates.vue
@@ -130,8 +130,8 @@ useInfiniteScroll(
   { distance: 500 }
 );
 
-watch(searchInputDebounced, () => {
-  loadDelegate(searchInput.value);
+watch(searchInputDebounced, async () => {
+  await loadDelegate(searchInput.value);
 });
 
 watch(matchFilter, () => {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Trying to fix issue pointed out in https://jam.dev/c/cb4b5003-3dd9-4156-9ccb-dc4a5ac2fc36

When typing letters quickly in the search box, some requests are shown as "no results" wrongly.

This is somewhat hard to reproduce, this PR fix this by making the search `sync`, so any slow requests will not override latest results.

### How to test

1. Go to http://localhost:8080/#/test.wa0x6e.eth/delegates?search=fabien.eth
2. It should load the card for the searched ENS name
3. Try typing something else in the searchbox quickly
4. It should load the results for the searched name
