### PR TITLE
fix: Keep existing labels on spaces and proposals

### DIFF
--- a/src/composables/useClient.ts
+++ b/src/composables/useClient.ts
@@ -68,7 +68,7 @@ export function useClient() {
         body: payload.body,
         discussion: payload.discussion,
         choices: payload.choices,
-        labels: [],
+        labels: payload.labels,
         plugins: JSON.stringify(plugins)
       });
     } else if (type === 'vote') {

--- a/src/composables/useFormSpaceProposal.ts
+++ b/src/composables/useFormSpaceProposal.ts
@@ -9,6 +9,7 @@ interface ProposalForm {
   body: string;
   discussion: string;
   choices: { key: number; text: string }[];
+  labels: string[];
   start: number;
   end: number;
   snapshot: number;
@@ -29,6 +30,7 @@ const EMPTY_PROPOSAL: ProposalForm = {
     { key: 0, text: '' },
     { key: 1, text: '' }
   ],
+  labels: [],
   start: parseInt((Date.now() / 1e3).toFixed()),
   end: 0,
   snapshot: 0,
@@ -60,6 +62,7 @@ export function useFormSpaceProposal({ spaceType = 'default' } = {}) {
     name: string;
     body: string;
     choices: { key: number; text: string }[];
+    labels: string[];
     isBodySet: boolean;
   }>(`snapshot.proposal.${route.params.key}`, clone(EMPTY_PROPOSAL_DRAFT));
 

--- a/src/composables/useFormSpaceSettings.ts
+++ b/src/composables/useFormSpaceSettings.ts
@@ -16,6 +16,7 @@ const DEFAULT_DELEGATION = {
 const EMPTY_SPACE_FORM = {
   strategies: [],
   categories: [],
+  labels: [],
   treasuries: [],
   admins: [],
   moderators: [],

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -46,6 +46,7 @@ export const PROPOSAL_QUERY = gql`
       body
       discussion
       choices
+      labels
       start
       end
       snapshot
@@ -460,6 +461,12 @@ export const SPACE_QUERY = gql`
       moderators
       members
       categories
+      labels {
+        id
+        name
+        description
+        color
+      }
       plugins
       followersCount
       template

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -298,6 +298,7 @@ function setSourceProposal(proposal) {
     body: proposal.body,
     discussion: proposal.discussion,
     choices: proposal.choices,
+    labels: proposal.labels,
     start: proposal.start,
     end: proposal.end,
     snapshot: proposal.snapshot,


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/workflow/issues/143

### Summary
- Keep existing labels on space settings update
- Keep existing labels on proposal update

### How to test

1. Go to any space with labels (or add labels on v2)
2. Edit space settings, should keep the labels space
3. Create a proposal on v2 with labels
4. Edit proposal on v1, should keep the labels on proposal

