### PR TITLE
fix: improve error message when checksum address is expected

### DIFF
--- a/src/components/SpaceSplitDelegationRow.vue
+++ b/src/components/SpaceSplitDelegationRow.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { validateForm } from '@/helpers/validation';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
+import { prop } from 'lodash/fp';
 
 type DelegateRowForm = {
   to: string;
@@ -24,7 +25,12 @@ const definition = {
     }
   },
   required: ['to', 'weight'],
-  additionalProperties: false
+  additionalProperties: false,
+  errorMessage: {
+    properties: {
+      to: 'Must be a valid checksum address'
+    }
+  }
 };
 
 const props = defineProps<{


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR improves the error message when a non-checksum address is given in split delegation form

### How to test

1. Go to http://localhost:8081/#/paraswap-dao.eth/delegates?delegate=
2. Add a new delegation, with a all lowercase address
3. It should show the error: `Must be a valid checksum address.`
