### PR TITLE
fix: consider all delegation strategies

### DIFF
--- a/src/views/DelegateView.vue
+++ b/src/views/DelegateView.vue
@@ -171,11 +171,13 @@ async function getDelegatesWithScore() {
     );
 
     uniqueDelegators.forEach(delegate => {
-      const delegationScore = scores[0];
-      Object.entries(delegationScore).forEach(([address, score]) => {
-        if (address === delegate.delegate) {
-          delegate.score = score;
-        }
+      delegate.score = 0;
+      scores.forEach(delegationScore => {
+        Object.entries(delegationScore).forEach(([address, score]) => {
+          if (address === delegate.delegate) {
+            delegate.score += score;
+          }
+        });
       });
     });
 


### PR DESCRIPTION
### Summary

Related to https://github.com/snapshot-labs/workflow/issues/306

- Previously we consider only first delegation strategy, this is resulting in wrong voting power in delegates page

### How to test

1. Go to https://snapshot.org/#/delegate/sandboxdao.eth
2. you will see vp of first delegation strategy
3. After the fix, you will see voting power of all delegation strategies 
