### PR TITLE
fix: walletconnect options: move methods to optionalMethods

### DIFF
--- a/src/helpers/connectors.ts
+++ b/src/helpers/connectors.ts
@@ -13,8 +13,12 @@ const connectors = {
       optionalChains: [
         1, 4, 5, 10, 42, 56, 100, 137, 246, 1088, 42161, 73799, 11155111
       ],
-      methods: ['eth_sendTransaction', 'personal_sign'],
-      optionalMethods: ['eth_accounts', 'eth_signTypedData_v4'],
+      optionalMethods: [
+        'eth_sendTransaction',
+        'personal_sign',
+        'eth_accounts',
+        'eth_signTypedData_v4'
+      ],
       rpcMap: {
         '1': `${import.meta.env.VITE_BROVIDER_URL}/1`,
         '4': `${import.meta.env.VITE_BROVIDER_URL}/4`,


### PR DESCRIPTION
### Summary
Same fix as https://github.com/snapshot-labs/sx-monorepo/pull/745
- moving all methods into optional methods

### How to test

1. Go to http://localhost:8081/#/delegate/apecoin.eth
2. Connect to your safe with walletconnect (with new changes make sure to disconnect if you are already connected)
3. Delegete or remove delegate
4. Before fix. it will show error: "unknown account"
5. After fix: it will open transaction modal on Safe
