### PR TITLE
feat: Domains list to allow iframe on all subdomains

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -23,6 +23,9 @@ export const KNOWN_HOSTS = [
   'safe.mainnet.frax.com'
 ];
 
+// All subdomains of these domains are allowed
+export const KNOWN_DOMAINS = ['blockscout.com'];
+
 export const SPACE_CATEGORIES = [
   'protocol',
   'social',

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import VueTippy from 'vue-tippy';
 import VueViewer from 'v-viewer';
 import { apolloClient } from '@/helpers/apollo';
 // import { initSentry } from '@/sentry';
-import { KNOWN_HOSTS } from '@/helpers/constants';
+import { KNOWN_DOMAINS, KNOWN_HOSTS } from '@/helpers/constants';
 import i18n from '@/helpers/i18n';
 import router from '@/router';
 import '@/assets/css/main.scss';
@@ -24,7 +24,11 @@ const parentUrl =
       ]
     : document.location.href;
 const parentHost = new URL(parentUrl).host;
-if (window !== window.parent && !KNOWN_HOSTS.includes(parentHost)) {
+if (
+  window !== window.parent &&
+  !KNOWN_HOSTS.includes(parentHost) &&
+  !KNOWN_DOMAINS.includes(parentHost.split('.').slice(-2).join('.'))
+) {
   document.documentElement.style.display = 'none';
   throw new Error(`Unknown host: ${parentHost}`);
 }


### PR DESCRIPTION
### Summary
Allow `*.blockscout.com` to show snapshot in iframes

Context https://discord.com/channels/955773041898573854/1125390177888645231/1290249564623736885

### How to test

1. Go to https://eth.blockscout.com/apps/zerion, or https://optimism.blockscout.com/apps/zerion open console and edit HTML, replace with 
```HTML
<body>
    <iframe src="http://localhost:8080/#/"></iframe>
</body>
```
2. Previously it should not allow
3. Now it should allow on all subdomains
4. It should allow snapshot on any other domains 