### PR TITLE
ci: fix missing `on` property in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,5 @@
 name: Tests
+on: [push]
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix the failing test workflow, which now required `on` to be defined explicitly

### How to tests

- On this PR, all github actions are passing