### PR TITLE
fix: fix broken space delegationPortal settings

### DIFF
--- a/src/components/SettingsDelegationBlock.vue
+++ b/src/components/SettingsDelegationBlock.vue
@@ -1,12 +1,22 @@
 <script setup lang="ts">
 import schemas from '@snapshot-labs/snapshot.js/src/schemas';
 
+const delegationDefinition =
+  schemas.space.properties.delegationPortal.properties;
+
 const props = defineProps<{
   context: 'setup' | 'settings';
   isViewOnly?: boolean;
 }>();
 
 const { form, validationErrors, addRef } = useFormSpaceSettings(props.context);
+
+const delegationTypes = computed(() => {
+  return delegationDefinition.delegationType.anyOf.map((item: any) => ({
+    value: item.const,
+    name: item.title
+  }));
+});
 </script>
 
 <template>
@@ -14,11 +24,37 @@ const { form, validationErrors, addRef } = useFormSpaceSettings(props.context);
     <BaseMessageBlock level="info" class="mb-3">
       {{ $t('settings.delegationPortal.information') }}
     </BaseMessageBlock>
-    <TuneForm
-      :ref="addRef"
-      v-model="form.delegationPortal"
-      :definition="schemas.space.properties.delegationPortal"
-      :error="validationErrors?.delegationPortal || {}"
-    />
+
+    <div class="space-y-2">
+      <TuneListbox
+        :ref="addRef"
+        :items="delegationTypes"
+        :model-value="form.delegationPortal.delegationType"
+        :definition="delegationDefinition.delegationType"
+        @update:model-value="
+          value => (form.delegationPortal.delegationType = value)
+        "
+      />
+      <TuneInput
+        :ref="addRef"
+        v-model="form.delegationPortal.delegationContract"
+        :definition="delegationDefinition.delegationContract"
+        :error="validationErrors.delegationPortal?.delegationContract"
+      />
+
+      <ComboboxNetwork
+        :ref="addRef"
+        label="Delegation network"
+        :hint="delegationDefinition.delegationContract.description"
+        :network="form.delegationPortal.delegationNetwork"
+        @select="value => (form.delegationPortal.delegationNetwork = value)"
+      />
+      <TuneInput
+        :ref="addRef"
+        v-model="form.delegationPortal.delegationApi"
+        :definition="delegationDefinition.delegationApi"
+        :error="validationErrors.delegationPortal?.delegationApi"
+      />
+    </div>
   </BaseBlock>
 </template>

--- a/src/composables/useFormSpaceSettings.ts
+++ b/src/composables/useFormSpaceSettings.ts
@@ -10,6 +10,7 @@ const DEFAULT_VOTE_VALIDATION = { name: 'any', params: {} };
 const DEFAULT_DELEGATION = {
   delegationType: 'compound-governor',
   delegationContract: '',
+  delegationNetwork: '1',
   delegationApi: ''
 };
 const EMPTY_SPACE_FORM = {

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -189,6 +189,7 @@ export interface ExtendedSpace {
 export interface DelegatesConfig {
   delegationType: DelegationTypes;
   delegationContract: string;
+  delegationNetwork: string;
   delegationApi: string;
 }
 export interface SpaceValidation {

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -515,6 +515,7 @@ export const SPACE_QUERY = gql`
       delegationPortal {
         delegationType
         delegationContract
+        delegationNetwork
         delegationApi
       }
       treasuries {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/snapshot/issues/4912

This PR fixes the broken delegation portal, due to TuneForm not supporting having other thing than a choice list in `anyOf`, and missing `delegationNetwork` selector, not supported by TuneForm

### How to test

1. Go to your space settings > Delegation 
2. The form should show properly, with a network selector 
3. It should save without error
