### PR TITLE
feat: add `space` param to strategy playground

### DIFF
--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -18,6 +18,7 @@ interface StrategyExample {
   network: string;
   addresses: string[];
   snapshot: number;
+  space?: string;
 }
 
 interface StrategySchema {

--- a/src/views/PlaygroundView.vue
+++ b/src/views/PlaygroundView.vue
@@ -34,11 +34,13 @@ const scores = ref(null);
 const searchInput = ref('');
 const form = ref<{
   params: Record<string, any>;
+  space: string;
   network: string;
   snapshot: string;
   addresses: string[];
 }>({
   params: {},
+  space: '',
   network: '1',
   snapshot: '',
   addresses: []
@@ -67,7 +69,7 @@ const scoresWithZeroBalanceAddresses = computed(() => {
 const strategyExample = computed(() => {
   if (queryParams.query) {
     try {
-      const { params, network, snapshot, addresses } = decodeJson(
+      const { params, network, snapshot, addresses, space } = decodeJson(
         queryParams.query
       );
       return {
@@ -75,6 +77,7 @@ const strategyExample = computed(() => {
         addresses: addresses || extendedStrategy.value?.examples?.[0].addresses,
         network,
         snapshot,
+        space,
         strategy: { params }
       };
     } catch (e) {
@@ -97,7 +100,7 @@ async function loadScores() {
       params: form.value.params
     };
     scores.value = await getScores(
-      '',
+      form.value.space,
       [strategyParams],
       form.value.network,
       form.value.addresses,
@@ -155,6 +158,7 @@ watch(
   () => {
     form.value.params = strategyExample.value?.strategy.params ?? defaultParams;
     form.value.network = strategyExample.value?.network ?? '1';
+    form.value.space = strategyExample.value?.space ?? '';
     form.value.addresses = strategyExample.value?.addresses ?? [];
   },
   { immediate: true }
@@ -219,6 +223,11 @@ function handleNetworkSelect(value) {
               <BaseInput
                 v-model="form.snapshot"
                 :title="$t('snapshot')"
+                @update:model-value="handleURLUpdate"
+              />
+              <BaseInput
+                v-model="form.space"
+                title="Space"
                 @update:model-value="handleURLUpdate"
               />
             </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR adds the `space` params to the strategy playground.

Currently, we pass a hardcoded empty string as space when testing strategies, but some strategies like "split-delegation" have specific voting power for each space.

This PR adds a new "space" input to the playground, defaulting to empty string.

### How to test

1. Go to http://localhost:8081/#/playground/split-delegation?query=eyJwYXJhbXMiOnsiYmFja2VuZFVybCI6Imh0dHBzOi8vZGVsZWdhdGUtYXBpLmdub3Npc2d1aWxkLm9yZyIsInN0cmF0ZWdpZXMiOlt7Im5hbWUiOiJlcmMyMC1iYWxhbmNlLW9mIiwicGFyYW1zIjp7InN5bWJvbCI6InZDT1cgKG1haW5uZXQpIiwiYWRkcmVzcyI6IjB4ZDA1N2I2M2Y1ZTY5Y2YxYjkyOWIzNTZiNTc5Y2JhMDhkNzY4ODA0OCIsImRlY2ltYWxzIjoxOH0sIm5ldHdvcmsiOiIxIn0seyJuYW1lIjoiZXJjMjAtYmFsYW5jZS1vZiIsInBhcmFtcyI6eyJzeW1ib2wiOiJ2Q09XIChHQykiLCJhZGRyZXNzIjoiMHhjMjBDOUMxM0U4NTNmYzY0ZDA1NGI3M2ZGMjFkMzYzNkIyZDk3ZWFCIiwiZGVjaW1hbHMiOjE4fSwibmV0d29yayI6IjEwMCJ9LHsibmFtZSI6ImVyYzIwLWJhbGFuY2Utb2YiLCJwYXJhbXMiOnsic3ltYm9sIjoiQ09XIChNYWlubmV0KSIsImFkZHJlc3MiOiIweERFZjFDQTFmYjdGQmNEQzc3NzUyMGFhN2YzOTZiNEUwMTVGNDk3YUIiLCJkZWNpbWFscyI6MTh9LCJuZXR3b3JrIjoiMSJ9LHsibmFtZSI6ImVyYzIwLWJhbGFuY2Utb2YiLCJwYXJhbXMiOnsic3ltYm9sIjoiQ09XIChHQykiLCJhZGRyZXNzIjoiMHgxNzcxMjc2MjJjNEEwMEYzZDQwOUI3NTU3MWUxMmNCM2M4OTczZDNjIiwiZGVjaW1hbHMiOjE4fSwibmV0d29yayI6IjEwMCJ9XSwidG90YWxTdXBwbHkiOjEyODQ5NDk5NzYsImRlbGVnYXRpb25PdmVycmlkZSI6ZmFsc2V9LCJzcGFjZSI6InRlc3Qud2EweDZlLmV0aCIsIm5ldHdvcmsiOiIxIiwic25hcHNob3QiOiIyMTMwNzAyMCIsImFkZHJlc3NlcyI6WyIweDkxRkQyYzhkMjQ3NjdkYjRFY2U3MDY5QUEyNzgzMmZmYWY4NTkwZjMiXX0.
2. It should show some positive Voting power for the address
3. When space is empty, it show 0 VP
