### PR TITLE
fix: seed object array items as objects in FormArray

### DIFF
--- a/src/components/Tune/_Form/FormArray.spec.js
+++ b/src/components/Tune/_Form/FormArray.spec.js
@@ -1,0 +1,90 @@
+import { describe, expect, it, afterEach, beforeAll, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+describe('FormArray', () => {
+  let wrapper;
+  let FormArray;
+  let TuneButton;
+
+  beforeAll(async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn()
+    });
+
+    FormArray = (await import('./FormArray.vue')).default;
+    TuneButton = (await import('../TuneButton.vue')).default;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  const objectItems = {
+    type: 'array',
+    title: 'Inner strategies',
+    items: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        network: { type: 'string' },
+        params: { type: 'object' }
+      }
+    }
+  };
+
+  function createComponent(props) {
+    wrapper = shallowMount(FormArray, {
+      props: { error: {}, ...props }
+    });
+  }
+
+  function lastModelValue() {
+    const events = wrapper.emitted('update:modelValue');
+    return events?.[events.length - 1]?.[0];
+  }
+
+  it('initializes object array items as an object, not an empty string', () => {
+    createComponent({ modelValue: undefined, definition: objectItems });
+
+    // Object items must be objects so their fields can be edited and persisted;
+    // an empty string would fail the schema with "Must be object".
+    expect(lastModelValue()).toEqual([{}]);
+  });
+
+  it('respects items.default when initializing', () => {
+    createComponent({
+      modelValue: undefined,
+      definition: {
+        ...objectItems,
+        items: {
+          ...objectItems.items,
+          default: { name: '', network: '1', params: {} }
+        }
+      }
+    });
+
+    expect(lastModelValue()).toEqual([{ name: '', network: '1', params: {} }]);
+  });
+
+  it('appends an object when adding an item to an object array', async () => {
+    createComponent({
+      modelValue: [{ name: 'whitelist' }],
+      definition: objectItems
+    });
+
+    await wrapper.findComponent(TuneButton).trigger('click');
+
+    expect(lastModelValue()).toEqual([{ name: 'whitelist' }, {}]);
+  });
+
+  it('keeps empty-string items for string arrays', () => {
+    createComponent({
+      modelValue: undefined,
+      definition: { type: 'array', title: 'Tokens', items: { type: 'string' } }
+    });
+
+    expect(lastModelValue()).toEqual(['']);
+  });
+});

--- a/src/components/Tune/_Form/FormArray.vue
+++ b/src/components/Tune/_Form/FormArray.vue
@@ -34,9 +34,18 @@ const getComponent = (type: string) => {
   }
 };
 
+// Build a fresh array item. Object items must start as an object, otherwise
+// TuneForm renders their fields against a throwaway object and edits are never
+// written back (the item stays undefined/'' and fails "Must be object").
+function createItem() {
+  const items = props.definition?.items;
+  if (items?.default !== undefined) return cloneDeep(items.default);
+  return items?.type === 'object' ? {} : '';
+}
+
 function addItem() {
   const array = cloneDeep(input.value);
-  array.push(cloneDeep(props.definition?.items?.default) || '');
+  array.push(createItem());
   input.value = array;
 }
 
@@ -57,8 +66,7 @@ defineExpose({
 
 onMounted(() => {
   if (props.definition?.title === 'Strategies') return;
-  if (!props.modelValue)
-    input.value = cloneDeep([props.definition?.items?.default] || []);
+  if (!props.modelValue) input.value = [createItem()];
 });
 </script>
 


### PR DESCRIPTION
## Summary
Schema-driven object array items (e.g. `voting-proxy`'s **inner strategies**) could not be filled in: typing into a newly added/initialized item was silently discarded and the form stayed stuck at `"Must be object"`.

`FormArray` seeded items from `items.default`, which many strategy schemas don't define — so `onMounted` produced `[undefined]` and `addItem` pushed `''`. `TuneForm` then renders those falsy items against a throwaway `{}` (`props.modelValue || {}`), and since object fields update by in-place mutation (no emit), edits never reach the model.

This adds a `createItem()` helper that seeds object items as `{}` (still respecting `items.default`), used by both `addItem` and the initial `onMounted`. String items keep their previous `''` default, so existing string/array inputs are unaffected.

## Why it matters
This is the companion to #5015. #5015 makes the free-form `params` field **render**; without this, a user still can't add or fill inner strategies at all (the item object never becomes editable). Both are needed for a working `voting-proxy` config UI.

## Root cause
- `FormArray.onMounted`: `input.value = cloneDeep([items?.default] || [])` → `[undefined]`.
- `FormArray.addItem`: `array.push(cloneDeep(items?.default) || '')` → `''`.
- `TuneForm.input` getter: `props.modelValue || … || {}` returns a throwaway object for falsy items, so child edits are lost.

## Testing
- **New unit spec** `FormArray.spec.js` (4 tests): object items initialize as `{}`, respect `items.default`, `addItem` appends `{}`, and string arrays still seed `''`. `npx vitest run src/components/Tune/_Form/FormArray.spec.js` → 4 passed.
- `eslint` on both changed files exits 0.
- **Manual, real playground** (`/#/playground/voting-proxy`, with #5015 applied): added a second inner strategy and both persisted end to end:
  ```json
  "strategies": [
    { "name": "whitelist",        "params": { "symbol": "VP",  "addresses": ["0x9668…"] } },
    { "name": "erc20-balance-of", "params": { "symbol": "APE", "decimals": 18 } }
  ]
  ```

## Notes / follow-ups (not in this PR)
- Deeper hardening of `TuneForm` (persist edits even when an object `modelValue` arrives falsy, e.g. from saved data with `null` items) is left out to keep this change minimal.
- Separately, invalid JSON typed into a free-form `params` field is silently ignored while the form still reports valid (the JSON textarea's `update:isValid` isn't propagated up) — worth a follow-up.