### PR TITLE
Render free-form object fields in TuneForm

### DIFF
--- a/src/components/Tune/TuneForm.spec.js
+++ b/src/components/Tune/TuneForm.spec.js
@@ -1,0 +1,84 @@
+import { describe, expect, it, afterEach, beforeAll, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+describe('TuneForm', () => {
+  let wrapper;
+  let TuneForm;
+  let TuneTextareaJson;
+
+  beforeAll(async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn()
+    });
+
+    TuneForm = (await import('./TuneForm.vue')).default;
+    TuneTextareaJson = (await import('./TuneTextareaJson.vue')).default;
+  });
+
+  function createComponent(params = {}) {
+    wrapper = shallowMount(TuneForm, {
+      props: {
+        modelValue: params.modelValue || {},
+        definition: params.definition,
+        error: params.error || {}
+      }
+    });
+  }
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('renders free-form object fields as JSON textareas', () => {
+    const params = { address: '0x0000000000000000000000000000000000000000' };
+
+    createComponent({
+      modelValue: { params },
+      definition: {
+        type: 'object',
+        properties: {
+          params: {
+            type: 'object',
+            title: 'Params'
+          }
+        }
+      }
+    });
+
+    const textareaJson = wrapper.findComponent(TuneTextareaJson);
+
+    expect(textareaJson.exists()).toBe(true);
+    expect(textareaJson.props('modelValue')).toEqual(params);
+    expect(textareaJson.props('definition')).toEqual({
+      type: 'object',
+      title: 'Params'
+    });
+  });
+
+  it('renders object fields with properties as nested forms', () => {
+    createComponent({
+      modelValue: { metadata: { name: 'Snapshot' } },
+      error: { metadata: {} },
+      definition: {
+        type: 'object',
+        properties: {
+          metadata: {
+            type: 'object',
+            title: 'Metadata',
+            properties: {
+              name: {
+                type: 'string',
+                title: 'Name'
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(wrapper.findComponent(TuneTextareaJson).exists()).toBe(false);
+    expect(wrapper.findAllComponents(TuneForm)).toHaveLength(1);
+  });
+});

--- a/src/components/Tune/TuneForm.vue
+++ b/src/components/Tune/TuneForm.vue
@@ -4,6 +4,7 @@ import FormString from './_Form/FormString.vue';
 import FormNumber from './_Form/FormNumber.vue';
 import FormBoolean from './_Form/FormBoolean.vue';
 import FormArray from './_Form/FormArray.vue';
+import TuneTextareaJson from './TuneTextareaJson.vue';
 
 const props = defineProps<{
   modelValue: Record<string, any>;
@@ -18,10 +19,10 @@ const input = computed({
   set: value => emit('update:modelValue', value)
 });
 
-const getComponent = (type: string) => {
-  switch (type) {
+const getComponent = (definition: Record<string, any>) => {
+  switch (definition.type) {
     case 'object':
-      return TuneForm;
+      return definition.properties ? TuneForm : TuneTextareaJson;
     case 'string':
       return FormString;
     case 'number':
@@ -51,7 +52,7 @@ defineExpose({
 <template>
   <div class="space-y-2">
     <component
-      :is="getComponent(property.type)"
+      :is="getComponent(property)"
       v-for="(property, key) in definition.properties as Record<string, any>"
       ref="componentRefs"
       :key="key"


### PR DESCRIPTION
## Summary
1. Render schema object fields without nested `properties` as JSON textareas in `TuneForm`.
2. Preserve the existing nested form renderer for object fields that define `properties`.
3. Pass the strategy modal playground button the current modal input instead of the original prop values.
4. Add focused regression specs for the form rendering paths and modal playground payload.

## Root Cause
`TuneForm` rendered every `type: "object"` field by recursively mounting another `TuneForm`. Free-form object fields such as `{ "type": "object" }` have no nested `properties`, so the generated form showed no input for those values.

This affects strategy schemas such as [`voting-proxy`](https://github.com/snapshot-labs/score-api/tree/master/src/strategies/strategies/voting-proxy), where inner strategy `params` are intentionally a free-form object. Users could enter the inner strategy name and network, but not the params object, causing malformed strategy params to be submitted.

The strategy modal playground footer also read from `props.strategy`. When adding a new strategy, that prop is still empty after selecting and editing a strategy, so the playground button opened with empty strategy data.

## Security Impact
This does not let voters influence strategy params. It only renders schema-declared object params for users who can already edit space strategy settings. Invalid JSON remains rejected by the existing JSON textarea component.

## Validation
1. `npx -y yarn@1.22.22 test:unit src/components/ModalStrategy.spec.js src/components/Tune/TuneForm.spec.js src/composables/useWeb3.spec.js`
2. `npx -y yarn@1.22.22 lint src/components/ModalStrategy.vue src/components/ModalStrategy.spec.js src/components/Tune/TuneForm.vue src/components/Tune/TuneForm.spec.js src/composables/useWeb3.ts src/composables/useWeb3.spec.js` exits 0; it reports one existing warning in `SettingsStrategiesBlock.vue`.
3. `npx -y yarn@1.22.22 build`
4. Ran the patched UI locally with Vite against `http://127.0.0.1:8080/#/orbs-network.eth/settings`; the Orbs settings page loads without page errors. The editable modal flow is covered by the focused component regression because the automated browser is view-only without an admin wallet.

Note: the full `test:unit` suite fails locally before four existing component suites because `localStorage` is unavailable in this local Vitest environment. The focused specs above pass in that same environment.