### PR TITLE
fix: send empty labels with proposals

### DIFF
--- a/src/components/SpaceCreateVoting.vue
+++ b/src/components/SpaceCreateVoting.vue
@@ -166,7 +166,7 @@ defineEmits<{
                 </template>
                 <template #info>
                   <span
-                    class="hidden text-xs text-skin-text group-focus-within:block"
+                    class="hidden text-xs text-skin-text whitespace-nowrap group-focus-within:block"
                   >
                     {{ `${element.text.length}/32` }}
                   </span>

--- a/src/composables/useClient.ts
+++ b/src/composables/useClient.ts
@@ -52,6 +52,7 @@ export function useClient() {
         body: payload.body,
         discussion: payload.discussion,
         choices: payload.choices,
+        labels: [],
         start: payload.start,
         end: payload.end,
         snapshot: payload.snapshot,
@@ -67,6 +68,7 @@ export function useClient() {
         body: payload.body,
         discussion: payload.discussion,
         choices: payload.choices,
+        labels: [],
         plugins: JSON.stringify(plugins)
       });
     } else if (type === 'vote') {


### PR DESCRIPTION
### Summary
- Fix the proposal creation, which is broken because of https://github.com/snapshot-labs/snapshot.js/compare/v0.12.19...v0.12.20

### How to test

1. Create a proposal on any space
2. Before it was throwing an error
