### PR TITLE
fix: fix overflowing statement

### DIFF
--- a/src/components/SpaceDelegatesCard.vue
+++ b/src/components/SpaceDelegatesCard.vue
@@ -124,7 +124,7 @@ function handleDropdownAction(action: string) {
 
     <div class="mt-3 h-[48px] cursor-pointer">
       <template v-if="about">
-        <span class="line-clamp-2 text-left">
+        <span class="line-clamp-2 break-words text-left">
           {{ about }}
         </span>
       </template>

--- a/src/components/SpaceDelegatesSplitDelegationModal.vue
+++ b/src/components/SpaceDelegatesSplitDelegationModal.vue
@@ -336,7 +336,7 @@ watch(
             <span>Add delegate</span>
           </TuneButton>
           <button
-            v-if="delegates.length > 0"
+            v-if="currentDelegations.length > 0"
             class="text-red underline hover:opacity-50 text-xs bg-none"
             @click="deleteAllDelegates"
           >


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR an issue where the statement is overflowing outside the delegation card

Before fix

![Screenshot 2024-12-01 at 19 21 30](https://github.com/user-attachments/assets/6ee55377-7236-497e-800f-6a08681cbea9)

After fix

![Screenshot 2024-12-01 at 19 21 15](https://github.com/user-attachments/assets/1515403d-730c-48d5-94c7-c0714b7d8d32)


### How to test

1. Go to http://localhost:8081/#/paraswap-dao.eth/delegates
2. The card about `jameskbh.eth` should not overflow anymore
