### PR TITLE
fix: Whitelist with-delegation strategies and use checksum addresses

### DIFF
--- a/src/views/DelegateView.vue
+++ b/src/views/DelegateView.vue
@@ -151,11 +151,11 @@ async function getDelegatesWithScore() {
       .map(delegate => {
         return delegations.find(a => a.delegate === delegate);
       })
-      .map(delegate => {
+      .map(delegation => {
         return {
-          ...delegate,
-          delegate: getAddress(delegate.delegate),
-          delegator: getAddress(delegate.delegator)
+          ...delegation,
+          delegate: getAddress(delegation.delegate),
+          delegator: getAddress(delegation.delegator)
         };
       });
 

--- a/src/views/DelegateView.vue
+++ b/src/views/DelegateView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { debouncedWatch } from '@vueuse/core';
-import { isAddress } from '@ethersproject/address';
+import { getAddress, isAddress } from '@ethersproject/address';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import {
   getScores,
@@ -125,7 +125,9 @@ const delegationStrategies = [
   'delegation',
   'erc20-balance-of-delegation',
   'delegation-with-cap',
-  'delegation-with-overrides'
+  'delegation-with-overrides',
+  'with-delegation',
+  'erc20-balance-of-delegation-with-delegation'
 ];
 
 async function getDelegatesWithScore() {
@@ -145,9 +147,17 @@ async function getDelegatesWithScore() {
 
     const uniqueDelegators = Array.from(
       new Set(delegations.map(d => d.delegate))
-    ).map(delegate => {
-      return delegations.find(a => a.delegate === delegate);
-    });
+    )
+      .map(delegate => {
+        return delegations.find(a => a.delegate === delegate);
+      })
+      .map(delegate => {
+        return {
+          ...delegate,
+          delegate: getAddress(delegate.delegate),
+          delegator: getAddress(delegate.delegator)
+        };
+      });
 
     const delegatesAddresses = uniqueDelegators.map(d => d.delegate);
 


### PR DESCRIPTION
### Summary
Delegation is broken if space is using with-delegation strategies, Because:
1. with-delegation strategies are not whitelisted 
2. these strategies return checksummed addresses from score-api

### How to test

1. Go to https://snapshot.org/#/delegate/moxie.eth
2. You should see top delegates
